### PR TITLE
Unit test refactoring

### DIFF
--- a/contracts/RocketPoolMiniDelegate.sol
+++ b/contracts/RocketPoolMiniDelegate.sol
@@ -378,10 +378,10 @@ contract RocketPoolMiniDelegate is RocketBase {
             // Remove the user from the pool now they dont have a balance
             removeUser(userAddress);
         }
-        // Update the status of the pool
-        updateStatus();
         // Send withdrawal amount to user's address
         userAddress.transfer(withdrawAmount);
+        // Update the status of the pool
+        updateStatus();
         // Fire the event for the withdrawal
         emit PoolTransfer(this, userAddress, keccak256("withdrawal"), withdrawAmount, users[userAddress].balance, now);
         // Success

--- a/test/rocket-node/rocket-node-validator/rocket-node-validator-scenarios.js
+++ b/test/rocket-node/rocket-node-validator/rocket-node-validator-scenarios.js
@@ -1,5 +1,5 @@
 const os = require('os');
-import { RocketNodeValidator, Casper } from '../../artifacts';
+import { RocketNodeValidator, Casper, RocketPoolMini } from '../../artifacts';
 import { scenarioIncrementEpoch, scenarioIncrementDynasty } from '../../casper/casper-scenarios';
 import { scenarioNodeCheckin } from '../rocket-node-status/rocket-node-status-scenarios';
 
@@ -31,6 +31,11 @@ export async function scenarioNodeLogout({nodeAddress, minipoolAddress, logoutMe
 
     let log = result.logs.find(({ event }) => event == 'NodeLogout');
     assert.isDefined(log, 'NodeLogout event was not logged');
+
+    // Check minipool status
+    let miniPool = RocketPoolMini.at(minipoolAddress);
+    let miniPoolStatus = await miniPool.getStatus.call();
+    assert.equal(miniPoolStatus.valueOf(), 3, 'Invalid minipool status');
 
     // check parameters were correct
     let recordedMinipool = log.args.minipool_address;

--- a/test/rocket-user/rocket-user-tests.js
+++ b/test/rocket-user/rocket-user-tests.js
@@ -107,6 +107,32 @@ export default function({owner}) {
             });
 
 
+            // Second user withdraws initial deposit, to trigger the pool to revert to accepting deposits
+            it(printTitle('userSecond', 'withdraws ether from minipool, first minipool status changes to accepting deposits'), async () => {
+
+                // Get the amount of ether to withdraw - enough to revert the minipool to accepting deposits
+                let withdrawAmount = parseInt(web3.toWei('4.5', 'ether').valueOf());
+
+                // Withdraw ether
+                await scenarioWithdrawDeposit({
+                    miniPool: miniPools.first,
+                    withdrawalAmount: withdrawAmount,
+                    fromAddress: userSecond,
+                    feeAccountAddress: owner,
+                    gas: rocketWithdrawalGas,
+                });
+
+                // Re-deposit ether
+                await scenarioDeposit({
+                    stakingTimeID: 'short',
+                    fromAddress: userSecond,
+                    depositAmount: withdrawAmount,
+                    gas: rocketDepositGas,
+                });
+
+            });
+
+
             // Have a new user send a deposit to create a second minipool and trigger it to go into countdown
             it(printTitle('userThird', 'sends a lot of ether to RP, creates second minipool, registers user with pool and sets status of minipool to countdown'), async () => {
 


### PR DESCRIPTION
- Update minipool status *after* transferring funds to user on withdrawal
- Check minipool reverts from "pre-launch countdown" to "accepting deposits" when ether is withdrawn and balance goes below staking threshold
- Check minipool status is "logged out" after logging out from Casper