### PR TITLE
Rocket vault store

### DIFF
--- a/contracts/RocketVault.sol
+++ b/contracts/RocketVault.sol
@@ -82,7 +82,7 @@ contract RocketVault is RocketBase {
             // Capture the amount of ether sent
             deposit = msg.value;
             // Send ether to the store
-            vaultStore.depositEther.value(deposit)();
+            require(vaultStore.depositEther.value(deposit)() == true);
         } else {
             // Make sure ether balance is not sent with token deposit
             require(msg.value == 0);
@@ -135,7 +135,7 @@ contract RocketVault is RocketBase {
         // Are we transferring ether or tokens?
         if (rocketStorage.getAddress(keccak256("vault.account.token.address", _account)) == 0x0) {
             // Transfer the withdrawal amount to the sender
-            vaultStore.withdrawEther(_withdrawalAddress, _amount);
+            require(vaultStore.withdrawEther(_withdrawalAddress, _amount) == true);
         } else {
             // Transfer the tokens from our Vault contract account
             tokenContract = ERC20(rocketStorage.getAddress(keccak256("vault.account.token.address", _account)));

--- a/contracts/RocketVault.sol
+++ b/contracts/RocketVault.sol
@@ -24,6 +24,7 @@ contract RocketVault is RocketBase {
 
     ERC20 tokenContract = ERC20(0);                                             // The address of an ERC20 token contract
     RocketSettingsInterface rocketSettings = RocketSettingsInterface(0);        // The main settings contract most global parameters are maintained
+    RocketVaultStore vaultStore = RocketVaultStore(0);                          // The rocket vault store of ether & tokens
 
 
     /*** Events ****************/

--- a/contracts/RocketVault.sol
+++ b/contracts/RocketVault.sol
@@ -3,6 +3,7 @@ pragma solidity 0.4.19;
 
 import "./RocketBase.sol";
 import "./RocketStorage.sol";
+import "./RocketVaultStore.sol";
 import "./interface/ERC20.sol";
 import "./interface/RocketSettingsInterface.sol";
 import "./lib/SafeMath.sol";
@@ -10,8 +11,7 @@ import "./lib/SafeMath.sol";
 
 /// @title Ether/Tokens held by Rocket Pool are stored here in the vault for safe keeping
 /// @author David Rugendyke
- // TODO: Add in deposits/withdrawals for RPL tokens
- // TODO: Add in an upgrade method that will allow the balance and tokens to be transferred to a new RocketVault contract, but only if it matches the current 'contract.name' == RocketVault in storage
+/// TODO: Add in deposits/withdrawals for RPL tokens
 contract RocketVault is RocketBase {
 
 

--- a/contracts/RocketVault.sol
+++ b/contracts/RocketVault.sol
@@ -81,15 +81,15 @@ contract RocketVault is RocketBase {
         if (rocketStorage.getAddress(keccak256("vault.account.token.address", _account)) == 0x0) {
             // Capture the amount of ether sent
             deposit = msg.value;
-            // Send ether to the store
+            // Send the ether to the store
             require(vaultStore.depositEther.value(deposit)() == true);
         } else {
             // Make sure ether balance is not sent with token deposit
             require(msg.value == 0);
             // Transfer the tokens from the users account
             tokenContract = ERC20(rocketStorage.getAddress(keccak256("vault.account.token.address", _account)));
-            // Send them to Rocket Vault now
-            require(tokenContract.transferFrom(msg.sender, address(this), _amount) == true);
+            // Send them to the store now
+            require(tokenContract.transferFrom(msg.sender, vaultStore, _amount) == true);
             // Set the amount now
             deposit = _amount;
         }
@@ -134,13 +134,11 @@ contract RocketVault is RocketBase {
         rocketStorage.setUint(keccak256("vault.account.withdrawal.total", _account), withdrawalNumber + 1);
         // Are we transferring ether or tokens?
         if (rocketStorage.getAddress(keccak256("vault.account.token.address", _account)) == 0x0) {
-            // Transfer the withdrawal amount to the sender
+            // Transfer the withdrawal amount from the store to the sender
             require(vaultStore.withdrawEther(_withdrawalAddress, _amount) == true);
         } else {
-            // Transfer the tokens from our Vault contract account
-            tokenContract = ERC20(rocketStorage.getAddress(keccak256("vault.account.token.address", _account)));
-            // Send them from Rocket Vault now
-            require(tokenContract.transfer(_withdrawalAddress, _amount) == true);
+            // Transfer the tokens from the store to the sender
+            require(vaultStore.withdrawTokens(rocketStorage.getAddress(keccak256("vault.account.token.address", _account)), _withdrawalAddress, _amount) == true);
         }
         // Log it
         Withdrawal(msg.sender, _account, _amount, withdrawalNumber, now);

--- a/contracts/RocketVaultStore.sol
+++ b/contracts/RocketVaultStore.sol
@@ -11,8 +11,6 @@ contract RocketVaultStore is RocketBase {
 
 
     /**** Libs *****************/
-    
-    using SafeMath for uint;
 
 
     /*** Contracts *************/
@@ -48,7 +46,7 @@ contract RocketVaultStore is RocketBase {
     /// @dev Withdraw ether to address
     /// @param _withdrawalAddress The address to withdraw ether to
     /// @param _amount The amount of ether to withdraw
-    function withdrawEther(address _withdrawalAddress, uint256 amount) onlyLatestRocketVault external returns (bool) {
+    function withdrawEther(address _withdrawalAddress, uint256 _amount) onlyLatestRocketVault external returns (bool) {
         _withdrawalAddress.transfer(_amount);
         return true;
     }

--- a/contracts/RocketVaultStore.sol
+++ b/contracts/RocketVaultStore.sol
@@ -39,6 +39,19 @@ contract RocketVaultStore is RocketBase {
     /**** Methods **************/
 
 
+    /// @dev Deposit ether
+    function depositEther() payable onlyLatestRocketVault external returns (bool) {
+        return true;
+    }
+
+
+    /// @dev Withdraw ether to address
+    /// @param _withdrawalAddress The address to withdraw ether to
+    /// @param _amount The amount of ether to withdraw
+    function withdrawEther(address _withdrawalAddress, uint256 amount) onlyLatestRocketVault external returns (bool) {
+        _withdrawalAddress.transfer(_amount);
+        return true;
+    }
 
 
 }

--- a/contracts/RocketVaultStore.sol
+++ b/contracts/RocketVaultStore.sol
@@ -1,0 +1,44 @@
+pragma solidity 0.4.19;
+
+
+import "./RocketBase.sol";
+
+
+/// @title Ether/Tokens held in the RocketVault are stored here
+/// @author Jake Pospischil
+
+contract RocketVaultStore is RocketBase {
+
+
+    /**** Libs *****************/
+    
+    using SafeMath for uint;
+
+
+    /*** Contracts *************/
+
+
+    /*** Modifiers *************/
+
+    /// @dev Only allow access from the latest version of the RocketVault contract
+    modifier onlyLatestRocketVault() {
+        require(msg.sender == rocketStorage.getAddress(keccak256("contract.name", "rocketVault")));
+        _;
+    }
+
+
+    /*** Constructor ***********/
+
+    /// @dev RocketVaultStore constructor
+    function RocketVaultStore(address _rocketStorageAddress) RocketBase(_rocketStorageAddress) public {
+        // Set the version
+        version = 1;
+    }
+
+
+    /**** Methods **************/
+
+
+
+
+}

--- a/contracts/RocketVaultStore.sol
+++ b/contracts/RocketVaultStore.sol
@@ -2,6 +2,7 @@ pragma solidity 0.4.19;
 
 
 import "./RocketBase.sol";
+import "./interface/ERC20.sol";
 
 
 /// @title Ether/Tokens held in the RocketVault are stored here
@@ -10,10 +11,9 @@ import "./RocketBase.sol";
 contract RocketVaultStore is RocketBase {
 
 
-    /**** Libs *****************/
-
-
     /*** Contracts *************/
+
+    ERC20 tokenContract = ERC20(0);         // The address of an ERC20 token contract
 
 
     /*** Modifiers *************/
@@ -38,7 +38,7 @@ contract RocketVaultStore is RocketBase {
 
 
     /// @dev Deposit ether
-    function depositEther() payable onlyLatestRocketVault external returns (bool) {
+    function depositEther() payable external onlyLatestRocketVault returns (bool) {
         return true;
     }
 
@@ -46,9 +46,19 @@ contract RocketVaultStore is RocketBase {
     /// @dev Withdraw ether to address
     /// @param _withdrawalAddress The address to withdraw ether to
     /// @param _amount The amount of ether to withdraw
-    function withdrawEther(address _withdrawalAddress, uint256 _amount) onlyLatestRocketVault external returns (bool) {
+    function withdrawEther(address _withdrawalAddress, uint256 _amount) external onlyLatestRocketVault returns (bool) {
         _withdrawalAddress.transfer(_amount);
         return true;
+    }
+
+
+    /// @dev Withdraw tokens to address
+    /// @param _tokenAddress The address of the ERC20 token contract
+    /// @param _withdrawalAddress The address to withdraw tokens to
+    /// @param _amount The amount of tokens to withdraw
+    function withdrawTokens(address _tokenAddress, address _withdrawalAddress, uint256 _amount) external onlyLatestRocketVault returns (bool) {
+        tokenContract = ERC20(_tokenAddress);
+        return tokenContract.transfer(_withdrawalAddress, _amount);
     }
 
 

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -11,6 +11,7 @@ const rocketPoolMiniDelegate = artifacts.require('./RocketPoolMiniDelegate.sol')
 const rocketDepositToken = artifacts.require('./RocketDepositToken.sol');
 const rocketPartnerAPI = artifacts.require('./RocketPartnerAPI.sol');
 const rocketVault = artifacts.require('./RocketVault.sol');
+const rocketVaultStore = artifacts.require('./RocketVaultStore.sol');
 const rocketSettings = artifacts.require('./RocketSettings.sol');
 const rocketFactory = artifacts.require('./RocketFactory.sol');
 const rocketUpgrade = artifacts.require('./RocketUpgrade.sol');
@@ -38,6 +39,8 @@ module.exports = async (deployer, network) => {
         });
         // Deploy Rocket Vault
         return deployer.deploy(rocketVault, rocketStorage.address).then(() => {
+        // Deploy Rocket Vault Store
+        return deployer.deploy(rocketVaultStore, rocketStorage.address).then(() => {
           // Deploy Rocket Utils
           return deployer.deploy(rocketUtils, rocketStorage.address).then(() => {
             // Deploy Rocket Upgrade
@@ -238,6 +241,20 @@ module.exports = async (deployer, network) => {
                                   console.log(rocketVault.address);
                                   console.log('\n');
 
+                                  // Rocket Vault Store
+                                  await rocketStorageInstance.setAddress(
+                                    config.web3.utils.soliditySha3('contract.address', rocketVaultStore.address),
+                                    rocketVaultStore.address
+                                  );
+                                  await rocketStorageInstance.setAddress(
+                                    config.web3.utils.soliditySha3('contract.name', 'rocketVaultStore'),
+                                    rocketVaultStore.address
+                                  );
+                                  // Log it
+                                  console.log('\x1b[33m%s\x1b[0m:', 'Set Storage rocketVaultStore Address');
+                                  console.log(rocketVaultStore.address);
+                                  console.log('\n');
+
                                   // Rocket Settings
                                   await rocketStorageInstance.setAddress(
                                     config.web3.utils.soliditySha3('contract.address', rocketSettings.address),
@@ -281,6 +298,7 @@ module.exports = async (deployer, network) => {
               });
             });
           });
+        });
         });
       });
     });

--- a/test/artifacts.js
+++ b/test/artifacts.js
@@ -5,6 +5,7 @@ export const RocketPoolMini = artifacts.require('./contract/RocketPoolMini');
 export const RocketDepositToken = artifacts.require('./contract/RocketDepositToken');
 export const RocketPartnerAPI = artifacts.require('./contract/RocketPartnerAPI');
 export const RocketVault = artifacts.require('./contract/RocketVault');
+export const RocketVaultStore = artifacts.require('./contract/RocketVaultStore');
 export const RocketRole = artifacts.require('./contract/RocketRole');
 export const RocketSettings = artifacts.require('./contract/RocketSettings');
 export const RocketStorage = artifacts.require('./contract/RocketStorage');

--- a/test/rocket-vault/rocket-vault-account-tests.js
+++ b/test/rocket-vault/rocket-vault-account-tests.js
@@ -1,5 +1,5 @@
 import { printTitle, assertThrows, soliditySha3 } from '../utils';
-import { RocketVault, RocketDepositToken, RocketSettings, RocketRole } from '../artifacts';
+import { RocketVault, RocketVaultStore, RocketDepositToken, RocketSettings, RocketRole } from '../artifacts';
 import { scenarioAddAccount, scenarioAllowDeposits, scenarioAllowWithdrawals, scenarioDepositEther, scenarioWithdrawEther, scenarioDepositTokens, scenarioWithdrawTokens } from './rocket-vault-scenarios';
 
 export default function({owner, accounts}) {
@@ -9,11 +9,13 @@ export default function({owner, accounts}) {
 
         // Contract dependencies
         let rocketVault;
+        let rocketVaultStore;
         let rocketDepositToken;
         let rocketSettings;
         let rocketRole;
         before(async () => {
             rocketVault = await RocketVault.deployed();
+            rocketVaultStore = await RocketVaultStore.deployed();
             rocketDepositToken = await RocketDepositToken.deployed();
             rocketSettings = await RocketSettings.deployed();
             rocketRole = await RocketRole.deployed();
@@ -503,6 +505,31 @@ export default function({owner, accounts}) {
                 fromAddress: accountOwner,
             });
 
+        });
+
+
+        // Random address cannot deposit ether directly to store
+        it(printTitle('random address', 'cannot deposit ether to rocket vault store'), async () => {
+            await assertThrows(rocketVaultStore.depositEther({
+                from: owner,
+                value: web3.toWei('1', 'ether'),
+            }), 'random address deposited ether directly to rocket vault store');
+        });
+
+
+        // Random address cannot withdraw ether directly from store
+        it(printTitle('random address', 'cannot withdraw ether from rocket vault store'), async () => {
+            await assertThrows(rocketVaultStore.withdrawEther(accounts[1], web3.toWei('1', 'ether'), {
+                from: owner,
+            }), 'random address withdrew ether directly from rocket vault store');
+        });
+
+
+        // Random address cannot withdraw tokens directly from store
+        it(printTitle('random address', 'cannot withdraw tokens from rocket vault store'), async () => {
+            await assertThrows(rocketVaultStore.withdrawTokens(rocketDepositToken.address, accounts[1], web3.toWei('0.1', 'ether'), {
+                from: owner,
+            }), 'random address withdrew tokens directly from rocket vault store');
         });
 
 

--- a/test/rocket-vault/rocket-vault-scenarios.js
+++ b/test/rocket-vault/rocket-vault-scenarios.js
@@ -123,14 +123,14 @@ export async function scenarioDepositEther({accountName, fromAddress, depositAmo
     const rocketVault = await RocketVault.deployed();
     const rocketVaultStore = await RocketVaultStore.deployed();
 
-    // Get old vault & account balances
+    // Get old vault store & account balances
     let vaultBalanceOld = web3.eth.getBalance(rocketVaultStore.address).valueOf();
     let accountBalanceOld = await rocketVault.getBalance(accountName);
 
     // Deposit ether
     await rocketVault.deposit(accountName, 0, {from: fromAddress, value: depositAmount});
 
-    // Get new vault & account balances
+    // Get new vault store & account balances
     let vaultBalanceNew = web3.eth.getBalance(rocketVaultStore.address).valueOf();
     let accountBalanceNew = await rocketVault.getBalance(accountName);
 
@@ -164,18 +164,19 @@ export async function scenarioWithdrawEther({accountName, fromAddress, withdrawa
 // Deposits tokens to account and asserts balances updated correctly
 export async function scenarioDepositTokens({accountName, fromAddress, depositAmount, etherBalance = 0}) {
     const rocketVault = await RocketVault.deployed();
+    const rocketVaultStore = await RocketVaultStore.deployed();
     const rocketDepositToken = await RocketDepositToken.deployed();
 
-    // Get old vault & account balances
-    let vaultBalanceOld = await rocketDepositToken.balanceOf(rocketVault.address);
+    // Get old vault store & account balances
+    let vaultBalanceOld = await rocketDepositToken.balanceOf(rocketVaultStore.address);
     let accountBalanceOld = await rocketVault.getBalance(accountName);
 
     // Allow deposit & deposit tokens
     await rocketDepositToken.approve(rocketVault.address, depositAmount, {from: fromAddress});
     await rocketVault.deposit(accountName, depositAmount, {from: fromAddress, value: etherBalance});
 
-    // Get new vault & account balances
-    let vaultBalanceNew = await rocketDepositToken.balanceOf(rocketVault.address);
+    // Get new vault store & account balances
+    let vaultBalanceNew = await rocketDepositToken.balanceOf(rocketVaultStore.address);
     let accountBalanceNew = await rocketVault.getBalance(accountName);
 
     assert.notEqual(vaultBalanceOld.valueOf(), vaultBalanceNew.valueOf(), 'Vault token balance was not increased');

--- a/test/rocket-vault/rocket-vault-scenarios.js
+++ b/test/rocket-vault/rocket-vault-scenarios.js
@@ -1,5 +1,5 @@
 import { assertThrows, soliditySha3 } from '../utils';
-import { RocketStorage, RocketVault, RocketDepositToken } from "../artifacts";
+import { RocketStorage, RocketVault, RocketVaultStore, RocketDepositToken } from "../artifacts";
 
 /** SCENARIOS */
 
@@ -121,16 +121,17 @@ export async function scenarioAllowWithdrawals({accountName, withdrawalAddress, 
 // Deposits ether to account and asserts balances updated correctly
 export async function scenarioDepositEther({accountName, fromAddress, depositAmount}) {
     const rocketVault = await RocketVault.deployed();
+    const rocketVaultStore = await RocketVaultStore.deployed();
 
     // Get old vault & account balances
-    let vaultBalanceOld = web3.eth.getBalance(rocketVault.address).valueOf();
+    let vaultBalanceOld = web3.eth.getBalance(rocketVaultStore.address).valueOf();
     let accountBalanceOld = await rocketVault.getBalance(accountName);
 
     // Deposit ether
     await rocketVault.deposit(accountName, 0, {from: fromAddress, value: depositAmount});
 
     // Get new vault & account balances
-    let vaultBalanceNew = web3.eth.getBalance(rocketVault.address).valueOf();
+    let vaultBalanceNew = web3.eth.getBalance(rocketVaultStore.address).valueOf();
     let accountBalanceNew = await rocketVault.getBalance(accountName);
 
     assert.notEqual(vaultBalanceOld, vaultBalanceNew, 'Vault ether balance was not increased');


### PR DESCRIPTION
- Added Rocket Vault Store for ether and tokens
- Rocket Vault stores all ether and tokens in the store contract; no need to transfer funds on upgrade
- Added tests to check that direct access to store methods is not possible