### PR TITLE
change input argument size in delegation call and remove useless code

### DIFF
--- a/contracts/RocketPoolMini.sol
+++ b/contracts/RocketPoolMini.sol
@@ -147,9 +147,8 @@ contract RocketPoolMini is RocketBase {
             let returnSize := 32
             let mem := mload(0x40)
             mstore(mem, _signature)
-            let err := delegatecall(sub(gas, 10000), minipoolDelegateAddress, mem, 0x44, mem, returnSize)
+            let err := delegatecall(sub(gas, 10000), minipoolDelegateAddress, mem, 0x04, mem, returnSize)
             response := mload(mem)
-            mstore(0x40, add(mem,0x44))
         }
         return response; 
     }


### PR DESCRIPTION
It only need 4 bytes for function signature because no other input arguments. And the data in memory stores into response after delegationcall is called, so there is no need to change free pointer.