### PR TITLE
Rocket Vault additions & tests

### DIFF
--- a/contracts/RocketVault.sol
+++ b/contracts/RocketVault.sol
@@ -108,7 +108,7 @@ contract RocketVault is RocketBase {
     /// @param _account The name of an existing account in RocketVault
     /// @param _amount The amount being withdrawn in RocketVault
     /// @param _withdrawalAddress The address to withdraw too
-    function withdrawal(bytes32 _account, uint256 _amount, address _withdrawalAddress) external returns(uint256) {
+    function withdraw(bytes32 _account, uint256 _amount, address _withdrawalAddress) external returns(uint256) {
         // Verify withdrawal is ok based on the account type and exact values transferred to the vault, throws if not
         acceptableWithdrawal(_account, _amount, _withdrawalAddress);
         // Get how many individual withdrawals in this account we currently have  

--- a/contracts/RocketVault.sol
+++ b/contracts/RocketVault.sol
@@ -67,6 +67,8 @@ contract RocketVault is RocketBase {
 
     /**** Methods ***********/
 
+
+
     /// @dev Deposits to RocketVault can be of ether or tokens
     /// @param _account The name of an existing account in RocketVault
     /// @param _amount The amount being deposited in RocketVault
@@ -168,8 +170,8 @@ contract RocketVault is RocketBase {
         require(rocketStorage.getUint(keccak256("vault.account.balance", _account)).sub(_amount) >= 0);
     }
 
-    // @dev Checks whether the sending address can deposit into an account
-    // @param _account The name of the account to check
+    /// @dev Checks whether the sending address can deposit into an account
+    /// @param _account The name of the account to check
     function canDeposit(bytes32 _account) external view returns (bool) {
         return (
             rocketStorage.getBool(keccak256("settings.vault.deposit.allowed")) && // Vault deposits enabled (not using rocketSettings to keep method pure)
@@ -179,8 +181,8 @@ contract RocketVault is RocketBase {
         );
     }
 
-    // @dev Checks whether the sending address can withdraw from an account
-    // @param _account The name of the account to check
+    /// @dev Checks whether the sending address can withdraw from an account
+    /// @param _account The name of the account to check
     function canWithdraw(bytes32 _account) external view returns (bool) {
         return (
             rocketStorage.getBool(keccak256("settings.vault.withdrawal.allowed")) && // Vault withdrawals enabled (not using rocketSettings to keep method pure)
@@ -217,56 +219,56 @@ contract RocketVault is RocketBase {
         }
     }
 
-    // @dev Returns whether an account's deposits are enabled (true) or disabled (false)
-    // @param _account The name of the account to test whether deposits are enabled or disabled
+    /// @dev Returns whether an account's deposits are enabled (true) or disabled (false)
+    /// @param _account The name of the account to test whether deposits are enabled or disabled
     function getAccountDepositsEnabled(bytes32 _account) external view returns(bool) {
         return rocketStorage.getBool(keccak256("vault.account.deposit.enabled", _account));
     }
 
-    // @dev Disable/Enable a vault account's deposits, only the owner of that account or top level owner can do this
-    // @param _account The name of the account to disable/enable deposits for in RocketVault
+    /// @dev Disable/Enable a vault account's deposits, only the owner of that account or top level owner can do this
+    /// @param _account The name of the account to disable/enable deposits for in RocketVault
     function setAccountDepositsEnabled(bytes32 _account, bool _option) onlyAccountOwner(_account) external {
         // Ok set the option now
         rocketStorage.setBool(keccak256("vault.account.deposit.enabled", _account), _option);
     }
 
-    // @dev Returns whether an account's deposits are allowed (true) or disallowed (false)
-    // @param _account The name of the account
-    // @param _address The address to test whether deposits are allowed or disallowed for
+    /// @dev Returns whether an account's deposits are allowed (true) or disallowed (false)
+    /// @param _account The name of the account
+    /// @param _address The address to test whether deposits are allowed or disallowed for
     function getAccountDepositsAllowed(bytes32 _account, address _address) external view returns(bool) {
         return rocketStorage.getBool(keccak256("vault.account.deposit.allowed", _account, _address));
     }
 
-    // @dev Allow/Disallow a vault account's deposits for an address, only the owner of that account or top level owner can do this
-    // @param _account The name of the account
-    // @param _address The address to allow/disallow deposits for
+    /// @dev Allow/Disallow a vault account's deposits for an address, only the owner of that account or top level owner can do this
+    /// @param _account The name of the account
+    /// @param _address The address to allow/disallow deposits for
     function setAccountDepositsAllowed(bytes32 _account, address _address, bool _option) onlyAccountOwner(_account) external {
         rocketStorage.setBool(keccak256("vault.account.deposit.allowed", _account, _address), _option);
     }
 
-    // @dev Returns whether an account's withdrawals are enabled (true) or disabled (false)
-    // @param _account The name of the account to test whether withdrawals are enabled or disabled
+    /// @dev Returns whether an account's withdrawals are enabled (true) or disabled (false)
+    /// @param _account The name of the account to test whether withdrawals are enabled or disabled
     function getAccountWithdrawalsEnabled(bytes32 _account) external view returns(bool) {
         return rocketStorage.getBool(keccak256("vault.account.withdrawal.enabled", _account));
     }
 
-    // @dev Disable/Enable a vault account's withdrawals, only the owner of that account or top level owner can do this
-    // @param _account The name of the account to disable/enable deposits for in RocketVault
+    /// @dev Disable/Enable a vault account's withdrawals, only the owner of that account or top level owner can do this
+    /// @param _account The name of the account to disable/enable deposits for in RocketVault
     function setAccountWithdrawalsEnabled(bytes32 _account, bool _option) onlyAccountOwner(_account) external {
         // Ok set the option now
         rocketStorage.setBool(keccak256("vault.account.withdrawal.enabled", _account), _option);
     }
 
-    // @dev Returns whether an account's withdrawals are allowed (true) or disallowed (false)
-    // @param _account The name of the account
-    // @param _address The address to test whether withdrawals are allowed or disallowed for
+    /// @dev Returns whether an account's withdrawals are allowed (true) or disallowed (false)
+    /// @param _account The name of the account
+    /// @param _address The address to test whether withdrawals are allowed or disallowed for
     function getAccountWithdrawalsAllowed(bytes32 _account, address _address) external view returns(bool) {
         return rocketStorage.getBool(keccak256("vault.account.withdrawal.allowed", _account, _address));
     }
 
-    // @dev Allow/Disallow a vault account's withdrawals for an address, only the owner of that account or top level owner can do this
-    // @param _account The name of the account
-    // @param _address The address to allow/disallow withdrawals for
+    /// @dev Allow/Disallow a vault account's withdrawals for an address, only the owner of that account or top level owner can do this
+    /// @param _account The name of the account
+    /// @param _address The address to allow/disallow withdrawals for
     function setAccountWithdrawalsAllowed(bytes32 _account, address _address, bool _option) onlyAccountOwner(_account) external {
         rocketStorage.setBool(keccak256("vault.account.withdrawal.allowed", _account, _address), _option);
     }

--- a/contracts/RocketVault.sol
+++ b/contracts/RocketVault.sol
@@ -181,7 +181,6 @@ contract RocketVault is RocketBase {
         require(rocketStorage.getAddress(keccak256("vault.account.owner", _account)) == 0x0); 
         // Check the balance is 0
         require(rocketStorage.getUint(keccak256("vault.account.balance", _account)) == 0);
-        // Check there has been
         // Ok good to go
         rocketStorage.setString(keccak256("vault.account", _account), _account); 
         rocketStorage.setAddress(keccak256("vault.account.owner", _account), msg.sender); 

--- a/contracts/RocketVault.sol
+++ b/contracts/RocketVault.sol
@@ -69,6 +69,7 @@ contract RocketVault is RocketBase {
 
 
     /// @dev Deposits to RocketVault can be of ether or tokens
+    /// @dev Token deposits must be preceded by a call to tokenContract.approve(rocketVault.address, depositAmount);
     /// @param _account The name of an existing account in RocketVault
     /// @param _amount The amount being deposited in RocketVault
     function deposit(bytes32 _account, uint256 _amount) payable external returns(uint256) {
@@ -79,10 +80,10 @@ contract RocketVault is RocketBase {
             // Capture the amount of ether sent
             deposit = msg.value;
         } else {
-            // Transfer the tokens from the users account, user must initiate this transaction so we know exactly how many tokens we received
+            // Transfer the tokens from the users account
             tokenContract = ERC20(rocketStorage.getAddress(keccak256("vault.account.token.address", _account)));
             // Send them to Rocket Vault now
-            require(tokenContract.transfer(address(this), _amount) == true);
+            require(tokenContract.transferFrom(msg.sender, address(this), _amount) == true);
             // Set the amount now
             deposit = _amount;
         }

--- a/contracts/RocketVault.sol
+++ b/contracts/RocketVault.sol
@@ -186,7 +186,9 @@ contract RocketVault is RocketBase {
         //rocketStorage.setString(keccak256("vault.account", _account), _account);
         rocketStorage.setAddress(keccak256("vault.account.owner", _account), msg.sender); 
         rocketStorage.setBool(keccak256("vault.account.deposit.enabled", _account), true);
+        rocketStorage.setBool(keccak256("vault.account.deposit.allowed", _account, msg.sender), true);
         rocketStorage.setBool(keccak256("vault.account.withdrawal.enabled", _account), true);
+        rocketStorage.setBool(keccak256("vault.account.withdrawal.allowed", _account, msg.sender), true);
         // Are we storing a token address for this account?
         if (_tokenAddress != 0x0) {
             rocketStorage.setAddress(keccak256("vault.account.token.address", _account), _tokenAddress); 

--- a/contracts/RocketVault.sol
+++ b/contracts/RocketVault.sol
@@ -121,7 +121,7 @@ contract RocketVault is RocketBase {
         rocketStorage.setAddress(keccak256("vault.account.withdrawal.address", _account, withdrawalNumber), msg.sender);
         // Record the time
         rocketStorage.setUint(keccak256("vault.account.withdrawal.time", _account, withdrawalNumber), now);
-        // Update total deposits made into this account
+        // Update total withdrawals made from this account
         rocketStorage.setUint(keccak256("vault.account.withdrawal.total", _account), withdrawalNumber + 1);
         // Are we transferring ether or tokens?
         if (rocketStorage.getAddress(keccak256("vault.account.token.address", _account)) == 0x0) {

--- a/contracts/RocketVault.sol
+++ b/contracts/RocketVault.sol
@@ -80,6 +80,8 @@ contract RocketVault is RocketBase {
             // Capture the amount of ether sent
             deposit = msg.value;
         } else {
+            // Make sure ether balance is not sent with token deposit
+            require(msg.value == 0);
             // Transfer the tokens from the users account
             tokenContract = ERC20(rocketStorage.getAddress(keccak256("vault.account.token.address", _account)));
             // Send them to Rocket Vault now

--- a/contracts/RocketVault.sol
+++ b/contracts/RocketVault.sol
@@ -168,6 +168,28 @@ contract RocketVault is RocketBase {
         require(rocketStorage.getUint(keccak256("vault.account.balance", _account)).sub(_amount) >= 0);
     }
 
+    // @dev Checks whether the sending address can deposit into an account
+    // @param _account The name of the account to check
+    function canDeposit(bytes32 _account) external view returns (bool) {
+        return (
+            rocketStorage.getBool(keccak256("settings.vault.deposit.allowed")) && // Vault deposits enabled (not using rocketSettings to keep method pure)
+            rocketStorage.getBool(keccak256("vault.account.deposit.enabled", _account)) && // Account deposits enabled
+            rocketStorage.getBool(keccak256("vault.account.deposit.allowed", _account, msg.sender)) && // Sender allowed to deposit into account
+            rocketStorage.getAddress(keccak256("vault.account.owner", _account)) != 0x0 // Account exists (has owner)
+        );
+    }
+
+    // @dev Checks whether the sending address can withdraw from an account
+    // @param _account The name of the account to check
+    function canWithdraw(bytes32 _account) external view returns (bool) {
+        return (
+            rocketStorage.getBool(keccak256("settings.vault.withdrawal.allowed")) && // Vault withdrawals enabled (not using rocketSettings to keep method pure)
+            rocketStorage.getBool(keccak256("vault.account.withdrawal.enabled", _account)) && // Account withdrawals enabled
+            rocketStorage.getBool(keccak256("vault.account.withdrawal.allowed", _account, msg.sender)) && // Sender allowed to withdraw from account
+            rocketStorage.getAddress(keccak256("vault.account.owner", _account)) != 0x0 // Account exists (has owner)
+        );
+    }
+
 
     /*** Setters **************/
 

--- a/contracts/RocketVault.sol
+++ b/contracts/RocketVault.sol
@@ -201,11 +201,25 @@ contract RocketVault is RocketBase {
         return rocketStorage.getBool(keccak256("vault.account.deposit.enabled", _account));
     }
 
-    // @dev Disable/Enable a vault accounts deposits, only the owner of that account or top level owner can do this
-    /// @param _account The name of the account to disable/enable deposits for in RocketVault
+    // @dev Disable/Enable a vault account's deposits, only the owner of that account or top level owner can do this
+    // @param _account The name of the account to disable/enable deposits for in RocketVault
     function setAccountDepositsEnabled(bytes32 _account, bool _option) onlyAccountOwner(_account) external {
         // Ok set the option now
         rocketStorage.setBool(keccak256("vault.account.deposit.enabled", _account), _option);
+    }
+
+    // @dev Returns whether an account's deposits are allowed (true) or disallowed (false)
+    // @param _account The name of the account
+    // @param _address The address to test whether deposits are allowed or disallowed for
+    function getAccountDepositsAllowed(bytes32 _account, address _address) external view returns(bool) {
+        return rocketStorage.getBool(keccak256("vault.account.deposit.allowed", _account, _address));
+    }
+
+    // @dev Allow/Disallow a vault account's deposits for an address, only the owner of that account or top level owner can do this
+    // @param _account The name of the account
+    // @param _address The address to allow/disallow deposits for
+    function setAccountDepositsAllowed(bytes32 _account, address _address, bool _option) onlyAccountOwner(_account) external {
+        rocketStorage.setBool(keccak256("vault.account.deposit.allowed", _account, _address), _option);
     }
 
     // @dev Returns whether an account's withdrawals are enabled (true) or disabled (false)
@@ -214,14 +228,26 @@ contract RocketVault is RocketBase {
         return rocketStorage.getBool(keccak256("vault.account.withdrawal.enabled", _account));
     }
 
-    // @dev Disable/Enable a vault accounts withdrawals, only the owner of that account or top level owner can do this
-    /// @param _account The name of the account to disable/enable deposits for in RocketVault
+    // @dev Disable/Enable a vault account's withdrawals, only the owner of that account or top level owner can do this
+    // @param _account The name of the account to disable/enable deposits for in RocketVault
     function setAccountWithdrawalsEnabled(bytes32 _account, bool _option) onlyAccountOwner(_account) external {
         // Ok set the option now
         rocketStorage.setBool(keccak256("vault.account.withdrawal.enabled", _account), _option);
     }
 
+    // @dev Returns whether an account's withdrawals are allowed (true) or disallowed (false)
+    // @param _account The name of the account
+    // @param _address The address to test whether withdrawals are allowed or disallowed for
+    function getAccountWithdrawalsAllowed(bytes32 _account, address _address) external view returns(bool) {
+        return rocketStorage.getBool(keccak256("vault.account.withdrawal.allowed", _account, _address));
+    }
 
+    // @dev Allow/Disallow a vault account's withdrawals for an address, only the owner of that account or top level owner can do this
+    // @param _account The name of the account
+    // @param _address The address to allow/disallow withdrawals for
+    function setAccountWithdrawalsAllowed(bytes32 _account, address _address, bool _option) onlyAccountOwner(_account) external {
+        rocketStorage.setBool(keccak256("vault.account.withdrawal.allowed", _account, _address), _option);
+    }
 
 
 }

--- a/contracts/RocketVault.sol
+++ b/contracts/RocketVault.sol
@@ -68,7 +68,6 @@ contract RocketVault is RocketBase {
     /**** Methods ***********/
 
 
-
     /// @dev Deposits to RocketVault can be of ether or tokens
     /// @param _account The name of an existing account in RocketVault
     /// @param _amount The amount being deposited in RocketVault
@@ -190,6 +189,12 @@ contract RocketVault is RocketBase {
             rocketStorage.getBool(keccak256("vault.account.withdrawal.allowed", _account, msg.sender)) && // Sender allowed to withdraw from account
             rocketStorage.getAddress(keccak256("vault.account.owner", _account)) != 0x0 // Account exists (has owner)
         );
+    }
+
+    /// @dev Check the balance of an account (returns 0 for nonexistent accounts)
+    /// @param _account The name of the account to check the balance of
+    function getBalance(bytes32 _account) external view returns (uint256) {
+        return rocketStorage.getUint(keccak256("vault.account.balance", _account));
     }
 
 

--- a/test/rocket-vault/rocket-vault-account-tests.js
+++ b/test/rocket-vault/rocket-vault-account-tests.js
@@ -17,9 +17,9 @@ export default function({owner, accounts}) {
 
 
         // Owner can deposit ether into created non-token account
-        it(printTitle('owner', 'can deposit ether into created non-token account'), async () => {
+        it(printTitle('allowed address', 'can deposit ether into created non-token account'), async () => {
 
-            // Create non-token account
+            // Create non-token account; owner is allowed by default on creation
             await scenarioAddAccount({
                 accountName: soliditySha3('owner.created.nontoken'),
                 ownerAddress: owner,
@@ -37,7 +37,7 @@ export default function({owner, accounts}) {
 
 
         // Owner can withdraw ether from created non-token account
-        it(printTitle('owner', 'can withdraw ether from created non-token account'), async () => {
+        it(printTitle('allowed address', 'can withdraw ether from created non-token account'), async () => {
 
             // Withdraw ether
             await scenarioWithdrawEther({
@@ -51,7 +51,7 @@ export default function({owner, accounts}) {
 
 
         // Owner cannot deposit zero ether into account
-        it(printTitle('owner', 'cannot deposit zero ether into account'), async () => {
+        it(printTitle('allowed address', 'cannot deposit zero ether into account'), async () => {
 
             // Deposit ether
             await assertThrows(scenarioDepositEther({
@@ -64,7 +64,7 @@ export default function({owner, accounts}) {
 
 
         // Owner cannot deposit ether into account while vault deposits are disabled
-        it(printTitle('owner', 'cannot deposit ether into account while vault deposits disabled'), async () => {
+        it(printTitle('allowed address', 'cannot deposit ether into account while vault deposits disabled'), async () => {
 
             // Disable vault deposits
             await rocketSettings.setVaultDepositAllowed(false);
@@ -83,7 +83,7 @@ export default function({owner, accounts}) {
 
 
         // Owner cannot deposit ether into account while account deposits are disabled
-        it(printTitle('owner', 'cannot deposit ether into account while account deposits disabled'), async () => {
+        it(printTitle('allowed address', 'cannot deposit ether into account while account deposits disabled'), async () => {
 
             // Disable account deposits
             await rocketVault.setAccountDepositsEnabled(soliditySha3('owner.created.nontoken'), false, {from: owner});
@@ -102,7 +102,7 @@ export default function({owner, accounts}) {
 
 
         // Owner cannot withdraw zero ether from account
-        it(printTitle('owner', 'cannot withdraw zero ether from account'), async () => {
+        it(printTitle('allowed address', 'cannot withdraw zero ether from account'), async () => {
 
             // Withdraw ether
             await assertThrows(scenarioWithdrawEther({
@@ -116,7 +116,7 @@ export default function({owner, accounts}) {
 
 
         // Owner cannot withdraw more ether than their account balance
-        it(printTitle('owner', 'cannot withdraw more ether than account balance'), async () => {
+        it(printTitle('allowed address', 'cannot withdraw more ether than account balance'), async () => {
 
             // Withdraw ether
             await assertThrows(scenarioWithdrawEther({
@@ -130,7 +130,7 @@ export default function({owner, accounts}) {
 
 
         // Owner cannot withdraw ether to a null address
-        it(printTitle('owner', 'cannot withdraw ether to a null address'), async () => {
+        it(printTitle('allowed address', 'cannot withdraw ether to a null address'), async () => {
 
             // Withdraw ether
             await assertThrows(scenarioWithdrawEther({
@@ -144,7 +144,7 @@ export default function({owner, accounts}) {
 
 
         // Owner cannot withdraw ether from account while vault withdrawals are disabled
-        it(printTitle('owner', 'cannot withdraw ether from account while vault withdrawals disabled'), async () => {
+        it(printTitle('allowed address', 'cannot withdraw ether from account while vault withdrawals disabled'), async () => {
 
             // Disable vault withdrawals
             await rocketSettings.setVaultWithdrawalAllowed(false);
@@ -164,7 +164,7 @@ export default function({owner, accounts}) {
 
 
         // Owner cannot withdraw ether from account while account withdrawals are disabled
-        it(printTitle('owner', 'cannot withdraw ether from account while account withdrawals disabled'), async () => {
+        it(printTitle('allowed address', 'cannot withdraw ether from account while account withdrawals disabled'), async () => {
 
             // Disable account withdrawals
             await rocketVault.setAccountWithdrawalsEnabled(soliditySha3('owner.created.nontoken'), false, {from: owner});

--- a/test/rocket-vault/rocket-vault-account-tests.js
+++ b/test/rocket-vault/rocket-vault-account-tests.js
@@ -30,7 +30,7 @@ export default function({owner, accounts}) {
             await scenarioDepositEther({
                 accountName: soliditySha3("owner.created.nontoken"),
                 fromAddress: owner,
-                depositAmount: web3.toWei('2', 'ether'),
+                depositAmount: web3.toWei('10', 'ether'),
             });
 
         });
@@ -84,6 +84,46 @@ export default function({owner, accounts}) {
 
             // Re-enable account deposits
             await rocketVault.setAccountDepositsEnabled(soliditySha3("owner.created.nontoken"), true, {from: owner});
+
+        });
+
+
+        // Owner cannot withdraw ether from account while vault withdrawals are disabled
+        it(printTitle('owner', 'cannot withdraw ether from account while vault withdrawals disabled'), async () => {
+
+            // Disable vault withdrawals
+            await rocketSettings.setVaultWithdrawalAllowed(false);
+
+            // Withdraw ether
+            await assertThrows(scenarioWithdrawEther({
+                accountName: soliditySha3("owner.created.nontoken"),
+                fromAddress: owner,
+                withdrawalAddress: accounts[1],
+                withdrawalAmount: web3.toWei('1', 'ether'),
+            }), 'ether was withdrawn while vault withdrawals disabled');
+
+            // Re-enable vault withdrawals
+            await rocketSettings.setVaultWithdrawalAllowed(true);
+
+        });
+
+
+        // Owner cannot withdraw ether from account while account withdrawals are disabled
+        it(printTitle('owner', 'cannot withdraw ether from account while account withdrawals disabled'), async () => {
+
+            // Disable account withdrawals
+            await rocketVault.setAccountWithdrawalsEnabled(soliditySha3("owner.created.nontoken"), false, {from: owner});
+
+            // Withdraw ether
+            await assertThrows(scenarioWithdrawEther({
+                accountName: soliditySha3("owner.created.nontoken"),
+                fromAddress: owner,
+                withdrawalAddress: accounts[1],
+                withdrawalAmount: web3.toWei('1', 'ether'),
+            }), 'ether was withdrawn while account withdrawals disabled');
+
+            // Re-enable account withdrawals
+            await rocketVault.setAccountWithdrawalsEnabled(soliditySha3("owner.created.nontoken"), true, {from: owner});
 
         });
 

--- a/test/rocket-vault/rocket-vault-account-tests.js
+++ b/test/rocket-vault/rocket-vault-account-tests.js
@@ -183,6 +183,33 @@ export default function({owner, accounts}) {
         });
 
 
+        // Random address cannot deposit ether into account
+        it(printTitle('random address', 'cannot deposit ether into account'), async () => {
+
+            // Deposit ether
+            await assertThrows(scenarioDepositEther({
+                accountName: soliditySha3('owner.created.nontoken'),
+                fromAddress: accounts[9],
+                depositAmount: web3.toWei('1', 'ether'),
+            }), 'random address deposited ether into account');
+
+        });
+
+
+        // Random address cannot withdraw ether from account
+        it(printTitle('random address', 'cannot withdraw ether from account'), async () => {
+
+            // Withdraw ether
+            await assertThrows(scenarioWithdrawEther({
+                accountName: soliditySha3('owner.created.nontoken'),
+                fromAddress: accounts[9],
+                withdrawalAddress: accounts[1],
+                withdrawalAmount: web3.toWei('1', 'ether'),
+            }), 'random address withdrew ether from account');
+
+        });
+
+
     });
 
 };

--- a/test/rocket-vault/rocket-vault-account-tests.js
+++ b/test/rocket-vault/rocket-vault-account-tests.js
@@ -1,6 +1,6 @@
-import { printTitle, assertThrows } from '../utils';
+import { printTitle, assertThrows, soliditySha3 } from '../utils';
 import { RocketVault, RocketSettings } from '../artifacts';
-import { scenarioAddAccount } from './rocket-vault-scenarios';
+import { scenarioAddAccount, scenarioDepositEtherSuccessfully } from './rocket-vault-scenarios';
 
 export default function({owner, accounts}) {
 
@@ -13,6 +13,26 @@ export default function({owner, accounts}) {
         before(async () => {
             rocketVault = await RocketVault.deployed();
             rocketSettings = await RocketSettings.deployed();
+        });
+
+
+        // Owner can deposit ether into created non-token account
+        it(printTitle('owner', 'can deposit ether into created non-token account'), async () => {
+
+            // Create non-token account
+            await scenarioAddAccount({
+                accountName: soliditySha3("owner.created.nontoken"),
+                ownerAddress: owner,
+                tokenContractAddress: 0x0,
+            });
+
+            // Deposit ether
+            await scenarioDepositEtherSuccessfully({
+                accountName: soliditySha3("owner.created.nontoken"),
+                fromAddress: owner,
+                depositAmount: web3.toWei('1', 'ether'),
+            });
+
         });
 
 

--- a/test/rocket-vault/rocket-vault-account-tests.js
+++ b/test/rocket-vault/rocket-vault-account-tests.js
@@ -1,6 +1,6 @@
 import { printTitle, assertThrows, soliditySha3 } from '../utils';
 import { RocketVault, RocketSettings } from '../artifacts';
-import { scenarioAddAccount, scenarioAllowDeposits, scenarioDepositEther, scenarioWithdrawEther } from './rocket-vault-scenarios';
+import { scenarioAddAccount, scenarioAllowDeposits, scenarioAllowWithdrawals, scenarioDepositEther, scenarioWithdrawEther } from './rocket-vault-scenarios';
 
 export default function({owner, accounts}) {
 
@@ -217,6 +217,20 @@ export default function({owner, accounts}) {
             await scenarioAllowDeposits({
                 accountName: soliditySha3('owner.created.nontoken'),
                 depositAddress: accounts[9],
+                fromAddress: owner,
+            });
+
+        });
+
+
+        // Owner can allow/disallow withdrawals from an address
+        it(printTitle('owner', 'can allow/disallow withdrawals from an address'), async () => {
+
+            // Run allow withdrawals scenario
+            await scenarioAllowWithdrawals({
+                accountName: soliditySha3('owner.created.nontoken'),
+                withdrawalAddress: accounts[9],
+                withdrawToAddress: accounts[1],
                 fromAddress: owner,
             });
 

--- a/test/rocket-vault/rocket-vault-account-tests.js
+++ b/test/rocket-vault/rocket-vault-account-tests.js
@@ -187,33 +187,6 @@ export default function({owner, accounts}) {
         });
 
 
-        // Random address cannot deposit ether into account
-        it(printTitle('random address', 'cannot deposit ether into account'), async () => {
-
-            // Deposit ether
-            await assertThrows(scenarioDepositEther({
-                accountName: soliditySha3('owner.created.nontoken'),
-                fromAddress: accounts[9],
-                depositAmount: web3.toWei('1', 'ether'),
-            }), 'random address deposited ether into account');
-
-        });
-
-
-        // Random address cannot withdraw ether from account
-        it(printTitle('random address', 'cannot withdraw ether from account'), async () => {
-
-            // Withdraw ether
-            await assertThrows(scenarioWithdrawEther({
-                accountName: soliditySha3('owner.created.nontoken'),
-                fromAddress: accounts[9],
-                withdrawalAddress: accounts[1],
-                withdrawalAmount: web3.toWei('1', 'ether'),
-            }), 'random address withdrew ether from account');
-
-        });
-
-
         // Allowed address can deposit tokens into token account
         it(printTitle('allowed address', 'can deposit tokens into token account'), async () => {
 
@@ -366,6 +339,75 @@ export default function({owner, accounts}) {
                 withdrawalAddress: '0x0000000000000000000000000000000000000000',
                 withdrawalAmount: web3.toWei('0.1', 'ether'),
             }), 'tokens were withdrawn to a null address');
+
+        });
+
+
+        // Allowed address cannot withdraw tokens from account while vault withdrawals are disabled
+        it(printTitle('allowed address', 'cannot withdraw tokens from account while vault withdrawals disabled'), async () => {
+            const tokenAddress = accounts[3];
+
+            // Disable vault withdrawals
+            await rocketSettings.setVaultWithdrawalAllowed(false);
+
+            // Withdraw tokens
+            await assertThrows(scenarioWithdrawTokens({
+                accountName: soliditySha3('owner.created.token'),
+                fromAddress: tokenAddress,
+                withdrawalAddress: accounts[1],
+                withdrawalAmount: web3.toWei('0.1', 'ether'),
+            }), 'tokens were withdrawn while vault withdrawals disabled');
+
+            // Re-enable vault withdrawals
+            await rocketSettings.setVaultWithdrawalAllowed(true);
+
+        });
+
+
+        // Allowed address cannot withdraw tokens from account while account withdrawals are disabled
+        it(printTitle('allowed address', 'cannot withdraw tokens from account while account withdrawals disabled'), async () => {
+            const tokenAddress = accounts[3];
+
+            // Disable account withdrawals
+            await rocketVault.setAccountWithdrawalsEnabled(soliditySha3('owner.created.token'), false, {from: owner});
+
+            // Withdraw tokens
+            await assertThrows(scenarioWithdrawTokens({
+                accountName: soliditySha3('owner.created.token'),
+                fromAddress: tokenAddress,
+                withdrawalAddress: accounts[1],
+                withdrawalAmount: web3.toWei('0.1', 'ether'),
+            }), 'tokens were withdrawn while account withdrawals disabled');
+
+            // Re-enable account withdrawals
+            await rocketVault.setAccountWithdrawalsEnabled(soliditySha3('owner.created.token'), true, {from: owner});
+
+        });
+
+
+        // Random address cannot deposit ether into account
+        it(printTitle('random address', 'cannot deposit ether into account'), async () => {
+
+            // Deposit ether
+            await assertThrows(scenarioDepositEther({
+                accountName: soliditySha3('owner.created.nontoken'),
+                fromAddress: accounts[9],
+                depositAmount: web3.toWei('1', 'ether'),
+            }), 'random address deposited ether into account');
+
+        });
+
+
+        // Random address cannot withdraw ether from account
+        it(printTitle('random address', 'cannot withdraw ether from account'), async () => {
+
+            // Withdraw ether
+            await assertThrows(scenarioWithdrawEther({
+                accountName: soliditySha3('owner.created.nontoken'),
+                fromAddress: accounts[9],
+                withdrawalAddress: accounts[1],
+                withdrawalAmount: web3.toWei('1', 'ether'),
+            }), 'random address withdrew ether from account');
 
         });
 

--- a/test/rocket-vault/rocket-vault-account-tests.js
+++ b/test/rocket-vault/rocket-vault-account-tests.js
@@ -325,6 +325,51 @@ export default function({owner, accounts}) {
         });
 
 
+        // Allowed address cannot withdraw zero tokens from account
+        it(printTitle('allowed address', 'cannot withdraw zero tokens from account'), async () => {
+            const tokenAddress = accounts[3];
+
+            // Withdraw tokens
+            await assertThrows(scenarioWithdrawTokens({
+                accountName: soliditySha3('owner.created.token'),
+                fromAddress: tokenAddress,
+                withdrawalAddress: accounts[1],
+                withdrawalAmount: web3.toWei('0', 'ether'),
+            }), 'zero tokens were withdrawn from account');
+
+        });
+
+
+        // Allowed address cannot withdraw more tokens than their account balance
+        it(printTitle('allowed address', 'cannot withdraw more tokens than account balance'), async () => {
+            const tokenAddress = accounts[3];
+
+            // Withdraw tokens
+            await assertThrows(scenarioWithdrawTokens({
+                accountName: soliditySha3('owner.created.token'),
+                fromAddress: tokenAddress,
+                withdrawalAddress: accounts[1],
+                withdrawalAmount: web3.toWei('20', 'ether'),
+            }), 'more tokens than account balance were withdrawn');
+
+        });
+
+
+        // Allowed address cannot withdraw tokens to a null address
+        it(printTitle('allowed address', 'cannot withdraw tokens to a null address'), async () => {
+            const tokenAddress = accounts[3];
+
+            // Withdraw tokens
+            await assertThrows(scenarioWithdrawTokens({
+                accountName: soliditySha3('owner.created.token'),
+                fromAddress: tokenAddress,
+                withdrawalAddress: '0x0000000000000000000000000000000000000000',
+                withdrawalAmount: web3.toWei('0.1', 'ether'),
+            }), 'tokens were withdrawn to a null address');
+
+        });
+
+
         // Owner can allow/disallow deposits from an address
         it(printTitle('owner', 'can allow/disallow deposits from an address'), async () => {
 

--- a/test/rocket-vault/rocket-vault-account-tests.js
+++ b/test/rocket-vault/rocket-vault-account-tests.js
@@ -1,6 +1,6 @@
 import { printTitle, assertThrows, soliditySha3 } from '../utils';
 import { RocketVault, RocketSettings } from '../artifacts';
-import { scenarioAddAccount, scenarioDepositEtherSuccessfully } from './rocket-vault-scenarios';
+import { scenarioAddAccount, scenarioDepositEtherSuccessfully, scenarioWithdrawEtherSuccessfully } from './rocket-vault-scenarios';
 
 export default function({owner, accounts}) {
 
@@ -30,7 +30,21 @@ export default function({owner, accounts}) {
             await scenarioDepositEtherSuccessfully({
                 accountName: soliditySha3("owner.created.nontoken"),
                 fromAddress: owner,
-                depositAmount: web3.toWei('1', 'ether'),
+                depositAmount: web3.toWei('2', 'ether'),
+            });
+
+        });
+
+
+        // Owner can withdraw ether from created non-token account
+        it(printTitle('owner', 'can withdraw ether from created non-token account'), async () => {
+
+            // Withdraw ether
+            await scenarioWithdrawEtherSuccessfully({
+                accountName: soliditySha3("owner.created.nontoken"),
+                fromAddress: owner,
+                withdrawalAddress: accounts[1],
+                withdrawalAmount: web3.toWei('1', 'ether'),
             });
 
         });

--- a/test/rocket-vault/rocket-vault-account-tests.js
+++ b/test/rocket-vault/rocket-vault-account-tests.js
@@ -18,7 +18,7 @@ export default function({owner, accounts}) {
         });
 
 
-        // Owner can deposit ether into created non-token account
+        // Allowed address can deposit ether into created non-token account
         it(printTitle('allowed address', 'can deposit ether into created non-token account'), async () => {
 
             // Create non-token account; owner is allowed by default on creation
@@ -38,7 +38,7 @@ export default function({owner, accounts}) {
         });
 
 
-        // Owner can withdraw ether from created non-token account
+        // Allowed address can withdraw ether from created non-token account
         it(printTitle('allowed address', 'can withdraw ether from created non-token account'), async () => {
 
             // Withdraw ether
@@ -52,7 +52,7 @@ export default function({owner, accounts}) {
         });
 
 
-        // Owner cannot deposit zero ether into account
+        // Allowed address cannot deposit zero ether into account
         it(printTitle('allowed address', 'cannot deposit zero ether into account'), async () => {
 
             // Deposit ether
@@ -65,7 +65,7 @@ export default function({owner, accounts}) {
         });
 
 
-        // Owner cannot deposit ether into account while vault deposits are disabled
+        // Allowed address cannot deposit ether into account while vault deposits are disabled
         it(printTitle('allowed address', 'cannot deposit ether into account while vault deposits disabled'), async () => {
 
             // Disable vault deposits
@@ -84,7 +84,7 @@ export default function({owner, accounts}) {
         });
 
 
-        // Owner cannot deposit ether into account while account deposits are disabled
+        // Allowed address cannot deposit ether into account while account deposits are disabled
         it(printTitle('allowed address', 'cannot deposit ether into account while account deposits disabled'), async () => {
 
             // Disable account deposits
@@ -103,7 +103,7 @@ export default function({owner, accounts}) {
         });
 
 
-        // Owner cannot withdraw zero ether from account
+        // Allowed address cannot withdraw zero ether from account
         it(printTitle('allowed address', 'cannot withdraw zero ether from account'), async () => {
 
             // Withdraw ether
@@ -117,7 +117,7 @@ export default function({owner, accounts}) {
         });
 
 
-        // Owner cannot withdraw more ether than their account balance
+        // Allowed address cannot withdraw more ether than their account balance
         it(printTitle('allowed address', 'cannot withdraw more ether than account balance'), async () => {
 
             // Withdraw ether
@@ -131,7 +131,7 @@ export default function({owner, accounts}) {
         });
 
 
-        // Owner cannot withdraw ether to a null address
+        // Allowed address cannot withdraw ether to a null address
         it(printTitle('allowed address', 'cannot withdraw ether to a null address'), async () => {
 
             // Withdraw ether
@@ -145,7 +145,7 @@ export default function({owner, accounts}) {
         });
 
 
-        // Owner cannot withdraw ether from account while vault withdrawals are disabled
+        // Allowed address cannot withdraw ether from account while vault withdrawals are disabled
         it(printTitle('allowed address', 'cannot withdraw ether from account while vault withdrawals disabled'), async () => {
 
             // Disable vault withdrawals
@@ -165,7 +165,7 @@ export default function({owner, accounts}) {
         });
 
 
-        // Owner cannot withdraw ether from account while account withdrawals are disabled
+        // Allowed address cannot withdraw ether from account while account withdrawals are disabled
         it(printTitle('allowed address', 'cannot withdraw ether from account while account withdrawals disabled'), async () => {
 
             // Disable account withdrawals

--- a/test/rocket-vault/rocket-vault-account-tests.js
+++ b/test/rocket-vault/rocket-vault-account-tests.js
@@ -21,14 +21,14 @@ export default function({owner, accounts}) {
 
             // Create non-token account
             await scenarioAddAccount({
-                accountName: soliditySha3("owner.created.nontoken"),
+                accountName: soliditySha3('owner.created.nontoken'),
                 ownerAddress: owner,
                 tokenContractAddress: 0x0,
             });
 
             // Deposit ether
             await scenarioDepositEther({
-                accountName: soliditySha3("owner.created.nontoken"),
+                accountName: soliditySha3('owner.created.nontoken'),
                 fromAddress: owner,
                 depositAmount: web3.toWei('10', 'ether'),
             });
@@ -41,7 +41,7 @@ export default function({owner, accounts}) {
 
             // Withdraw ether
             await scenarioWithdrawEther({
-                accountName: soliditySha3("owner.created.nontoken"),
+                accountName: soliditySha3('owner.created.nontoken'),
                 fromAddress: owner,
                 withdrawalAddress: accounts[1],
                 withdrawalAmount: web3.toWei('1', 'ether'),
@@ -55,7 +55,7 @@ export default function({owner, accounts}) {
 
             // Deposit ether
             await assertThrows(scenarioDepositEther({
-                accountName: soliditySha3("owner.created.nontoken"),
+                accountName: soliditySha3('owner.created.nontoken'),
                 fromAddress: owner,
                 depositAmount: web3.toWei('0', 'ether'),
             }), 'zero ether was deposited into account');
@@ -71,7 +71,7 @@ export default function({owner, accounts}) {
 
             // Deposit ether
             await assertThrows(scenarioDepositEther({
-                accountName: soliditySha3("owner.created.nontoken"),
+                accountName: soliditySha3('owner.created.nontoken'),
                 fromAddress: owner,
                 depositAmount: web3.toWei('1', 'ether'),
             }), 'ether was deposited while vault deposits disabled');
@@ -86,17 +86,17 @@ export default function({owner, accounts}) {
         it(printTitle('owner', 'cannot deposit ether into account while account deposits disabled'), async () => {
 
             // Disable account deposits
-            await rocketVault.setAccountDepositsEnabled(soliditySha3("owner.created.nontoken"), false, {from: owner});
+            await rocketVault.setAccountDepositsEnabled(soliditySha3('owner.created.nontoken'), false, {from: owner});
 
             // Deposit ether
             await assertThrows(scenarioDepositEther({
-                accountName: soliditySha3("owner.created.nontoken"),
+                accountName: soliditySha3('owner.created.nontoken'),
                 fromAddress: owner,
                 depositAmount: web3.toWei('1', 'ether'),
             }), 'ether was deposited while account deposits disabled');
 
             // Re-enable account deposits
-            await rocketVault.setAccountDepositsEnabled(soliditySha3("owner.created.nontoken"), true, {from: owner});
+            await rocketVault.setAccountDepositsEnabled(soliditySha3('owner.created.nontoken'), true, {from: owner});
 
         });
 
@@ -106,11 +106,39 @@ export default function({owner, accounts}) {
 
             // Withdraw ether
             await assertThrows(scenarioWithdrawEther({
-                accountName: soliditySha3("owner.created.nontoken"),
+                accountName: soliditySha3('owner.created.nontoken'),
                 fromAddress: owner,
                 withdrawalAddress: accounts[1],
                 withdrawalAmount: web3.toWei('0', 'ether'),
             }), 'zero ether was withdrawn from account');
+
+        });
+
+
+        // Owner cannot withdraw more ether than their account balance
+        it(printTitle('owner', 'cannot withdraw more ether than account balance'), async () => {
+
+            // Withdraw ether
+            await assertThrows(scenarioWithdrawEther({
+                accountName: soliditySha3('owner.created.nontoken'),
+                fromAddress: owner,
+                withdrawalAddress: accounts[1],
+                withdrawalAmount: web3.toWei('20', 'ether'),
+            }), 'more ether than account balance was withdrawn');
+
+        });
+
+
+        // Owner cannot withdraw ether to a null address
+        it(printTitle('owner', 'cannot withdraw ether to a null address'), async () => {
+
+            // Withdraw ether
+            await assertThrows(scenarioWithdrawEther({
+                accountName: soliditySha3('owner.created.nontoken'),
+                fromAddress: owner,
+                withdrawalAddress: '0x0000000000000000000000000000000000000000',
+                withdrawalAmount: web3.toWei('1', 'ether'),
+            }), 'ether was withdrawn to a null address');
 
         });
 
@@ -123,7 +151,7 @@ export default function({owner, accounts}) {
 
             // Withdraw ether
             await assertThrows(scenarioWithdrawEther({
-                accountName: soliditySha3("owner.created.nontoken"),
+                accountName: soliditySha3('owner.created.nontoken'),
                 fromAddress: owner,
                 withdrawalAddress: accounts[1],
                 withdrawalAmount: web3.toWei('1', 'ether'),
@@ -139,18 +167,18 @@ export default function({owner, accounts}) {
         it(printTitle('owner', 'cannot withdraw ether from account while account withdrawals disabled'), async () => {
 
             // Disable account withdrawals
-            await rocketVault.setAccountWithdrawalsEnabled(soliditySha3("owner.created.nontoken"), false, {from: owner});
+            await rocketVault.setAccountWithdrawalsEnabled(soliditySha3('owner.created.nontoken'), false, {from: owner});
 
             // Withdraw ether
             await assertThrows(scenarioWithdrawEther({
-                accountName: soliditySha3("owner.created.nontoken"),
+                accountName: soliditySha3('owner.created.nontoken'),
                 fromAddress: owner,
                 withdrawalAddress: accounts[1],
                 withdrawalAmount: web3.toWei('1', 'ether'),
             }), 'ether was withdrawn while account withdrawals disabled');
 
             // Re-enable account withdrawals
-            await rocketVault.setAccountWithdrawalsEnabled(soliditySha3("owner.created.nontoken"), true, {from: owner});
+            await rocketVault.setAccountWithdrawalsEnabled(soliditySha3('owner.created.nontoken'), true, {from: owner});
 
         });
 

--- a/test/rocket-vault/rocket-vault-account-tests.js
+++ b/test/rocket-vault/rocket-vault-account-tests.js
@@ -256,6 +256,35 @@ export default function({owner, accounts}) {
         });
 
 
+        // Allowed address cannot deposit zero tokens into account
+        it(printTitle('allowed address', 'cannot deposit zero tokens into account'), async () => {
+            const tokenAddress = accounts[3];
+
+            // Deposit tokens
+            await assertThrows(scenarioDepositTokens({
+                accountName: soliditySha3('owner.created.token'),
+                fromAddress: tokenAddress,
+                depositAmount: web3.toWei('0', 'ether'),
+            }), 'zero tokens were deposited into account');
+
+        });
+
+
+        // Allowed address cannot send ether balance with token deposit
+        it(printTitle('allowed address', 'cannot send ether balance with token deposit'), async () => {
+            const tokenAddress = accounts[3];
+
+            // Deposit tokens
+            await assertThrows(scenarioDepositTokens({
+                accountName: soliditySha3('owner.created.token'),
+                fromAddress: tokenAddress,
+                depositAmount: web3.toWei('0.1', 'ether'),
+                etherBalance: web3.toWei('1', 'ether'),
+            }), 'ether balance was sent with token deposit');
+
+        });
+
+
         // Owner can allow/disallow deposits from an address
         it(printTitle('owner', 'can allow/disallow deposits from an address'), async () => {
 

--- a/test/rocket-vault/rocket-vault-account-tests.js
+++ b/test/rocket-vault/rocket-vault-account-tests.js
@@ -1,6 +1,6 @@
 import { printTitle, assertThrows, soliditySha3 } from '../utils';
 import { RocketVault, RocketSettings } from '../artifacts';
-import { scenarioAddAccount, scenarioDepositEtherSuccessfully, scenarioWithdrawEtherSuccessfully } from './rocket-vault-scenarios';
+import { scenarioAddAccount, scenarioDepositEther, scenarioWithdrawEther } from './rocket-vault-scenarios';
 
 export default function({owner, accounts}) {
 
@@ -27,7 +27,7 @@ export default function({owner, accounts}) {
             });
 
             // Deposit ether
-            await scenarioDepositEtherSuccessfully({
+            await scenarioDepositEther({
                 accountName: soliditySha3("owner.created.nontoken"),
                 fromAddress: owner,
                 depositAmount: web3.toWei('2', 'ether'),
@@ -40,12 +40,31 @@ export default function({owner, accounts}) {
         it(printTitle('owner', 'can withdraw ether from created non-token account'), async () => {
 
             // Withdraw ether
-            await scenarioWithdrawEtherSuccessfully({
+            await scenarioWithdrawEther({
                 accountName: soliditySha3("owner.created.nontoken"),
                 fromAddress: owner,
                 withdrawalAddress: accounts[1],
                 withdrawalAmount: web3.toWei('1', 'ether'),
             });
+
+        });
+
+
+        // Owner cannot deposit ether into account while vault deposits are disabled
+        it(printTitle('owner', 'cannot deposit ether into account while vault deposits disabled'), async () => {
+
+            // Disable vault deposits
+            await rocketSettings.setVaultDepositAllowed(false);
+
+            // Deposit ether
+            await assertThrows(scenarioDepositEther({
+                accountName: soliditySha3("owner.created.nontoken"),
+                fromAddress: owner,
+                depositAmount: web3.toWei('1', 'ether'),
+            }), 'ether was deposited while vault deposits disabled');
+
+            // Re-enable vault deposits
+            await rocketSettings.setVaultDepositAllowed(true);
 
         });
 

--- a/test/rocket-vault/rocket-vault-account-tests.js
+++ b/test/rocket-vault/rocket-vault-account-tests.js
@@ -1,0 +1,21 @@
+import { printTitle, assertThrows } from '../utils';
+import { RocketVault, RocketSettings } from '../artifacts';
+import { scenarioAddAccount } from './rocket-vault-scenarios';
+
+export default function({owner, accounts}) {
+
+    describe('RocketVault - Accounts', async () => {
+
+
+        // Contract dependencies
+        let rocketVault;
+        let rocketSettings;
+        before(async () => {
+            rocketVault = await RocketVault.deployed();
+            rocketSettings = await RocketSettings.deployed();
+        });
+
+
+    });
+
+};

--- a/test/rocket-vault/rocket-vault-account-tests.js
+++ b/test/rocket-vault/rocket-vault-account-tests.js
@@ -50,6 +50,19 @@ export default function({owner, accounts}) {
         });
 
 
+        // Owner cannot deposit zero ether into account
+        it(printTitle('owner', 'cannot deposit zero ether into account'), async () => {
+
+            // Deposit ether
+            await assertThrows(scenarioDepositEther({
+                accountName: soliditySha3("owner.created.nontoken"),
+                fromAddress: owner,
+                depositAmount: web3.toWei('0', 'ether'),
+            }), 'zero ether was deposited into account');
+
+        });
+
+
         // Owner cannot deposit ether into account while vault deposits are disabled
         it(printTitle('owner', 'cannot deposit ether into account while vault deposits disabled'), async () => {
 
@@ -84,6 +97,20 @@ export default function({owner, accounts}) {
 
             // Re-enable account deposits
             await rocketVault.setAccountDepositsEnabled(soliditySha3("owner.created.nontoken"), true, {from: owner});
+
+        });
+
+
+        // Owner cannot withdraw zero ether from account
+        it(printTitle('owner', 'cannot withdraw zero ether from account'), async () => {
+
+            // Withdraw ether
+            await assertThrows(scenarioWithdrawEther({
+                accountName: soliditySha3("owner.created.nontoken"),
+                fromAddress: owner,
+                withdrawalAddress: accounts[1],
+                withdrawalAmount: web3.toWei('0', 'ether'),
+            }), 'zero ether was withdrawn from account');
 
         });
 

--- a/test/rocket-vault/rocket-vault-account-tests.js
+++ b/test/rocket-vault/rocket-vault-account-tests.js
@@ -285,6 +285,46 @@ export default function({owner, accounts}) {
         });
 
 
+        // Allowed address cannot deposit tokens into account while vault deposits are disabled
+        it(printTitle('allowed address', 'cannot deposit tokens into account while vault deposits disabled'), async () => {
+            const tokenAddress = accounts[3];
+
+            // Disable vault deposits
+            await rocketSettings.setVaultDepositAllowed(false);
+
+            // Deposit tokens
+            await assertThrows(scenarioDepositTokens({
+                accountName: soliditySha3('owner.created.token'),
+                fromAddress: tokenAddress,
+                depositAmount: web3.toWei('0.1', 'ether'),
+            }), 'tokens were deposited while vault deposits disabled');
+
+            // Re-enable vault deposits
+            await rocketSettings.setVaultDepositAllowed(true);
+
+        });
+
+
+        // Allowed address cannot deposit tokens into account while account deposits are disabled
+        it(printTitle('allowed address', 'cannot deposit tokens into account while account deposits disabled'), async () => {
+            const tokenAddress = accounts[3];
+
+            // Disable account deposits
+            await rocketVault.setAccountDepositsEnabled(soliditySha3('owner.created.token'), false, {from: owner});
+
+            // Deposit tokens
+            await assertThrows(scenarioDepositTokens({
+                accountName: soliditySha3('owner.created.token'),
+                fromAddress: tokenAddress,
+                depositAmount: web3.toWei('0.1', 'ether'),
+            }), 'tokens were deposited while account deposits disabled');
+
+            // Re-enable account deposits
+            await rocketVault.setAccountDepositsEnabled(soliditySha3('owner.created.token'), true, {from: owner});
+
+        });
+
+
         // Owner can allow/disallow deposits from an address
         it(printTitle('owner', 'can allow/disallow deposits from an address'), async () => {
 

--- a/test/rocket-vault/rocket-vault-account-tests.js
+++ b/test/rocket-vault/rocket-vault-account-tests.js
@@ -412,6 +412,39 @@ export default function({owner, accounts}) {
         });
 
 
+        // Random address cannot deposit tokens into account
+        it(printTitle('random address', 'cannot deposit tokens into account'), async () => {
+
+            // Send some tokens to random address
+            const tokenAddress = accounts[3];
+            const randomTokenAddress = accounts[9];
+            await rocketDepositToken.transfer(randomTokenAddress, web3.toWei('0.2', 'ether'), {from: tokenAddress});
+
+            // Deposit tokens
+            await assertThrows(scenarioDepositTokens({
+                accountName: soliditySha3('owner.created.token'),
+                fromAddress: randomTokenAddress,
+                depositAmount: web3.toWei('0.1', 'ether'),
+            }), 'random address deposited tokens into account');
+
+        });
+
+
+        // Random address cannot withdraw tokens from account
+        it(printTitle('random address', 'cannot withdraw tokens from account'), async () => {
+            const randomTokenAddress = accounts[9];
+
+            // Withdraw tokens
+            await assertThrows(scenarioWithdrawTokens({
+                accountName: soliditySha3('owner.created.token'),
+                fromAddress: randomTokenAddress,
+                withdrawalAddress: accounts[1],
+                withdrawalAmount: web3.toWei('0.1', 'ether'),
+            }), 'random address withdrew tokens from account');
+
+        });
+
+
         // Owner can allow/disallow deposits from an address
         it(printTitle('owner', 'can allow/disallow deposits from an address'), async () => {
 

--- a/test/rocket-vault/rocket-vault-account-tests.js
+++ b/test/rocket-vault/rocket-vault-account-tests.js
@@ -1,6 +1,6 @@
 import { printTitle, assertThrows, soliditySha3 } from '../utils';
 import { RocketVault, RocketDepositToken, RocketSettings, RocketRole } from '../artifacts';
-import { scenarioAddAccount, scenarioAllowDeposits, scenarioAllowWithdrawals, scenarioDepositEther, scenarioWithdrawEther, scenarioDepositTokens } from './rocket-vault-scenarios';
+import { scenarioAddAccount, scenarioAllowDeposits, scenarioAllowWithdrawals, scenarioDepositEther, scenarioWithdrawEther, scenarioDepositTokens, scenarioWithdrawTokens } from './rocket-vault-scenarios';
 
 export default function({owner, accounts}) {
 
@@ -235,7 +235,22 @@ export default function({owner, accounts}) {
             await scenarioDepositTokens({
                 accountName: soliditySha3('owner.created.token'),
                 fromAddress: tokenAddress,
-                depositAmount: web3.toWei('0.1', 'ether'),
+                depositAmount: web3.toWei('0.5', 'ether'),
+            });
+
+        });
+
+
+        // Allowed address can withdraw tokens from token account
+        it(printTitle('allowed address', 'can withdraw tokens from token account'), async () => {
+            const tokenAddress = accounts[3];
+
+            // Withdraw tokens
+            await scenarioWithdrawTokens({
+                accountName: soliditySha3('owner.created.token'),
+                fromAddress: tokenAddress,
+                withdrawalAddress: accounts[1],
+                withdrawalAmount: web3.toWei('0.1', 'ether'),
             });
 
         });

--- a/test/rocket-vault/rocket-vault-account-tests.js
+++ b/test/rocket-vault/rocket-vault-account-tests.js
@@ -1,6 +1,6 @@
 import { printTitle, assertThrows, soliditySha3 } from '../utils';
 import { RocketVault, RocketSettings } from '../artifacts';
-import { scenarioAddAccount, scenarioDepositEther, scenarioWithdrawEther } from './rocket-vault-scenarios';
+import { scenarioAddAccount, scenarioAllowDeposits, scenarioDepositEther, scenarioWithdrawEther } from './rocket-vault-scenarios';
 
 export default function({owner, accounts}) {
 
@@ -206,6 +206,19 @@ export default function({owner, accounts}) {
                 withdrawalAddress: accounts[1],
                 withdrawalAmount: web3.toWei('1', 'ether'),
             }), 'random address withdrew ether from account');
+
+        });
+
+
+        // Owner can allow/disallow deposits from an address
+        it(printTitle('owner', 'can allow/disallow deposits from an address'), async () => {
+
+            // Run allow deposits scenario
+            await scenarioAllowDeposits({
+                accountName: soliditySha3('owner.created.nontoken'),
+                depositAddress: accounts[9],
+                fromAddress: owner,
+            });
 
         });
 

--- a/test/rocket-vault/rocket-vault-account-tests.js
+++ b/test/rocket-vault/rocket-vault-account-tests.js
@@ -69,6 +69,25 @@ export default function({owner, accounts}) {
         });
 
 
+        // Owner cannot deposit ether into account while account deposits are disabled
+        it(printTitle('owner', 'cannot deposit ether into account while account deposits disabled'), async () => {
+
+            // Disable account deposits
+            await rocketVault.setAccountDepositsEnabled(soliditySha3("owner.created.nontoken"), false, {from: owner});
+
+            // Deposit ether
+            await assertThrows(scenarioDepositEther({
+                accountName: soliditySha3("owner.created.nontoken"),
+                fromAddress: owner,
+                depositAmount: web3.toWei('1', 'ether'),
+            }), 'ether was deposited while account deposits disabled');
+
+            // Re-enable account deposits
+            await rocketVault.setAccountDepositsEnabled(soliditySha3("owner.created.nontoken"), true, {from: owner});
+
+        });
+
+
     });
 
 };

--- a/test/rocket-vault/rocket-vault-admin-tests.js
+++ b/test/rocket-vault/rocket-vault-admin-tests.js
@@ -1,4 +1,4 @@
-import { printTitle, assertThrows } from "../utils";
+import { printTitle, assertThrows, soliditySha3 } from "../utils";
 import { RocketVault, RocketRole } from "../artifacts";
 import { scenarioAddAccount, scenarioDepositEnabling, sceanarioWithdrawalsEnabling } from "./rocket-vault-scenarios";
 
@@ -14,7 +14,7 @@ export default function({owner, accounts}){
         // As an owner I must be able to add a non-token account to the vault.
         it(printTitle("owner", "can add a non-token account to the vault"), async () => {
             await scenarioAddAccount({
-                accountName: "owner.nontoken",
+                accountName: soliditySha3("owner.nontoken"),
                 ownerAddress: owner,
                 tokenContractAddress: 0x0
             });
@@ -23,7 +23,7 @@ export default function({owner, accounts}){
         // As an owner I must be able to add a token account to the vault.
        it(printTitle("owner", "can add a token account to the vault"), async () => { 
             await scenarioAddAccount({
-                accountName: "owner.token",
+                accountName: soliditySha3("owner.token"),
                 ownerAddress: owner,
                 tokenContractAddress: 0xa917e0023dae346fe728ae51376a430df1ea9335 // random address
             });
@@ -40,7 +40,7 @@ export default function({owner, accounts}){
 
         // As an owner I must not be able to add an account that already exists.
        it(printTitle("owner", "cannot add an account that already exists"), async () => {
-            const existingAccountName = "owner.alreadyExists";
+            const existingAccountName = soliditySha3("owner.alreadyExists");
 
             // add an account with a specific name
             await rocketVault.setAccountAdd(existingAccountName, 0x0, {from: owner});
@@ -62,7 +62,7 @@ export default function({owner, accounts}){
             await rocketRole.adminRoleAdd("admin", accountOwner, {from: owner});
 
             // add an account by the admin account
-            const accountName = "owner.deposits.enabling";
+            const accountName = soliditySha3("owner.deposits.enabling");
             await rocketVault.setAccountAdd(accountName, 0x0, {from: accountOwner});
 
             // test owner can disable/enable account deposits of an account not owned by them
@@ -78,7 +78,7 @@ export default function({owner, accounts}){
             await rocketRole.adminRoleAdd("admin", accountOwner, {from: owner});
 
             // add an account owned by some account owner
-            const accountName = "owner.withdrawals.enabling";
+            const accountName = soliditySha3("owner.withdrawals.enabling");
             await rocketVault.setAccountAdd(accountName, 0x0, {from: accountOwner});
 
             // test owner can disable/enable account withdrawals of an account not owned by them 
@@ -95,7 +95,7 @@ export default function({owner, accounts}){
             await rocketRole.adminRoleAdd("admin", adminAddress, {from: owner});
 
             await scenarioAddAccount({
-                accountName: "admin.nontoken",
+                accountName: soliditySha3("admin.nontoken"),
                 ownerAddress: adminAddress,
                 tokenContractAddress: 0x0
             });
@@ -108,7 +108,7 @@ export default function({owner, accounts}){
             await rocketRole.adminRoleAdd("admin", adminAddress, {from: owner});
 
             await scenarioAddAccount({
-                accountName: "admin.token",
+                accountName: soliditySha3("admin.token"),
                 ownerAddress: adminAddress,
                 tokenContractAddress: 0xa917e0023dae346fe728ae51376a430df1ea9335 // random address
             });
@@ -134,7 +134,7 @@ export default function({owner, accounts}){
             await rocketRole.adminRoleAdd("admin", adminAddress, {from: owner});
 
             // add an account with a specific name
-            const existingAccountName = "admin.alreadyExists";
+            const existingAccountName = soliditySha3("admin.alreadyExists");
             await rocketVault.setAccountAdd(existingAccountName, 0x0, {from: owner});
 
             // try to add another with the same name
@@ -154,7 +154,7 @@ export default function({owner, accounts}){
             await rocketRole.adminRoleAdd("admin", accountOwner, {from: owner});
 
             // add an account, accountOwner must be admin to add an account
-            const accountName = "accountowner.deposit.enabling";
+            const accountName = soliditySha3("accountowner.deposit.enabling");
             await rocketVault.setAccountAdd(accountName, 0x0, {from: accountOwner});            
 
             // remove admin role so we are testing account ownership only
@@ -174,7 +174,7 @@ export default function({owner, accounts}){
             await rocketRole.adminRoleAdd("admin", accountOwner, {from: owner});
 
             // add an account, accountOwner must be admin to add an account
-            const accountName = "accountowner.withdrawal.enabling";
+            const accountName = soliditySha3("accountowner.withdrawal.enabling");
             await rocketVault.setAccountAdd(accountName, 0x0, {from: accountOwner});            
 
             // remove admin role so we are testing account ownership only
@@ -191,7 +191,7 @@ export default function({owner, accounts}){
        it(printTitle("random account", "cannot add an account to the vault"), async () => {
             let randomAccount = accounts[2];
             let promise = scenarioAddAccount({
-                accountName: "random.nontoken",
+                accountName: soliditySha3("random.nontoken"),
                 ownerAddress: randomAccount,
                 tokenContractAddress: 0x0
             });
@@ -204,7 +204,7 @@ export default function({owner, accounts}){
        it(printTitle("random account", "cannot add a token account to the vault"), async () => {
             let randomAccount = accounts[2];
             let promise = scenarioAddAccount({
-                accountName: "random.token",
+                accountName: soliditySha3("random.token"),
                 ownerAddress: randomAccount,
                 tokenContractAddress: 0xa917e0023dae346fe728ae51376a430df1ea9335
             });
@@ -220,7 +220,7 @@ export default function({owner, accounts}){
             await rocketRole.adminRoleAdd("admin", accountOwner, {from: owner});
 
             // add an account, accountOwner must be admin to add an account
-            const accountName = "random.deposit.enabling";
+            const accountName = soliditySha3("random.deposit.enabling");
             await rocketVault.setAccountAdd(accountName, 0x0, {from: accountOwner}); 
 
             let randomAccount = accounts[2];
@@ -241,7 +241,7 @@ export default function({owner, accounts}){
             await rocketRole.adminRoleAdd("admin", accountOwner, {from: owner});
 
             // add an account, accountOwner must be admin to add an account
-            const accountName = "random.withdrawals.enabling";
+            const accountName = soliditySha3("random.withdrawals.enabling");
             await rocketVault.setAccountAdd(accountName, 0x0, {from: accountOwner}); 
 
             let randomAccount = accounts[2];

--- a/test/rocket-vault/rocket-vault-scenarios.js
+++ b/test/rocket-vault/rocket-vault-scenarios.js
@@ -161,7 +161,7 @@ export async function scenarioWithdrawEther({accountName, fromAddress, withdrawa
 }
 
 // Deposits tokens to account and asserts balances updated correctly
-export async function scenarioDepositTokens({accountName, fromAddress, depositAmount}) {
+export async function scenarioDepositTokens({accountName, fromAddress, depositAmount, etherBalance = 0}) {
     const rocketVault = await RocketVault.deployed();
     const rocketDepositToken = await RocketDepositToken.deployed();
 
@@ -171,7 +171,7 @@ export async function scenarioDepositTokens({accountName, fromAddress, depositAm
 
     // Allow deposit & deposit tokens
     await rocketDepositToken.approve(rocketVault.address, depositAmount, {from: fromAddress});
-    await rocketVault.deposit(accountName, depositAmount, {from: fromAddress});
+    await rocketVault.deposit(accountName, depositAmount, {from: fromAddress, value: etherBalance});
 
     // Get new vault & account balances
     let vaultBalanceNew = await rocketDepositToken.balanceOf(rocketVault.address);

--- a/test/rocket-vault/rocket-vault-scenarios.js
+++ b/test/rocket-vault/rocket-vault-scenarios.js
@@ -64,8 +64,8 @@ export async function sceanarioWithdrawalsEnabling({accountName, accountToTestEn
     assert.isTrue(withdrawalEnabled, "Account withdrawals should be enabled.");
 }
 
-// Deposit ether successfully
-export async function scenarioDepositEtherSuccessfully({accountName, fromAddress, depositAmount}) {
+// Deposit ether to account
+export async function scenarioDepositEther({accountName, fromAddress, depositAmount}) {
     const rocketVault = await RocketVault.deployed();
 
     // Get old vault & account balances
@@ -85,8 +85,8 @@ export async function scenarioDepositEtherSuccessfully({accountName, fromAddress
 
 }
 
-// Withdraw ether successfully
-export async function scenarioWithdrawEtherSuccessfully({accountName, fromAddress, withdrawalAddress, withdrawalAmount}) {
+// Withdraw ether from account to address
+export async function scenarioWithdrawEther({accountName, fromAddress, withdrawalAddress, withdrawalAmount}) {
     const rocketVault = await RocketVault.deployed();
 
     // Get old address & account balances

--- a/test/rocket-vault/rocket-vault-scenarios.js
+++ b/test/rocket-vault/rocket-vault-scenarios.js
@@ -90,6 +90,34 @@ export async function scenarioAllowDeposits({accountName, depositAddress, fromAd
 
 }
 
+// Runs allow withdrawals scenario and asserts withdrawals work while address is allowed
+export async function scenarioAllowWithdrawals({accountName, withdrawalAddress, withdrawToAddress, fromAddress}) {
+    const rocketVault = await RocketVault.deployed();
+
+    // Allow withdrawals
+    await rocketVault.setAccountWithdrawalsAllowed(accountName, withdrawalAddress, true, {from: fromAddress});
+
+    // Withdraw ether to address
+    await scenarioWithdrawEther({
+        accountName,
+        fromAddress: withdrawalAddress,
+        withdrawalAddress: withdrawToAddress,
+        withdrawalAmount: web3.toWei('1', 'ether'),
+    });
+
+    // Disallow withdrawals
+    await rocketVault.setAccountWithdrawalsAllowed(accountName, withdrawalAddress, false, {from: fromAddress});
+
+    // Withdraw ether to address
+    await assertThrows(scenarioWithdrawEther({
+        accountName,
+        fromAddress: withdrawalAddress,
+        withdrawalAddress: withdrawToAddress,
+        withdrawalAmount: web3.toWei('1', 'ether'),
+    }), 'disallowed address withdrew ether from account');
+
+}
+
 // Deposits ether to account and asserts balances updated correctly
 export async function scenarioDepositEther({accountName, fromAddress, depositAmount}) {
     const rocketVault = await RocketVault.deployed();

--- a/test/rocket-vault/rocket-vault-scenarios.js
+++ b/test/rocket-vault/rocket-vault-scenarios.js
@@ -64,6 +64,27 @@ export async function sceanarioWithdrawalsEnabling({accountName, accountToTestEn
     assert.isTrue(withdrawalEnabled, "Account withdrawals should be enabled.");
 }
 
+// Deposit ether successfully
+export async function scenarioDepositEtherSuccessfully({accountName, fromAddress, depositAmount}) {
+    const rocketVault = await RocketVault.deployed();
+
+    // Get old vault & account balances
+    let vaultBalanceOld = web3.eth.getBalance(rocketVault.address).valueOf();
+    let accountBalanceOld = await rocketVault.getBalance(accountName);
+
+    // Deposit ether
+    await rocketVault.deposit(accountName, 0, {from: fromAddress, value: depositAmount});
+
+    // Get new vault & account balances
+    let vaultBalanceNew = web3.eth.getBalance(rocketVault.address).valueOf();
+    let accountBalanceNew = await rocketVault.getBalance(accountName);
+
+    assert.notEqual(vaultBalanceOld, vaultBalanceNew, 'Vault ether balance was not increased');
+    assert.notEqual(accountBalanceOld.valueOf(), accountBalanceNew.valueOf(), 'Account ether balance was not increased');
+    assert.equal((vaultBalanceNew - vaultBalanceOld), (accountBalanceNew.valueOf() - accountBalanceOld.valueOf()), 'Account ether balance was updated incorrectly');
+
+}
+
 /** ASSERTS */
 
 // Asserts that an account has been recorded correctly

--- a/test/rocket-vault/rocket-vault-scenarios.js
+++ b/test/rocket-vault/rocket-vault-scenarios.js
@@ -1,5 +1,5 @@
 import { assertThrows, soliditySha3 } from '../utils';
-import { RocketStorage, RocketVault } from "../artifacts";
+import { RocketStorage, RocketVault, RocketDepositToken } from "../artifacts";
 
 /** SCENARIOS */
 
@@ -157,6 +157,29 @@ export async function scenarioWithdrawEther({accountName, fromAddress, withdrawa
     assert.notEqual(addressBalanceOld, addressBalanceNew, 'Address ether balance was not increased');
     assert.notEqual(accountBalanceOld.valueOf(), accountBalanceNew.valueOf(), 'Account ether balance was not decreased');
     assert.equal((addressBalanceNew - addressBalanceOld), (accountBalanceOld.valueOf() - accountBalanceNew.valueOf()), 'Account ether balance was updated incorrectly');
+
+}
+
+// Deposits tokens to account and asserts balances updated correctly
+export async function scenarioDepositTokens({accountName, fromAddress, depositAmount}) {
+    const rocketVault = await RocketVault.deployed();
+    const rocketDepositToken = await RocketDepositToken.deployed();
+
+    // Get old vault & account balances
+    let vaultBalanceOld = await rocketDepositToken.balanceOf(rocketVault.address);
+    let accountBalanceOld = await rocketVault.getBalance(accountName);
+
+    // Allow deposit & deposit tokens
+    await rocketDepositToken.approve(rocketVault.address, depositAmount, {from: fromAddress});
+    await rocketVault.deposit(accountName, depositAmount, {from: fromAddress});
+
+    // Get new vault & account balances
+    let vaultBalanceNew = await rocketDepositToken.balanceOf(rocketVault.address);
+    let accountBalanceNew = await rocketVault.getBalance(accountName);
+
+    assert.notEqual(vaultBalanceOld, vaultBalanceNew, 'Vault token balance was not increased');
+    assert.notEqual(accountBalanceOld.valueOf(), accountBalanceNew.valueOf(), 'Account token balance was not increased');
+    assert.equal((vaultBalanceNew - vaultBalanceOld), (accountBalanceNew.valueOf() - accountBalanceOld.valueOf()), 'Account token balance was updated incorrectly');
 
 }
 

--- a/test/rocket-vault/rocket-vault-scenarios.js
+++ b/test/rocket-vault/rocket-vault-scenarios.js
@@ -85,6 +85,27 @@ export async function scenarioDepositEtherSuccessfully({accountName, fromAddress
 
 }
 
+// Withdraw ether successfully
+export async function scenarioWithdrawEtherSuccessfully({accountName, fromAddress, withdrawalAddress, withdrawalAmount}) {
+    const rocketVault = await RocketVault.deployed();
+
+    // Get old address & account balances
+    let addressBalanceOld = web3.eth.getBalance(withdrawalAddress).valueOf();
+    let accountBalanceOld = await rocketVault.getBalance(accountName);
+
+    // Withdraw ether
+    await rocketVault.withdraw(accountName, withdrawalAmount, withdrawalAddress, {from: fromAddress});
+
+    // Get new address & account balances
+    let addressBalanceNew = web3.eth.getBalance(withdrawalAddress).valueOf();
+    let accountBalanceNew = await rocketVault.getBalance(accountName);
+
+    assert.notEqual(addressBalanceOld, addressBalanceNew, 'Address ether balance was not increased');
+    assert.notEqual(accountBalanceOld.valueOf(), accountBalanceNew.valueOf(), 'Account ether balance was not decreased');
+    assert.equal((addressBalanceNew - addressBalanceOld), (accountBalanceOld.valueOf() - accountBalanceNew.valueOf()), 'Account ether balance was updated incorrectly');
+
+}
+
 /** ASSERTS */
 
 // Asserts that an account has been recorded correctly

--- a/test/rocket-vault/rocket-vault-scenarios.js
+++ b/test/rocket-vault/rocket-vault-scenarios.js
@@ -177,9 +177,31 @@ export async function scenarioDepositTokens({accountName, fromAddress, depositAm
     let vaultBalanceNew = await rocketDepositToken.balanceOf(rocketVault.address);
     let accountBalanceNew = await rocketVault.getBalance(accountName);
 
-    assert.notEqual(vaultBalanceOld, vaultBalanceNew, 'Vault token balance was not increased');
+    assert.notEqual(vaultBalanceOld.valueOf(), vaultBalanceNew.valueOf(), 'Vault token balance was not increased');
     assert.notEqual(accountBalanceOld.valueOf(), accountBalanceNew.valueOf(), 'Account token balance was not increased');
-    assert.equal((vaultBalanceNew - vaultBalanceOld), (accountBalanceNew.valueOf() - accountBalanceOld.valueOf()), 'Account token balance was updated incorrectly');
+    assert.equal((vaultBalanceNew.valueOf() - vaultBalanceOld.valueOf()), (accountBalanceNew.valueOf() - accountBalanceOld.valueOf()), 'Account token balance was updated incorrectly');
+
+}
+
+// Withdraws tokens from account to address and asserts balances updated correctly
+export async function scenarioWithdrawTokens({accountName, fromAddress, withdrawalAddress, withdrawalAmount}) {
+    const rocketVault = await RocketVault.deployed();
+    const rocketDepositToken = await RocketDepositToken.deployed();
+
+    // Get old address & account balances
+    let addressBalanceOld = await rocketDepositToken.balanceOf(withdrawalAddress);
+    let accountBalanceOld = await rocketVault.getBalance(accountName);
+
+    // Withdraw tokens
+    await rocketVault.withdraw(accountName, withdrawalAmount, withdrawalAddress, {from: fromAddress});
+
+    // Get new address & account balances
+    let addressBalanceNew = await rocketDepositToken.balanceOf(withdrawalAddress);
+    let accountBalanceNew = await rocketVault.getBalance(accountName);
+
+    assert.notEqual(addressBalanceOld.valueOf(), addressBalanceNew.valueOf(), 'Address token balance was not increased');
+    assert.notEqual(accountBalanceOld.valueOf(), accountBalanceNew.valueOf(), 'Account token balance was not decreased');
+    assert.equal((addressBalanceNew.valueOf() - addressBalanceOld.valueOf()), (accountBalanceOld.valueOf() - accountBalanceNew.valueOf()), 'Account token balance was updated incorrectly');
 
 }
 

--- a/test/rocketPool-tests.js
+++ b/test/rocketPool-tests.js
@@ -5,6 +5,7 @@ import { RocketUser, RocketNode, RocketPool, RocketPoolMini, RocketDepositToken,
 
 // Import modular tests
 import rocketVaultAdminTests from './rocket-vault/rocket-vault-admin-tests';
+import rocketVaultAccountTests from './rocket-vault/rocket-vault-account-tests';
 import rocketUpgradeTests from './rocket-upgrade/rocket-upgrade-tests';
 
 const displayEvents = false;
@@ -1281,6 +1282,8 @@ contract('RocketPool', accounts => {
       owner: owner,
       accounts: accounts
     });
+
+  rocketVaultAccountTests({owner, accounts});
 
   rocketUpgradeTests({owner, accounts});
 


### PR DESCRIPTION
Rocket Vault contract additions:
- Accounts indexed by bytes32 (for using hashes)
- Prevent ether balance from being sent with token deposit
- Use tokenContract.transferFrom to deposit tokens
- Method to check account balances
- Methods to check whether caller can deposit to / withdraw from an account
- Getters & setters for allowing addresses to deposit to / withdraw from accounts

Rocket Vault deposit & withdrawal unit tests