### PR TITLE
Track active minipool count towards limit

### DIFF
--- a/contracts/RocketPool.sol
+++ b/contracts/RocketPool.sol
@@ -440,7 +440,9 @@ contract RocketPool is RocketBase {
         pool.logout(_logoutMessage);
         // Decrement active minipool count
         uint256 minipoolActiveCountTotal = getActivePoolsCount();
-        rocketStorage.setUint(keccak256("minipools.active.total"), minipoolActiveCountTotal - 1);
+        if (minipoolActiveCountTotal > 0) {
+            rocketStorage.setUint(keccak256("minipools.active.total"), minipoolActiveCountTotal - 1);
+        }
         // Done
         return true;
     }

--- a/contracts/RocketPool.sol
+++ b/contracts/RocketPool.sol
@@ -239,6 +239,11 @@ contract RocketPool is RocketBase {
         return rocketStorage.getUint(keccak256("minipools.total"));
     }
 
+    /// @dev Returns a count of the current active minipools (accepting deposits, in countdown or staking)
+    function getActivePoolsCount() view public returns(uint256) {
+        return rocketStorage.getUint(keccak256("minipools.active.total"));
+    }
+
     /// @dev Get all pools that match this status (explicit method)
     /// @param _status Get pools with the current status
     function getPoolsFilterWithStatus(uint256 _status) public view returns(address[] memory) {
@@ -351,12 +356,14 @@ contract RocketPool is RocketBase {
         require(!getPoolExists(newPoolAddress));
         // Get how many minipools we currently have  
         uint256 minipoolCountTotal = getPoolsCount(); 
+        uint256 minipoolActiveCountTotal = getActivePoolsCount();
         // Ok now set our data to key/value pair storage
         rocketStorage.setBool(keccak256("minipool.exists", newPoolAddress), true);
         // We store our data in an key/value array, so set its index so we can use an array to find it if needed
         rocketStorage.setUint(keccak256("minipool.index", newPoolAddress), minipoolCountTotal);
         // Update total minipools
         rocketStorage.setUint(keccak256("minipools.total"), minipoolCountTotal + 1);
+        rocketStorage.setUint(keccak256("minipools.active.total"), minipoolActiveCountTotal + 1);
         // We also index all our data so we can do a reverse lookup based on its array index
         rocketStorage.setAddress(keccak256("minipools.index.reverse", minipoolCountTotal), newPoolAddress);
         // Fire the event
@@ -431,6 +438,9 @@ contract RocketPool is RocketBase {
         require(pool.getNodeAddress() == _nodeAddress);
         // Ask the minipool send logout to Casper
         pool.logout(_logoutMessage);
+        // Decrement active minipool count
+        uint256 minipoolActiveCountTotal = getActivePoolsCount();
+        rocketStorage.setUint(keccak256("minipools.active.total"), minipoolActiveCountTotal - 1);
         // Done
         return true;
     }

--- a/contracts/RocketSettings.sol
+++ b/contracts/RocketSettings.sol
@@ -2,6 +2,7 @@ pragma solidity 0.4.23;
 
 
 import "./RocketBase.sol";
+import "./interface/RocketPoolInterface.sol";
 import "./interface/RocketStorageInterface.sol";
 
 
@@ -138,8 +139,10 @@ contract RocketSettings is RocketBase {
     
     /// @dev Check to see if new pools are allowed to be created
     function getMiniPoolAllowedToBeCreated() public view returns (bool) { 
+        // Get the main Rocket Pool contract
+        RocketPoolInterface rocketPool = RocketPoolInterface(rocketStorage.getAddress(keccak256("contract.name", "rocketPool")));
         // New pools allowed to be created?
-        if (!getMiniPoolNewEnabled() || rocketStorage.getUint(keccak256("minipools.active.total")) >= getMiniPoolMax()) {
+        if (!getMiniPoolNewEnabled() || rocketPool.getActivePoolsCount() >= getMiniPoolMax()) {
             return false;
         }
         return true;

--- a/contracts/RocketSettings.sol
+++ b/contracts/RocketSettings.sol
@@ -139,7 +139,7 @@ contract RocketSettings is RocketBase {
     /// @dev Check to see if new pools are allowed to be created
     function getMiniPoolAllowedToBeCreated() public view returns (bool) { 
         // New pools allowed to be created?
-        if (!getMiniPoolNewEnabled() || rocketStorage.getUint(keccak256("minipools.total")) >= getMiniPoolMax()) {
+        if (!getMiniPoolNewEnabled() || rocketStorage.getUint(keccak256("minipools.active.total")) >= getMiniPoolMax()) {
             return false;
         }
         return true;

--- a/contracts/interface/RocketPoolInterface.sol
+++ b/contracts/interface/RocketPoolInterface.sol
@@ -2,6 +2,8 @@ pragma solidity 0.4.23;
 
 
 contract RocketPoolInterface {
+    /// @dev Returns a count of the current active minipools (accepting deposits, in countdown or staking)
+    function getActivePoolsCount() view public returns(uint256);
     /// @dev Returns a count of the current minipools attached to this node address
     /// @param _nodeAddress Address of the node
     function getPoolsFilterWithNodeCount(address _nodeAddress) view public returns(uint256);


### PR DESCRIPTION
- Tracking active minipool (accepting deposits / in countdown / staking) count
- Count is incremented on creation and decremented on logout
- Minipool creation allowed check updated to use active minipool count