### PR TITLE
handle negative rewards to minipools

### DIFF
--- a/contracts/RocketUser.sol
+++ b/contracts/RocketUser.sol
@@ -251,7 +251,7 @@ contract RocketUser is RocketBase {
          // Calculate how much the user deposit has changed based on their original % deposited and the new post Casper balance of the pool
         uint256 userDepositAmountUpdated = rocketPoolMiniI.getStakingBalanceReceived().mul(userBalance) / rocketPoolMiniI.getStakingBalance();
         // Calculate how much rewards the user earned
-        userRewardsAmount = int256(userDepositAmountUpdated.sub(userBalance));
+        userRewardsAmount = int256(userDepositAmountUpdated) - int256(userBalance);
         // So only process fees if we've received rewards from Casper
         if (userRewardsAmount > 0) {
             // Calculate the fee we take from the rewards now to cover node server costs etc

--- a/test/rocket-user/rocket-user-scenarios.js
+++ b/test/rocket-user/rocket-user-scenarios.js
@@ -137,7 +137,7 @@ export async function scenarioRegisterWithdrawalAddress({withdrawalAddress, mini
 
 
 // Withdraws staking deposit and asserts that deposit was withdrawn successfully
-export async function scenarioWithdrawDeposit({miniPool, withdrawalAmount, fromAddress, depositFromAddress = null, feeAccountAddress, gas, expectPoolClosed=false}) {
+export async function scenarioWithdrawDeposit({miniPool, withdrawalAmount, fromAddress, depositFromAddress = null, feeAccountAddress, gas, expectPoolClosed=false, expectPositiveRewards=true}) {
     const rocketUser = await RocketUser.deployed();
     const rocketPool = await RocketPool.deployed();
     const rocketSettings = await RocketSettings.deployed();
@@ -193,7 +193,7 @@ export async function scenarioWithdrawDeposit({miniPool, withdrawalAmount, fromA
         }
 
         // Asserts
-        if (miniPoolStatusOld.valueOf() == 4) {
+        if (expectPositiveRewards && miniPoolStatusOld.valueOf() == 4) {
             assert.isTrue(withdrawnAmount.valueOf() > depositAmountOld.valueOf(), 'Amount withdrawn was not more than initial deposit amount');
             assert.isTrue(feeAccountBalanceNew.gt(feeAccountBalanceOld), 'Fee account balance did not increase');
         }

--- a/test/rocket-user/rocket-user-tests.js
+++ b/test/rocket-user/rocket-user-tests.js
@@ -394,6 +394,9 @@ export default function({owner}) {
                 await casperEpochInitialise(owner);
                 await casperEpochIncrementAmount(owner, 2);
 
+                // Mine some more epochs to simulate vote failure and negative rewards
+                await casperEpochIncrementAmount(owner, 10);
+
                 await scenarioNodeLogoutForWithdrawal({
                     owner: owner,
                     validators: [
@@ -526,6 +529,7 @@ export default function({owner}) {
                     fromAddress: userFirst,
                     feeAccountAddress: owner,
                     gas: rocketWithdrawalGas,
+                    expectPositiveRewards: false,
                 });
             });
 


### PR DESCRIPTION
- correctly handle negative rewards to minipools in RocketUser contract
- updated unit tests to include negative rewards