### PR TITLE
Rocket two list storage

### DIFF
--- a/contracts/contract/utils/lists/AddressSetStorage.sol
+++ b/contracts/contract/utils/lists/AddressSetStorage.sol
@@ -64,6 +64,7 @@ contract AddressSetStorage is RocketBase {
             rocketStorage.setAddress(keccak256(abi.encodePacked(_key, "item", index)), lastItem);
             rocketStorage.setUint(keccak256(abi.encodePacked(_key, "index", lastItem)), index + 1);
         }
+        rocketStorage.setUint(keccak256(abi.encodePacked(_key, "index", _value)), 0);
         rocketStorage.setUint(keccak256(abi.encodePacked(_key, "count")), count - 1);
     }
 

--- a/contracts/contract/utils/lists/AddressSetStorage.sol
+++ b/contracts/contract/utils/lists/AddressSetStorage.sol
@@ -1,0 +1,71 @@
+pragma solidity 0.4.24;
+
+
+import "../../../RocketBase.sol";
+
+
+/// @title Address set storage helper for RocketStorage data (contains unique items; has reverse index lookups)
+/// @author Jake Pospischil
+contract AddressSetStorage is RocketBase {
+
+
+    /// @dev Only allow access from the latest version of a contract in the Rocket Pool network after deployment
+    modifier onlyLatestRocketNetworkContract() {
+        require(rocketStorage.getAddress(keccak256(abi.encodePacked("contract.address", msg.sender))) != 0x0, "Calls permitted from latest Rocket Pool network contracts only");
+        _;
+    }
+
+
+    /// @dev RocketSetStorage constructor
+    constructor(address _rocketStorageAddress) RocketBase(_rocketStorageAddress) public {
+        version = 1;
+    }
+
+
+    /// @dev The number of items in a set
+    function getCount(bytes32 _key) external view returns (uint) {
+        return rocketStorage.getUint(keccak256(abi.encodePacked(_key, "count")));
+    }
+
+
+    /// @dev The item in a set by index
+    function getItem(bytes32 _key, uint _index) external view returns (address) {
+        return rocketStorage.getAddress(keccak256(abi.encodePacked(_key, "item", _index)));
+    }
+
+
+    /// @dev The index of an item in a set
+    /// @dev Returns -1 if the value is not found
+    function getIndexOf(bytes32 _key, address _value) external view returns (int) {
+        return int(rocketStorage.getUint(keccak256(abi.encodePacked(_key, "index", _value)))) - 1;
+    }
+
+
+    /// @dev Add an item to a set
+    /// @dev Requires that the item does not exist in the set
+    function addItem(bytes32 _key, address _value) onlyLatestRocketNetworkContract external {
+        require(rocketStorage.getUint(keccak256(abi.encodePacked(_key, "index", _value))) == 0, "Item already exists in set");
+        uint count = rocketStorage.getUint(keccak256(abi.encodePacked(_key, "count")));
+        rocketStorage.setAddress(keccak256(abi.encodePacked(_key, "item", count)), _value);
+        rocketStorage.setUint(keccak256(abi.encodePacked(_key, "index", _value)), count + 1);
+        rocketStorage.setUint(keccak256(abi.encodePacked(_key, "count")), count + 1);
+    }
+
+
+    /// @dev Remove an item from a set
+    /// @dev Swaps the item with the last item in the set and truncates it; computationally cheap
+    /// @dev Requires that the item exists in the set
+    function removeItem(bytes32 _key, address _value) onlyLatestRocketNetworkContract external {
+        uint256 index = rocketStorage.getUint(keccak256(abi.encodePacked(_key, "index", _value)));
+        require(index-- > 0, "Item does not exist in set");
+        uint count = rocketStorage.getUint(keccak256(abi.encodePacked(_key, "count")));
+        if (index < count - 1) {
+            address lastItem = rocketStorage.getAddress(keccak256(abi.encodePacked(_key, "item", count - 1)));
+            rocketStorage.setAddress(keccak256(abi.encodePacked(_key, "item", index)), lastItem);
+            rocketStorage.setUint(keccak256(abi.encodePacked(_key, "index", lastItem)), index + 1);
+        }
+        rocketStorage.setUint(keccak256(abi.encodePacked(_key, "count")), count - 1);
+    }
+
+
+}

--- a/contracts/contract/utils/lists/BoolSetStorage.sol
+++ b/contracts/contract/utils/lists/BoolSetStorage.sol
@@ -1,0 +1,72 @@
+pragma solidity 0.4.24;
+
+
+import "../../../RocketBase.sol";
+
+
+/// @title Bool set storage helper for RocketStorage data (contains unique items; has reverse index lookups)
+/// @author Jake Pospischil
+contract BoolSetStorage is RocketBase {
+
+
+    /// @dev Only allow access from the latest version of a contract in the Rocket Pool network after deployment
+    modifier onlyLatestRocketNetworkContract() {
+        require(rocketStorage.getAddress(keccak256(abi.encodePacked("contract.address", msg.sender))) != 0x0, "Calls permitted from latest Rocket Pool network contracts only");
+        _;
+    }
+
+
+    /// @dev RocketSetStorage constructor
+    constructor(address _rocketStorageAddress) RocketBase(_rocketStorageAddress) public {
+        version = 1;
+    }
+
+
+    /// @dev The number of items in a set
+    function getCount(bytes32 _key) external view returns (uint) {
+        return rocketStorage.getUint(keccak256(abi.encodePacked(_key, "count")));
+    }
+
+
+    /// @dev The item in a set by index
+    function getItem(bytes32 _key, uint _index) external view returns (bool) {
+        return rocketStorage.getBool(keccak256(abi.encodePacked(_key, "item", _index)));
+    }
+
+
+    /// @dev The index of an item in a set
+    /// @dev Returns -1 if the value is not found
+    function getIndexOf(bytes32 _key, bool _value) external view returns (int) {
+        return int(rocketStorage.getUint(keccak256(abi.encodePacked(_key, "index", _value)))) - 1;
+    }
+
+
+    /// @dev Add an item to a set
+    /// @dev Requires that the item does not exist in the set
+    function addItem(bytes32 _key, bool _value) onlyLatestRocketNetworkContract external {
+        require(rocketStorage.getUint(keccak256(abi.encodePacked(_key, "index", _value))) == 0, "Item already exists in set");
+        uint count = rocketStorage.getUint(keccak256(abi.encodePacked(_key, "count")));
+        rocketStorage.setBool(keccak256(abi.encodePacked(_key, "item", count)), _value);
+        rocketStorage.setUint(keccak256(abi.encodePacked(_key, "index", _value)), count + 1);
+        rocketStorage.setUint(keccak256(abi.encodePacked(_key, "count")), count + 1);
+    }
+
+
+    /// @dev Remove an item from a set
+    /// @dev Swaps the item with the last item in the set and truncates it; computationally cheap
+    /// @dev Requires that the item exists in the set
+    function removeItem(bytes32 _key, bool _value) onlyLatestRocketNetworkContract external {
+        uint256 index = rocketStorage.getUint(keccak256(abi.encodePacked(_key, "index", _value)));
+        require(index-- > 0, "Item does not exist in set");
+        uint count = rocketStorage.getUint(keccak256(abi.encodePacked(_key, "count")));
+        if (index < count - 1) {
+            bool lastItem = rocketStorage.getBool(keccak256(abi.encodePacked(_key, "item", count - 1)));
+            rocketStorage.setBool(keccak256(abi.encodePacked(_key, "item", index)), lastItem);
+            rocketStorage.setUint(keccak256(abi.encodePacked(_key, "index", lastItem)), index + 1);
+        }
+        rocketStorage.setUint(keccak256(abi.encodePacked(_key, "index", _value)), 0);
+        rocketStorage.setUint(keccak256(abi.encodePacked(_key, "count")), count - 1);
+    }
+
+
+}

--- a/contracts/contract/utils/lists/Bytes32SetStorage.sol
+++ b/contracts/contract/utils/lists/Bytes32SetStorage.sol
@@ -1,0 +1,72 @@
+pragma solidity 0.4.24;
+
+
+import "../../../RocketBase.sol";
+
+
+/// @title Bytes32 set storage helper for RocketStorage data (contains unique items; has reverse index lookups)
+/// @author Jake Pospischil
+contract Bytes32SetStorage is RocketBase {
+
+
+    /// @dev Only allow access from the latest version of a contract in the Rocket Pool network after deployment
+    modifier onlyLatestRocketNetworkContract() {
+        require(rocketStorage.getAddress(keccak256(abi.encodePacked("contract.address", msg.sender))) != 0x0, "Calls permitted from latest Rocket Pool network contracts only");
+        _;
+    }
+
+
+    /// @dev RocketSetStorage constructor
+    constructor(address _rocketStorageAddress) RocketBase(_rocketStorageAddress) public {
+        version = 1;
+    }
+
+
+    /// @dev The number of items in a set
+    function getCount(bytes32 _key) external view returns (uint) {
+        return rocketStorage.getUint(keccak256(abi.encodePacked(_key, "count")));
+    }
+
+
+    /// @dev The item in a set by index
+    function getItem(bytes32 _key, uint _index) external view returns (bytes32) {
+        return rocketStorage.getBytes32(keccak256(abi.encodePacked(_key, "item", _index)));
+    }
+
+
+    /// @dev The index of an item in a set
+    /// @dev Returns -1 if the value is not found
+    function getIndexOf(bytes32 _key, bytes32 _value) external view returns (int) {
+        return int(rocketStorage.getUint(keccak256(abi.encodePacked(_key, "index", _value)))) - 1;
+    }
+
+
+    /// @dev Add an item to a set
+    /// @dev Requires that the item does not exist in the set
+    function addItem(bytes32 _key, bytes32 _value) onlyLatestRocketNetworkContract external {
+        require(rocketStorage.getUint(keccak256(abi.encodePacked(_key, "index", _value))) == 0, "Item already exists in set");
+        uint count = rocketStorage.getUint(keccak256(abi.encodePacked(_key, "count")));
+        rocketStorage.setBytes32(keccak256(abi.encodePacked(_key, "item", count)), _value);
+        rocketStorage.setUint(keccak256(abi.encodePacked(_key, "index", _value)), count + 1);
+        rocketStorage.setUint(keccak256(abi.encodePacked(_key, "count")), count + 1);
+    }
+
+
+    /// @dev Remove an item from a set
+    /// @dev Swaps the item with the last item in the set and truncates it; computationally cheap
+    /// @dev Requires that the item exists in the set
+    function removeItem(bytes32 _key, bytes32 _value) onlyLatestRocketNetworkContract external {
+        uint256 index = rocketStorage.getUint(keccak256(abi.encodePacked(_key, "index", _value)));
+        require(index-- > 0, "Item does not exist in set");
+        uint count = rocketStorage.getUint(keccak256(abi.encodePacked(_key, "count")));
+        if (index < count - 1) {
+            bytes32 lastItem = rocketStorage.getBytes32(keccak256(abi.encodePacked(_key, "item", count - 1)));
+            rocketStorage.setBytes32(keccak256(abi.encodePacked(_key, "item", index)), lastItem);
+            rocketStorage.setUint(keccak256(abi.encodePacked(_key, "index", lastItem)), index + 1);
+        }
+        rocketStorage.setUint(keccak256(abi.encodePacked(_key, "index", _value)), 0);
+        rocketStorage.setUint(keccak256(abi.encodePacked(_key, "count")), count - 1);
+    }
+
+
+}

--- a/contracts/contract/utils/lists/BytesSetStorage.sol
+++ b/contracts/contract/utils/lists/BytesSetStorage.sol
@@ -1,0 +1,72 @@
+pragma solidity 0.4.24;
+
+
+import "../../../RocketBase.sol";
+
+
+/// @title Bytes set storage helper for RocketStorage data (contains unique items; has reverse index lookups)
+/// @author Jake Pospischil
+contract BytesSetStorage is RocketBase {
+
+
+    /// @dev Only allow access from the latest version of a contract in the Rocket Pool network after deployment
+    modifier onlyLatestRocketNetworkContract() {
+        require(rocketStorage.getAddress(keccak256(abi.encodePacked("contract.address", msg.sender))) != 0x0, "Calls permitted from latest Rocket Pool network contracts only");
+        _;
+    }
+
+
+    /// @dev RocketSetStorage constructor
+    constructor(address _rocketStorageAddress) RocketBase(_rocketStorageAddress) public {
+        version = 1;
+    }
+
+
+    /// @dev The number of items in a set
+    function getCount(bytes32 _key) external view returns (uint) {
+        return rocketStorage.getUint(keccak256(abi.encodePacked(_key, "count")));
+    }
+
+
+    /// @dev The item in a set by index
+    function getItem(bytes32 _key, uint _index) external view returns (bytes) {
+        return rocketStorage.getBytes(keccak256(abi.encodePacked(_key, "item", _index)));
+    }
+
+
+    /// @dev The index of an item in a set
+    /// @dev Returns -1 if the value is not found
+    function getIndexOf(bytes32 _key, bytes _value) external view returns (int) {
+        return int(rocketStorage.getUint(keccak256(abi.encodePacked(_key, "index", _value)))) - 1;
+    }
+
+
+    /// @dev Add an item to a set
+    /// @dev Requires that the item does not exist in the set
+    function addItem(bytes32 _key, bytes _value) onlyLatestRocketNetworkContract external {
+        require(rocketStorage.getUint(keccak256(abi.encodePacked(_key, "index", _value))) == 0, "Item already exists in set");
+        uint count = rocketStorage.getUint(keccak256(abi.encodePacked(_key, "count")));
+        rocketStorage.setBytes(keccak256(abi.encodePacked(_key, "item", count)), _value);
+        rocketStorage.setUint(keccak256(abi.encodePacked(_key, "index", _value)), count + 1);
+        rocketStorage.setUint(keccak256(abi.encodePacked(_key, "count")), count + 1);
+    }
+
+
+    /// @dev Remove an item from a set
+    /// @dev Swaps the item with the last item in the set and truncates it; computationally cheap
+    /// @dev Requires that the item exists in the set
+    function removeItem(bytes32 _key, bytes _value) onlyLatestRocketNetworkContract external {
+        uint256 index = rocketStorage.getUint(keccak256(abi.encodePacked(_key, "index", _value)));
+        require(index-- > 0, "Item does not exist in set");
+        uint count = rocketStorage.getUint(keccak256(abi.encodePacked(_key, "count")));
+        if (index < count - 1) {
+            bytes memory lastItem = rocketStorage.getBytes(keccak256(abi.encodePacked(_key, "item", count - 1)));
+            rocketStorage.setBytes(keccak256(abi.encodePacked(_key, "item", index)), lastItem);
+            rocketStorage.setUint(keccak256(abi.encodePacked(_key, "index", lastItem)), index + 1);
+        }
+        rocketStorage.setUint(keccak256(abi.encodePacked(_key, "index", _value)), 0);
+        rocketStorage.setUint(keccak256(abi.encodePacked(_key, "count")), count - 1);
+    }
+
+
+}

--- a/contracts/contract/utils/lists/IntSetStorage.sol
+++ b/contracts/contract/utils/lists/IntSetStorage.sol
@@ -1,0 +1,72 @@
+pragma solidity 0.4.24;
+
+
+import "../../../RocketBase.sol";
+
+
+/// @title Int set storage helper for RocketStorage data (contains unique items; has reverse index lookups)
+/// @author Jake Pospischil
+contract IntSetStorage is RocketBase {
+
+
+    /// @dev Only allow access from the latest version of a contract in the Rocket Pool network after deployment
+    modifier onlyLatestRocketNetworkContract() {
+        require(rocketStorage.getAddress(keccak256(abi.encodePacked("contract.address", msg.sender))) != 0x0, "Calls permitted from latest Rocket Pool network contracts only");
+        _;
+    }
+
+
+    /// @dev RocketSetStorage constructor
+    constructor(address _rocketStorageAddress) RocketBase(_rocketStorageAddress) public {
+        version = 1;
+    }
+
+
+    /// @dev The number of items in a set
+    function getCount(bytes32 _key) external view returns (uint) {
+        return rocketStorage.getUint(keccak256(abi.encodePacked(_key, "count")));
+    }
+
+
+    /// @dev The item in a set by index
+    function getItem(bytes32 _key, uint _index) external view returns (int) {
+        return rocketStorage.getInt(keccak256(abi.encodePacked(_key, "item", _index)));
+    }
+
+
+    /// @dev The index of an item in a set
+    /// @dev Returns -1 if the value is not found
+    function getIndexOf(bytes32 _key, int _value) external view returns (int) {
+        return int(rocketStorage.getUint(keccak256(abi.encodePacked(_key, "index", _value)))) - 1;
+    }
+
+
+    /// @dev Add an item to a set
+    /// @dev Requires that the item does not exist in the set
+    function addItem(bytes32 _key, int _value) onlyLatestRocketNetworkContract external {
+        require(rocketStorage.getUint(keccak256(abi.encodePacked(_key, "index", _value))) == 0, "Item already exists in set");
+        uint count = rocketStorage.getUint(keccak256(abi.encodePacked(_key, "count")));
+        rocketStorage.setInt(keccak256(abi.encodePacked(_key, "item", count)), _value);
+        rocketStorage.setUint(keccak256(abi.encodePacked(_key, "index", _value)), count + 1);
+        rocketStorage.setUint(keccak256(abi.encodePacked(_key, "count")), count + 1);
+    }
+
+
+    /// @dev Remove an item from a set
+    /// @dev Swaps the item with the last item in the set and truncates it; computationally cheap
+    /// @dev Requires that the item exists in the set
+    function removeItem(bytes32 _key, int _value) onlyLatestRocketNetworkContract external {
+        uint256 index = rocketStorage.getUint(keccak256(abi.encodePacked(_key, "index", _value)));
+        require(index-- > 0, "Item does not exist in set");
+        uint count = rocketStorage.getUint(keccak256(abi.encodePacked(_key, "count")));
+        if (index < count - 1) {
+            int lastItem = rocketStorage.getInt(keccak256(abi.encodePacked(_key, "item", count - 1)));
+            rocketStorage.setInt(keccak256(abi.encodePacked(_key, "item", index)), lastItem);
+            rocketStorage.setUint(keccak256(abi.encodePacked(_key, "index", lastItem)), index + 1);
+        }
+        rocketStorage.setUint(keccak256(abi.encodePacked(_key, "index", _value)), 0);
+        rocketStorage.setUint(keccak256(abi.encodePacked(_key, "count")), count - 1);
+    }
+
+
+}

--- a/contracts/contract/utils/lists/StringSetStorage.sol
+++ b/contracts/contract/utils/lists/StringSetStorage.sol
@@ -1,0 +1,72 @@
+pragma solidity 0.4.24;
+
+
+import "../../../RocketBase.sol";
+
+
+/// @title String set storage helper for RocketStorage data (contains unique items; has reverse index lookups)
+/// @author Jake Pospischil
+contract StringSetStorage is RocketBase {
+
+
+    /// @dev Only allow access from the latest version of a contract in the Rocket Pool network after deployment
+    modifier onlyLatestRocketNetworkContract() {
+        require(rocketStorage.getAddress(keccak256(abi.encodePacked("contract.address", msg.sender))) != 0x0, "Calls permitted from latest Rocket Pool network contracts only");
+        _;
+    }
+
+
+    /// @dev RocketSetStorage constructor
+    constructor(address _rocketStorageAddress) RocketBase(_rocketStorageAddress) public {
+        version = 1;
+    }
+
+
+    /// @dev The number of items in a set
+    function getCount(bytes32 _key) external view returns (uint) {
+        return rocketStorage.getUint(keccak256(abi.encodePacked(_key, "count")));
+    }
+
+
+    /// @dev The item in a set by index
+    function getItem(bytes32 _key, uint _index) external view returns (string) {
+        return rocketStorage.getString(keccak256(abi.encodePacked(_key, "item", _index)));
+    }
+
+
+    /// @dev The index of an item in a set
+    /// @dev Returns -1 if the value is not found
+    function getIndexOf(bytes32 _key, string _value) external view returns (int) {
+        return int(rocketStorage.getUint(keccak256(abi.encodePacked(_key, "index", _value)))) - 1;
+    }
+
+
+    /// @dev Add an item to a set
+    /// @dev Requires that the item does not exist in the set
+    function addItem(bytes32 _key, string _value) onlyLatestRocketNetworkContract external {
+        require(rocketStorage.getUint(keccak256(abi.encodePacked(_key, "index", _value))) == 0, "Item already exists in set");
+        uint count = rocketStorage.getUint(keccak256(abi.encodePacked(_key, "count")));
+        rocketStorage.setString(keccak256(abi.encodePacked(_key, "item", count)), _value);
+        rocketStorage.setUint(keccak256(abi.encodePacked(_key, "index", _value)), count + 1);
+        rocketStorage.setUint(keccak256(abi.encodePacked(_key, "count")), count + 1);
+    }
+
+
+    /// @dev Remove an item from a set
+    /// @dev Swaps the item with the last item in the set and truncates it; computationally cheap
+    /// @dev Requires that the item exists in the set
+    function removeItem(bytes32 _key, string _value) onlyLatestRocketNetworkContract external {
+        uint256 index = rocketStorage.getUint(keccak256(abi.encodePacked(_key, "index", _value)));
+        require(index-- > 0, "Item does not exist in set");
+        uint count = rocketStorage.getUint(keccak256(abi.encodePacked(_key, "count")));
+        if (index < count - 1) {
+            string memory lastItem = rocketStorage.getString(keccak256(abi.encodePacked(_key, "item", count - 1)));
+            rocketStorage.setString(keccak256(abi.encodePacked(_key, "item", index)), lastItem);
+            rocketStorage.setUint(keccak256(abi.encodePacked(_key, "index", lastItem)), index + 1);
+        }
+        rocketStorage.setUint(keccak256(abi.encodePacked(_key, "index", _value)), 0);
+        rocketStorage.setUint(keccak256(abi.encodePacked(_key, "count")), count - 1);
+    }
+
+
+}

--- a/contracts/contract/utils/lists/UintSetStorage.sol
+++ b/contracts/contract/utils/lists/UintSetStorage.sol
@@ -1,0 +1,72 @@
+pragma solidity 0.4.24;
+
+
+import "../../../RocketBase.sol";
+
+
+/// @title Uint set storage helper for RocketStorage data (contains unique items; has reverse index lookups)
+/// @author Jake Pospischil
+contract UintSetStorage is RocketBase {
+
+
+    /// @dev Only allow access from the latest version of a contract in the Rocket Pool network after deployment
+    modifier onlyLatestRocketNetworkContract() {
+        require(rocketStorage.getAddress(keccak256(abi.encodePacked("contract.address", msg.sender))) != 0x0, "Calls permitted from latest Rocket Pool network contracts only");
+        _;
+    }
+
+
+    /// @dev RocketSetStorage constructor
+    constructor(address _rocketStorageAddress) RocketBase(_rocketStorageAddress) public {
+        version = 1;
+    }
+
+
+    /// @dev The number of items in a set
+    function getCount(bytes32 _key) external view returns (uint) {
+        return rocketStorage.getUint(keccak256(abi.encodePacked(_key, "count")));
+    }
+
+
+    /// @dev The item in a set by index
+    function getItem(bytes32 _key, uint _index) external view returns (uint) {
+        return rocketStorage.getUint(keccak256(abi.encodePacked(_key, "item", _index)));
+    }
+
+
+    /// @dev The index of an item in a set
+    /// @dev Returns -1 if the value is not found
+    function getIndexOf(bytes32 _key, uint _value) external view returns (int) {
+        return int(rocketStorage.getUint(keccak256(abi.encodePacked(_key, "index", _value)))) - 1;
+    }
+
+
+    /// @dev Add an item to a set
+    /// @dev Requires that the item does not exist in the set
+    function addItem(bytes32 _key, uint _value) onlyLatestRocketNetworkContract external {
+        require(rocketStorage.getUint(keccak256(abi.encodePacked(_key, "index", _value))) == 0, "Item already exists in set");
+        uint count = rocketStorage.getUint(keccak256(abi.encodePacked(_key, "count")));
+        rocketStorage.setUint(keccak256(abi.encodePacked(_key, "item", count)), _value);
+        rocketStorage.setUint(keccak256(abi.encodePacked(_key, "index", _value)), count + 1);
+        rocketStorage.setUint(keccak256(abi.encodePacked(_key, "count")), count + 1);
+    }
+
+
+    /// @dev Remove an item from a set
+    /// @dev Swaps the item with the last item in the set and truncates it; computationally cheap
+    /// @dev Requires that the item exists in the set
+    function removeItem(bytes32 _key, uint _value) onlyLatestRocketNetworkContract external {
+        uint256 index = rocketStorage.getUint(keccak256(abi.encodePacked(_key, "index", _value)));
+        require(index-- > 0, "Item does not exist in set");
+        uint count = rocketStorage.getUint(keccak256(abi.encodePacked(_key, "count")));
+        if (index < count - 1) {
+            uint lastItem = rocketStorage.getUint(keccak256(abi.encodePacked(_key, "item", count - 1)));
+            rocketStorage.setUint(keccak256(abi.encodePacked(_key, "item", index)), lastItem);
+            rocketStorage.setUint(keccak256(abi.encodePacked(_key, "index", lastItem)), index + 1);
+        }
+        rocketStorage.setUint(keccak256(abi.encodePacked(_key, "index", _value)), 0);
+        rocketStorage.setUint(keccak256(abi.encodePacked(_key, "count")), count - 1);
+    }
+
+
+}

--- a/contracts/interface/utils/lists/AddressSetStorageInterface.sol
+++ b/contracts/interface/utils/lists/AddressSetStorageInterface.sol
@@ -1,0 +1,9 @@
+pragma solidity 0.4.24; 
+
+contract AddressSetStorageInterface {
+    function getCount(bytes32 _key) external view returns (uint);
+	function getItem(bytes32 _key, uint _index) external view returns (address);
+	function getIndexOf(bytes32 _key, address _value) external view returns (int);
+	function addItem(bytes32 _key, address _value) external;
+	function removeItem(bytes32 _key, address _value) external;
+}

--- a/contracts/interface/utils/lists/AddressSetStorageInterface.sol
+++ b/contracts/interface/utils/lists/AddressSetStorageInterface.sol
@@ -2,8 +2,8 @@ pragma solidity 0.4.24;
 
 contract AddressSetStorageInterface {
     function getCount(bytes32 _key) external view returns (uint);
-	function getItem(bytes32 _key, uint _index) external view returns (address);
-	function getIndexOf(bytes32 _key, address _value) external view returns (int);
-	function addItem(bytes32 _key, address _value) external;
-	function removeItem(bytes32 _key, address _value) external;
+    function getItem(bytes32 _key, uint _index) external view returns (address);
+    function getIndexOf(bytes32 _key, address _value) external view returns (int);
+    function addItem(bytes32 _key, address _value) external;
+    function removeItem(bytes32 _key, address _value) external;
 }

--- a/contracts/interface/utils/lists/BoolSetStorageInterface.sol
+++ b/contracts/interface/utils/lists/BoolSetStorageInterface.sol
@@ -1,0 +1,9 @@
+pragma solidity 0.4.24; 
+
+contract BoolSetStorageInterface {
+    function getCount(bytes32 _key) external view returns (uint);
+    function getItem(bytes32 _key, uint _index) external view returns (bool);
+    function getIndexOf(bytes32 _key, bool _value) external view returns (int);
+    function addItem(bytes32 _key, bool _value) external;
+    function removeItem(bytes32 _key, bool _value) external;
+}

--- a/contracts/interface/utils/lists/Bytes32SetStorageInterface.sol
+++ b/contracts/interface/utils/lists/Bytes32SetStorageInterface.sol
@@ -1,0 +1,9 @@
+pragma solidity 0.4.24; 
+
+contract Bytes32SetStorageInterface {
+    function getCount(bytes32 _key) external view returns (uint);
+    function getItem(bytes32 _key, uint _index) external view returns (bytes32);
+    function getIndexOf(bytes32 _key, bytes32 _value) external view returns (int);
+    function addItem(bytes32 _key, bytes32 _value) external;
+    function removeItem(bytes32 _key, bytes32 _value) external;
+}

--- a/contracts/interface/utils/lists/BytesSetStorageInterface.sol
+++ b/contracts/interface/utils/lists/BytesSetStorageInterface.sol
@@ -1,0 +1,9 @@
+pragma solidity 0.4.24; 
+
+contract BytesSetStorageInterface {
+    function getCount(bytes32 _key) external view returns (uint);
+    function getItem(bytes32 _key, uint _index) external view returns (bytes);
+    function getIndexOf(bytes32 _key, bytes _value) external view returns (int);
+    function addItem(bytes32 _key, bytes _value) external;
+    function removeItem(bytes32 _key, bytes _value) external;
+}

--- a/contracts/interface/utils/lists/IntSetStorageInterface.sol
+++ b/contracts/interface/utils/lists/IntSetStorageInterface.sol
@@ -1,0 +1,9 @@
+pragma solidity 0.4.24; 
+
+contract IntSetStorageInterface {
+    function getCount(bytes32 _key) external view returns (uint);
+    function getItem(bytes32 _key, uint _index) external view returns (int);
+    function getIndexOf(bytes32 _key, int _value) external view returns (int);
+    function addItem(bytes32 _key, int _value) external;
+    function removeItem(bytes32 _key, int _value) external;
+}

--- a/contracts/interface/utils/lists/StringSetStorageInterface.sol
+++ b/contracts/interface/utils/lists/StringSetStorageInterface.sol
@@ -1,0 +1,9 @@
+pragma solidity 0.4.24; 
+
+contract StringSetStorageInterface {
+    function getCount(bytes32 _key) external view returns (uint);
+    function getItem(bytes32 _key, uint _index) external view returns (string);
+    function getIndexOf(bytes32 _key, string _value) external view returns (int);
+    function addItem(bytes32 _key, string _value) external;
+    function removeItem(bytes32 _key, string _value) external;
+}

--- a/contracts/interface/utils/lists/UintSetStorageInterface.sol
+++ b/contracts/interface/utils/lists/UintSetStorageInterface.sol
@@ -1,0 +1,9 @@
+pragma solidity 0.4.24; 
+
+contract UintSetStorageInterface {
+    function getCount(bytes32 _key) external view returns (uint);
+    function getItem(bytes32 _key, uint _index) external view returns (uint);
+    function getIndexOf(bytes32 _key, uint _value) external view returns (int);
+    function addItem(bytes32 _key, uint _value) external;
+    function removeItem(bytes32 _key, uint _value) external;
+}

--- a/contracts/test/TestSets.sol
+++ b/contracts/test/TestSets.sol
@@ -1,0 +1,48 @@
+pragma solidity 0.4.24;
+
+
+import "../RocketBase.sol";
+import "../interface/utils/lists/AddressSetStorageInterface.sol";
+
+
+contract TestSets is RocketBase {
+
+
+    // Contracts
+    AddressSetStorageInterface addressSetStorage = AddressSetStorageInterface(0);
+
+
+    // Constructor
+    constructor(address _rocketStorageAddress) RocketBase(_rocketStorageAddress) public {
+        version = 1;
+    }
+
+
+    // Initialise
+    function init() external {
+
+        // Initialise contracts
+        addressSetStorage = AddressSetStorageInterface(getContractAddress("utilAddressSetStorage"));
+
+    }
+
+
+    // Address set tests
+    function address_getCount(bytes32 _key) external view returns (uint) {
+        return addressSetStorage.getCount(_key);
+    }
+    function address_getItem(bytes32 _key, uint _index) external view returns (address) {
+        return addressSetStorage.getItem(_key, _index);
+    }
+    function address_getIndexOf(bytes32 _key, address _value) external view returns (int) {
+        return addressSetStorage.getIndexOf(_key, _value);
+    }
+    function address_addItem(bytes32 _key, address _value) external {
+        addressSetStorage.addItem(_key, _value);
+    }
+    function address_removeItem(bytes32 _key, address _value) external {
+        addressSetStorage.removeItem(_key, _value);
+    }
+
+
+}

--- a/contracts/test/TestSets.sol
+++ b/contracts/test/TestSets.sol
@@ -3,6 +3,12 @@ pragma solidity 0.4.24;
 
 import "../RocketBase.sol";
 import "../interface/utils/lists/AddressSetStorageInterface.sol";
+import "../interface/utils/lists/BoolSetStorageInterface.sol";
+import "../interface/utils/lists/Bytes32SetStorageInterface.sol";
+import "../interface/utils/lists/BytesSetStorageInterface.sol";
+import "../interface/utils/lists/IntSetStorageInterface.sol";
+import "../interface/utils/lists/StringSetStorageInterface.sol";
+import "../interface/utils/lists/UintSetStorageInterface.sol";
 
 
 contract TestSets is RocketBase {
@@ -10,6 +16,12 @@ contract TestSets is RocketBase {
 
     // Contracts
     AddressSetStorageInterface addressSetStorage = AddressSetStorageInterface(0);
+    BoolSetStorageInterface boolSetStorage = BoolSetStorageInterface(0);
+    Bytes32SetStorageInterface bytes32SetStorage = Bytes32SetStorageInterface(0);
+    BytesSetStorageInterface bytesSetStorage = BytesSetStorageInterface(0);
+    IntSetStorageInterface intSetStorage = IntSetStorageInterface(0);
+    StringSetStorageInterface stringSetStorage = StringSetStorageInterface(0);
+    UintSetStorageInterface uintSetStorage = UintSetStorageInterface(0);
 
 
     // Constructor
@@ -23,6 +35,12 @@ contract TestSets is RocketBase {
 
         // Initialise contracts
         addressSetStorage = AddressSetStorageInterface(getContractAddress("utilAddressSetStorage"));
+        boolSetStorage = BoolSetStorageInterface(getContractAddress("utilBoolSetStorage"));
+        bytes32SetStorage = Bytes32SetStorageInterface(getContractAddress("utilBytes32SetStorage"));
+        bytesSetStorage = BytesSetStorageInterface(getContractAddress("utilBytesSetStorage"));
+        intSetStorage = IntSetStorageInterface(getContractAddress("utilIntSetStorage"));
+        stringSetStorage = StringSetStorageInterface(getContractAddress("utilStringSetStorage"));
+        uintSetStorage = UintSetStorageInterface(getContractAddress("utilUintSetStorage"));
 
     }
 
@@ -42,6 +60,114 @@ contract TestSets is RocketBase {
     }
     function address_removeItem(bytes32 _key, address _value) external {
         addressSetStorage.removeItem(_key, _value);
+    }
+
+
+    // Bool set tests
+    function bool_getCount(bytes32 _key) external view returns (uint) {
+        return boolSetStorage.getCount(_key);
+    }
+    function bool_getItem(bytes32 _key, uint _index) external view returns (bool) {
+        return boolSetStorage.getItem(_key, _index);
+    }
+    function bool_getIndexOf(bytes32 _key, bool _value) external view returns (int) {
+        return boolSetStorage.getIndexOf(_key, _value);
+    }
+    function bool_addItem(bytes32 _key, bool _value) external {
+        boolSetStorage.addItem(_key, _value);
+    }
+    function bool_removeItem(bytes32 _key, bool _value) external {
+        boolSetStorage.removeItem(_key, _value);
+    }
+
+
+    // Bytes32 set tests
+    function bytes32_getCount(bytes32 _key) external view returns (uint) {
+        return bytes32SetStorage.getCount(_key);
+    }
+    function bytes32_getItem(bytes32 _key, uint _index) external view returns (bytes32) {
+        return bytes32SetStorage.getItem(_key, _index);
+    }
+    function bytes32_getIndexOf(bytes32 _key, bytes32 _value) external view returns (int) {
+        return bytes32SetStorage.getIndexOf(_key, _value);
+    }
+    function bytes32_addItem(bytes32 _key, bytes32 _value) external {
+        bytes32SetStorage.addItem(_key, _value);
+    }
+    function bytes32_removeItem(bytes32 _key, bytes32 _value) external {
+        bytes32SetStorage.removeItem(_key, _value);
+    }
+
+
+    // Bytes set tests
+    function bytes_getCount(bytes32 _key) external view returns (uint) {
+        return bytesSetStorage.getCount(_key);
+    }
+    function bytes_getItem(bytes32 _key, uint _index) external view returns (bytes) {
+        return bytesSetStorage.getItem(_key, _index);
+    }
+    function bytes_getIndexOf(bytes32 _key, bytes _value) external view returns (int) {
+        return bytesSetStorage.getIndexOf(_key, _value);
+    }
+    function bytes_addItem(bytes32 _key, bytes _value) external {
+        bytesSetStorage.addItem(_key, _value);
+    }
+    function bytes_removeItem(bytes32 _key, bytes _value) external {
+        bytesSetStorage.removeItem(_key, _value);
+    }
+
+
+    // Int set tests
+    function int_getCount(bytes32 _key) external view returns (uint) {
+        return intSetStorage.getCount(_key);
+    }
+    function int_getItem(bytes32 _key, uint _index) external view returns (int) {
+        return intSetStorage.getItem(_key, _index);
+    }
+    function int_getIndexOf(bytes32 _key, int _value) external view returns (int) {
+        return intSetStorage.getIndexOf(_key, _value);
+    }
+    function int_addItem(bytes32 _key, int _value) external {
+        intSetStorage.addItem(_key, _value);
+    }
+    function int_removeItem(bytes32 _key, int _value) external {
+        intSetStorage.removeItem(_key, _value);
+    }
+
+
+    // String set tests
+    function string_getCount(bytes32 _key) external view returns (uint) {
+        return stringSetStorage.getCount(_key);
+    }
+    function string_getItem(bytes32 _key, uint _index) external view returns (string) {
+        return stringSetStorage.getItem(_key, _index);
+    }
+    function string_getIndexOf(bytes32 _key, string _value) external view returns (int) {
+        return stringSetStorage.getIndexOf(_key, _value);
+    }
+    function string_addItem(bytes32 _key, string _value) external {
+        stringSetStorage.addItem(_key, _value);
+    }
+    function string_removeItem(bytes32 _key, string _value) external {
+        stringSetStorage.removeItem(_key, _value);
+    }
+
+
+    // Uint set tests
+    function uint_getCount(bytes32 _key) external view returns (uint) {
+        return uintSetStorage.getCount(_key);
+    }
+    function uint_getItem(bytes32 _key, uint _index) external view returns (uint) {
+        return uintSetStorage.getItem(_key, _index);
+    }
+    function uint_getIndexOf(bytes32 _key, uint _value) external view returns (int) {
+        return uintSetStorage.getIndexOf(_key, _value);
+    }
+    function uint_addItem(bytes32 _key, uint _value) external {
+        uintSetStorage.addItem(_key, _value);
+    }
+    function uint_removeItem(bytes32 _key, uint _value) external {
+        uintSetStorage.removeItem(_key, _value);
     }
 
 

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -51,6 +51,12 @@ contracts.utilIntQueueStorage = artifacts.require('./IntQueueStorage.sol');
 contracts.utilStringQueueStorage = artifacts.require('./StringQueueStorage.sol');
 contracts.utilUintQueueStorage = artifacts.require('./UintQueueStorage.sol');
 contracts.utilAddressSetStorage = artifacts.require('./AddressSetStorage.sol');
+contracts.utilBoolSetStorage = artifacts.require('./BoolSetStorage.sol');
+contracts.utilBytesSetStorage = artifacts.require('./BytesSetStorage.sol');
+contracts.utilBytes32SetStorage = artifacts.require('./Bytes32SetStorage.sol');
+contracts.utilIntSetStorage = artifacts.require('./IntSetStorage.sol');
+contracts.utilStringSetStorage = artifacts.require('./StringSetStorage.sol');
+contracts.utilUintSetStorage = artifacts.require('./UintSetStorage.sol');
 
 
 /*** Utility Methods *****************/

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -50,6 +50,7 @@ contracts.utilBytes32QueueStorage = artifacts.require('./Bytes32QueueStorage.sol
 contracts.utilIntQueueStorage = artifacts.require('./IntQueueStorage.sol');
 contracts.utilStringQueueStorage = artifacts.require('./StringQueueStorage.sol');
 contracts.utilUintQueueStorage = artifacts.require('./UintQueueStorage.sol');
+contracts.utilAddressSetStorage = artifacts.require('./AddressSetStorage.sol');
 
 
 /*** Utility Methods *****************/
@@ -86,6 +87,7 @@ module.exports = async (deployer, network) => {
   if ( network !== 'live' ) {
     contracts.testLists = artifacts.require('./test/TestLists.sol');
     contracts.testQueues = artifacts.require('./test/TestQueues.sol');
+    contracts.testSets = artifacts.require('./test/TestSets.sol');
   }
  
   // Accounts

--- a/test/_lib/artifacts.js
+++ b/test/_lib/artifacts.js
@@ -9,4 +9,5 @@ export const RocketPIP = artifacts.require('./contract/RocketPIP');
 
 export const TestLists = artifacts.require('./test/TestLists');
 export const TestQueues = artifacts.require('./test/TestQueues');
+export const TestSets = artifacts.require('./test/TestSets');
 export const TestNodeTask = artifacts.require('./test/TestNodeTask');

--- a/test/rocket-storage/rocket-set-storage-scenarios.js
+++ b/test/rocket-storage/rocket-set-storage-scenarios.js
@@ -37,7 +37,11 @@ export async function scenarioAddItem({prefix, key, value, fromAddress, gas}) {
     let set2 = await getSet(prefix, key);
 
     // Asserts
-    
+    assert.equal(set2.length, set1.length + 1, 'Set count was not updated correctly');
+    assert.equal(set2[set2.length - 1], value, 'Value was not added correctly');
+    set1.forEach((item, index) => {
+        assert.equal(set1[index], set2[index], 'Set items changed which should not have');
+    });
 
 }
 
@@ -56,7 +60,12 @@ export async function scenarioRemoveItem({prefix, key, value, fromAddress, gas})
     let set2 = await getSet(prefix, key);
 
     // Asserts
-    
+    assert.equal(set2.length, set1.length - 1, 'Set count was not updated correctly');
+    assert.equal(set2.indexOf(value), -1, 'Value was not removed correctly');
+    set1.forEach((item, index) => {
+        if (item == value) return;
+        assert.notEqual(set2.indexOf(item), -1, 'Set items were removed and should not have been');
+    });
 
 }
 

--- a/test/rocket-storage/rocket-set-storage-scenarios.js
+++ b/test/rocket-storage/rocket-set-storage-scenarios.js
@@ -1,0 +1,62 @@
+// Dependencies
+import { TestSets } from '../_lib/artifacts';
+
+
+// Retrieve a set from storage
+async function getSet(prefix, key) {
+    const testSets = await TestSets.deployed();
+
+    // Get set count
+    let count = await testSets[`${prefix}_getCount`].call(key);
+
+    // Get set items
+    let items = [], item, index;
+    for (index = 0; index < count; ++index) {
+        item = await testSets[`${prefix}_getItem`].call(key, index);
+        if (item.constructor.name == 'BN') item = parseInt(item);
+        items.push(item);
+    }
+
+    // Return set
+    return items;
+
+}
+
+
+// Add an item
+export async function scenarioAddItem({prefix, key, value, fromAddress, gas}) {
+    const testSets = await TestSets.deployed();
+
+    // Get initial set
+    let set1 = await getSet(prefix, key);
+
+    // Add item
+    await testSets[`${prefix}_addItem`](key, value, {from: fromAddress, gas: gas});
+
+    // Get updated set
+    let set2 = await getSet(prefix, key);
+
+    // Asserts
+    
+
+}
+
+
+// Remove an item
+export async function scenarioRemoveItem({prefix, key, value, fromAddress, gas}) {
+    const testSets = await TestSets.deployed();
+
+    // Get initial set
+    let set1 = await getSet(prefix, key);
+
+    // Remove item
+    await testSets[`${prefix}_removeItem`](key, value, {from: fromAddress, gas: gas});
+
+    // Get updated set
+    let set2 = await getSet(prefix, key);
+
+    // Asserts
+    
+
+}
+

--- a/test/rocket-storage/rocket-storage-tests.js
+++ b/test/rocket-storage/rocket-storage-tests.js
@@ -623,6 +623,46 @@ export default function() {
         '0x0000000000000000000000000000000000000005',
         '0x0000000000000000000000000000000000000099',
     ]);
+    setTests('BytesSetStorage', 'bytes', web3.utils.soliditySha3('set.bytes'), [
+        web3.utils.soliditySha3('test string 1'),
+        web3.utils.soliditySha3('test string 2'),
+        web3.utils.soliditySha3('test string 3'),
+        web3.utils.soliditySha3('test string 4'),
+        web3.utils.soliditySha3('test string 5'),
+        web3.utils.soliditySha3('test string 99'),
+    ]);
+    setTests('Bytes32SetStorage', 'bytes32', web3.utils.soliditySha3('set.bytes32'), [
+        '0x0000000000000000000000000000000000000000000000000000000000000001',
+        '0x0000000000000000000000000000000000000000000000000000000000000002',
+        '0x0000000000000000000000000000000000000000000000000000000000000003',
+        '0x0000000000000000000000000000000000000000000000000000000000000004',
+        '0x0000000000000000000000000000000000000000000000000000000000000005',
+        '0x0000000000000000000000000000000000000000000000000000000000000099',
+    ]);
+    setTests('IntSetStorage', 'int', web3.utils.soliditySha3('set.ints'), [
+        -1,
+        2,
+        -3,
+        4,
+        -5,
+        99,
+    ]);
+    setTests('StringSetStorage', 'string', web3.utils.soliditySha3('set.strings'), [
+        'test string 1',
+        'test string 2',
+        'test string 3',
+        'test string 4',
+        'test string 5',
+        'test string 99',
+    ]);
+    setTests('UintSetStorage', 'uint', web3.utils.soliditySha3('set.uints'), [
+        1,
+        2,
+        3,
+        4,
+        5,
+        99,
+    ]);
 
 
 };

--- a/test/rocket-storage/rocket-storage-tests.js
+++ b/test/rocket-storage/rocket-storage-tests.js
@@ -1,8 +1,9 @@
 import { printTitle, assertThrows } from '../_lib/utils/general';
-import { TestLists, TestQueues } from '../_lib/artifacts';
+import { TestLists, TestQueues, TestSets } from '../_lib/artifacts';
 import { scenarioWriteBool } from './rocket-storage-scenarios';
 import { scenarioPushListItem, scenarioSetListItem, scenarioInsertListItem, scenarioRemoveOListItem, scenarioRemoveUListItem } from './rocket-list-storage-scenarios';
 import { scenarioEnqueueItem, scenarioDequeueItem } from './rocket-queue-storage-scenarios';
+import { scenarioAddItem, scenarioRemoveItem } from './rocket-set-storage-scenarios';
 
 export default function() {
 
@@ -280,6 +281,113 @@ export default function() {
     }
 
 
+    // Run set tests by type
+    function setTests(name, prefix, key, testValues) {
+        contract(name, async (accounts) => {
+
+
+            // Contract dependencies
+            let testSets;
+            before(async () => {
+                testSets = await TestSets.deployed();
+                testSets.init();
+            });
+
+
+            // Add items to a set
+            it(printTitle('-----', 'add items to a set'), async () => {
+
+                // Add items
+                await scenarioAddItem({
+                    prefix,
+                    key,
+                    value: testValues[0],
+                    fromAddress: accounts[0],
+                    gas: 500000,
+                });
+                await scenarioAddItem({
+                    prefix,
+                    key,
+                    value: testValues[1],
+                    fromAddress: accounts[0],
+                    gas: 500000,
+                });
+                await scenarioAddItem({
+                    prefix,
+                    key,
+                    value: testValues[2],
+                    fromAddress: accounts[0],
+                    gas: 500000,
+                });
+                await scenarioAddItem({
+                    prefix,
+                    key,
+                    value: testValues[3],
+                    fromAddress: accounts[0],
+                    gas: 500000,
+                });
+                await scenarioAddItem({
+                    prefix,
+                    key,
+                    value: testValues[4],
+                    fromAddress: accounts[0],
+                    gas: 500000,
+                });
+
+                // Add an existing item
+                await assertThrows(scenarioAddItem({
+                    prefix,
+                    key,
+                    value: testValues[0],
+                    fromAddress: accounts[0],
+                    gas: 500000,
+                }), 'Added an existing item to a set');
+
+            });
+
+
+            // Remove items from a set
+            it(printTitle('-----', 'remove items from a set'), async () => {
+
+                // Remove items
+                await scenarioRemoveItem({
+                    prefix,
+                    key,
+                    value: testValues[2],
+                    fromAddress: accounts[0],
+                    gas: 500000,
+                });
+                await scenarioRemoveItem({
+                    prefix,
+                    key,
+                    value: testValues[0],
+                    fromAddress: accounts[0],
+                    gas: 500000,
+                });
+                await scenarioRemoveItem({
+                    prefix,
+                    key,
+                    value: testValues[4],
+                    fromAddress: accounts[0],
+                    gas: 500000,
+                });
+
+                // Remove a nonexistent item
+                await assertThrows(scenarioRemoveItem({
+                    prefix,
+                    key,
+                    value: testValues[5],
+                    fromAddress: accounts[0],
+                    gas: 500000,
+                }), 'Removed a nonexistent item from a set');
+
+            });
+
+
+        });
+    }
+
+
     // Run list tests
     listTests('AddressListStorage', 'address', web3.utils.soliditySha3('list.addresses'), [
         '0x0000000000000000000000000000000000000001',
@@ -485,6 +593,16 @@ export default function() {
             11,
             12,
         ],
+    ]);
+
+    // Run set tests
+    setTests('AddressSetStorage', 'address', web3.utils.soliditySha3('set.addresses'), [
+        '0x0000000000000000000000000000000000000001',
+        '0x0000000000000000000000000000000000000002',
+        '0x0000000000000000000000000000000000000003',
+        '0x0000000000000000000000000000000000000004',
+        '0x0000000000000000000000000000000000000005',
+        '0x0000000000000000000000000000000000000099',
     ]);
 
 

--- a/test/rocket-storage/rocket-storage-tests.js
+++ b/test/rocket-storage/rocket-storage-tests.js
@@ -384,6 +384,25 @@ export default function() {
             });
 
 
+            // Add removed items to a set
+            it(printTitle('-----', 'add removed items to a set'), async () => {
+                await scenarioAddItem({
+                    prefix,
+                    key,
+                    value: testValues[0],
+                    fromAddress: accounts[0],
+                    gas: 500000,
+                });
+                await scenarioAddItem({
+                    prefix,
+                    key,
+                    value: testValues[2],
+                    fromAddress: accounts[0],
+                    gas: 500000,
+                });
+            });
+
+
         });
     }
 


### PR DESCRIPTION
- Implemented set storage helper classes
-- Sets can only contain unique items, and don't maintain a strict order
-- Sets use a reverse index lookup to check item existence and find item index
-- All set methods have constant complexity; no iteration
- Implemented set storage unit tests