### PR TITLE
Rocket two deposits

### DIFF
--- a/contracts/RocketAdmin.sol
+++ b/contracts/RocketAdmin.sol
@@ -4,6 +4,7 @@ pragma solidity 0.4.24;
 import "./RocketBase.sol";
 // Interfaces
 import "./interface/RocketStorageInterface.sol";
+import "./interface/utils/lists/AddressSetStorageInterface.sol";
 
 
 /// @title Admin only methods for Rocket Pool owner and admins
@@ -11,6 +12,8 @@ import "./interface/RocketStorageInterface.sol";
 contract RocketAdmin is RocketBase {
 
     /*** Contracts **************/
+
+    AddressSetStorageInterface addressSetStorage = AddressSetStorageInterface(0);
 
   
     /*** Events ****************/
@@ -33,12 +36,24 @@ contract RocketAdmin is RocketBase {
 
     /// @dev Set this node as a 'Trusted Node' - Is not required to stake as much ether as they receive, but does need the RPL. Is served after regular node operators to ensure the network can always grow.
     /// @param _nodeAddress The address of the node
-    function setNodeTrusted(address _nodeAddress) public onlySuperUser() returns (bool) {
-        // Check it exists first and isn't already trusted
+    /// @param _trusted The flag indicating whether the node is trusted
+    function setNodeTrusted(address _nodeAddress, bool _trusted) public onlySuperUser() returns (bool) {
+        // Check it exists first and isn't already the specified status
         require(rocketStorage.getBool(keccak256(abi.encodePacked("node.exists", _nodeAddress))), "Node address does not exist.");
-        require(rocketStorage.getBool(keccak256(abi.encodePacked("node.trusted", _nodeAddress))), "Node is already trusted.");
+        require(rocketStorage.getBool(keccak256(abi.encodePacked("node.trusted", _nodeAddress))) != _trusted, "Node trusted status already set.");
+        // Get contracts
+        addressSetStorage = AddressSetStorageInterface(getContractAddress("utilAddressSetStorage"));
         // Set now
-        rocketStorage.setBool(keccak256(abi.encodePacked("node.trusted", _nodeAddress)), true);
+        rocketStorage.setBool(keccak256(abi.encodePacked("node.trusted", _nodeAddress)), _trusted);
+        // Update available node indexes
+        bytes32 oldAvailableKey = keccak256(abi.encodePacked("nodes.available", "trusted", !_trusted));
+        bytes32 newAvailableKey = keccak256(abi.encodePacked("nodes.available", "trusted", _trusted));
+        if (addressSetStorage.getIndexOf(oldAvailableKey, _nodeAddress) != -1) {
+            addressSetStorage.removeItem(oldAvailableKey, _nodeAddress);
+            addressSetStorage.addItem(newAvailableKey, _nodeAddress);
+        }
+        // Return success flag
+        return true;
     }
 
    

--- a/contracts/RocketAdmin.sol
+++ b/contracts/RocketAdmin.sol
@@ -4,7 +4,6 @@ pragma solidity 0.4.24;
 import "./RocketBase.sol";
 // Interfaces
 import "./interface/RocketStorageInterface.sol";
-import "./interface/utils/lists/AddressSetStorageInterface.sol";
 
 
 /// @title Admin only methods for Rocket Pool owner and admins
@@ -12,8 +11,6 @@ import "./interface/utils/lists/AddressSetStorageInterface.sol";
 contract RocketAdmin is RocketBase {
 
     /*** Contracts **************/
-
-    AddressSetStorageInterface addressSetStorage = AddressSetStorageInterface(0);
 
   
     /*** Events ****************/
@@ -41,17 +38,8 @@ contract RocketAdmin is RocketBase {
         // Check it exists first and isn't already the specified status
         require(rocketStorage.getBool(keccak256(abi.encodePacked("node.exists", _nodeAddress))), "Node address does not exist.");
         require(rocketStorage.getBool(keccak256(abi.encodePacked("node.trusted", _nodeAddress))) != _trusted, "Node trusted status already set.");
-        // Get contracts
-        addressSetStorage = AddressSetStorageInterface(getContractAddress("utilAddressSetStorage"));
         // Set now
         rocketStorage.setBool(keccak256(abi.encodePacked("node.trusted", _nodeAddress)), _trusted);
-        // Update available node indexes
-        bytes32 oldAvailableKey = keccak256(abi.encodePacked("nodes.available", "trusted", !_trusted));
-        bytes32 newAvailableKey = keccak256(abi.encodePacked("nodes.available", "trusted", _trusted));
-        if (addressSetStorage.getIndexOf(oldAvailableKey, _nodeAddress) != -1) {
-            addressSetStorage.removeItem(oldAvailableKey, _nodeAddress);
-            addressSetStorage.addItem(newAvailableKey, _nodeAddress);
-        }
         // Return success flag
         return true;
     }

--- a/contracts/RocketNode.sol
+++ b/contracts/RocketNode.sol
@@ -1,0 +1,71 @@
+pragma solidity 0.4.24;
+
+import "./RocketBase.sol";
+import "./interface/utils/lists/AddressSetStorageInterface.sol";
+
+
+/// @title Main node management contract
+/// @author Jake Pospischil
+contract RocketNode is RocketBase {
+
+
+    /*** Contracts **************/
+
+
+    AddressSetStorageInterface addressSetStorage = AddressSetStorageInterface(0);                           // Address list utility
+
+
+    /*** Constructor *************/
+
+
+    /// @dev RocketNode constructor
+    constructor(address _rocketStorageAddress) RocketBase(_rocketStorageAddress) public {
+        version = 1;
+    }
+
+
+    /*** Getters *************/
+
+
+    /// @dev Get the address of a pseudorandom available node
+    /// @return The node address and trusted status
+    function getRandomAvailableNode(uint256 _nonce) public returns (address, bool) {
+        // Get contracts
+        addressSetStorage = AddressSetStorageInterface(getContractAddress("utilAddressSetStorage"));
+        // Get node set type
+        bool trusted;
+        if (addressSetStorage.getCount(keccak256(abi.encodePacked("nodes.available", "trusted", false))) > 0) { trusted = false; } // Use untrusted nodes if available
+        else if (addressSetStorage.getCount(keccak256(abi.encodePacked("nodes.available", "trusted", true))) > 0) { trusted = true; } // Use trusted nodes if available
+        else { return (0x0, false); } // No nodes available
+        // Get random node from set
+        bytes32 key = keccak256(abi.encodePacked("nodes.available", "trusted", trusted));
+        uint256 nodeCount = addressSetStorage.getCount(key);
+        uint256 randIndex = uint256(keccak256(abi.encodePacked(block.number, block.timestamp, _nonce))) % nodeCount;
+        return (addressSetStorage.getItem(key, randIndex), trusted);
+    }
+
+
+    /*** Methods *************/
+
+
+    /// @dev Set node availabile
+    /// @dev Adds the node to the available index if not already present
+    function setNodeAvailable(address _nodeOwner, bool _trusted) public onlyLatestContract("rocketPool", msg.sender) {
+        addressSetStorage = AddressSetStorageInterface(getContractAddress("utilAddressSetStorage"));
+        if (addressSetStorage.getIndexOf(keccak256(abi.encodePacked("nodes.available", "trusted", _trusted)), _nodeOwner) == -1) {
+            addressSetStorage.addItem(keccak256(abi.encodePacked("nodes.available", "trusted", _trusted)), _nodeOwner);
+        }
+    }
+
+
+    /// @dev Set node unavailabile
+    /// @dev Removes the node from the available index if already present
+    function setNodeUnavailable(address _nodeOwner, bool _trusted) public onlyLatestContract("rocketPool", msg.sender) {
+        addressSetStorage = AddressSetStorageInterface(getContractAddress("utilAddressSetStorage"));
+        if (addressSetStorage.getIndexOf(keccak256(abi.encodePacked("nodes.available", "trusted", _trusted)), _nodeOwner) != -1) {
+            addressSetStorage.removeItem(keccak256(abi.encodePacked("nodes.available", "trusted", _trusted)), _nodeOwner);
+        }
+    }
+
+
+}

--- a/contracts/contract/deposit/RocketDeposit.sol
+++ b/contracts/contract/deposit/RocketDeposit.sol
@@ -151,6 +151,7 @@ contract RocketDeposit is RocketBase {
         rocketStorage.setUint(keccak256(abi.encodePacked("deposits.queue.balance", _durationID)), queueBalance);
 
         // Transfer balance from vault to minipool contract
+        // TODO: transfer using deposit method instead of default payable function
         require(rocketDepositVault.withdrawEther(miniPoolAddress, chunkSize), "Deposit coult not be transferred to minipool contract");
 
         // Return success flag

--- a/contracts/contract/deposit/RocketDeposit.sol
+++ b/contracts/contract/deposit/RocketDeposit.sol
@@ -99,10 +99,9 @@ contract RocketDeposit is RocketBase {
         addressSetStorage = AddressSetStorageInterface(getContractAddress("utilAddressSetStorage"));
         bytes32QueueStorage = Bytes32QueueStorageInterface(getContractAddress("utilBytes32QueueStorage"));
 
-        // Get random node's minipool to assign chunk to
-        address nodeAddress = rocketPool.getRandomAvailableNode(msg.value);
-        address miniPoolAddress = addressSetStorage.getItem(keccak256(abi.encodePacked("minipools", "list.node", nodeAddress)), 0);
-        if (nodeAddress == 0x0 || miniPoolAddress == 0x0) { return false; }
+        // Get random available minipool to assign chunk to
+        address miniPoolAddress = rocketPool.getRandomAvailableMinipool(msg.value);
+        if (miniPoolAddress == 0x0) { return false; }
 
         // Remaining ether amount to match
         uint256 chunkSize = rocketDepositSettings.getDepositChunkSize();

--- a/contracts/contract/deposit/RocketDeposit.sol
+++ b/contracts/contract/deposit/RocketDeposit.sol
@@ -68,7 +68,7 @@ contract RocketDeposit is RocketBase {
 
 
     // Assign chunks while able
-    function assignChunks(string _durationID) public {
+    function assignChunks(string _durationID) public onlySuperUser() {
 
         // Deposit settings
         rocketDepositSettings = RocketDepositSettingsInterface(getContractAddress("rocketDepositSettings"));

--- a/contracts/contract/minipool/RocketMinipool.sol
+++ b/contracts/contract/minipool/RocketMinipool.sol
@@ -56,7 +56,7 @@ contract RocketMinipool {
         address contractAddress;                                // The nodes Rocket Pool contract
         uint256 depositEther;                                   // The nodes ether contribution
         uint256 depositRPL;                                     // The nodes RPL contribution
-        bool    trusted;                                        // Is this a trusted node?
+        bool    trusted;                                        // Was the node trusted at the time of minipool creation?
     }
 
     struct Staking {
@@ -124,7 +124,7 @@ contract RocketMinipool {
     /// @param _durationID Staking duration ID (eg 3m, 6m etc)
     /// @param _depositEther Ether amount deposited by the node owner
     /// @param _depositRPL RPL amount deposited by the node owner
-    /// @param _trusted Is this node owner trusted?
+    /// @param _trusted Is the node trusted at the time of minipool creation?
     constructor(address _rocketStorageAddress, address _nodeOwner, string _durationID, uint256 _depositEther, uint256 _depositRPL, bool _trusted) public {
         // Update the storage contract address
         rocketStorage = RocketStorageInterface(_rocketStorageAddress);
@@ -209,6 +209,11 @@ contract RocketMinipool {
     /// @dev Gets the amount of RPL the node owner must deposit
     function getNodeDepositRPL() public view returns(uint256) {
         return node.depositRPL;
+    }
+
+    /// @dev Gets the node's trusted status (at the time of minipool creation)
+    function getNodeTrusted() public view returns(bool) {
+        return node.trusted;
     }
 
     // Methods

--- a/contracts/interface/RocketNodeInterface.sol
+++ b/contracts/interface/RocketNodeInterface.sol
@@ -1,0 +1,7 @@
+pragma solidity 0.4.24;
+
+contract RocketNodeInterface {
+    function getRandomAvailableNode(uint256 _nonce) public view returns (address, bool);
+    function setNodeAvailable(address _nodeOwner, bool _trusted) public;
+    function setNodeUnavailable(address _nodeOwner, bool _trusted) public;
+}

--- a/contracts/interface/RocketPoolInterface.sol
+++ b/contracts/interface/RocketPoolInterface.sol
@@ -2,8 +2,7 @@ pragma solidity 0.4.24;
 
 
 contract RocketPoolInterface {
-	function getRandomAvailableNode(uint256 _nonce) public view returns (address, bool);
-	function getRandomAvailableMinipool(uint256 _nonce) public view returns (address);
+    function getRandomAvailableMinipool(uint256 _nonce) public view returns (address);
     function minipoolCreate(address _nodeOwner, string _durationID, uint256 _etherAmount, uint256 _rplAmount, bool _isTrustedNode) external returns (address);
     function minipoolRemove(address _minipool) public returns (bool);
     function minipoolRemoveCheck(address _sender, address _minipool) public returns (bool);

--- a/contracts/interface/RocketPoolInterface.sol
+++ b/contracts/interface/RocketPoolInterface.sol
@@ -2,7 +2,8 @@ pragma solidity 0.4.24;
 
 
 contract RocketPoolInterface {
-	function getRandomAvailableNode(uint256 _nonce) public view returns (address);
+	function getRandomAvailableNode(uint256 _nonce) public view returns (address, bool);
+	function getRandomAvailableMinipool(uint256 _nonce) public view returns (address);
     function minipoolCreate(address _nodeOwner, string _durationID, uint256 _etherAmount, uint256 _rplAmount, bool _isTrustedNode) external returns (address);
     function minipoolRemove(address _minipool) public returns (bool);
     function minipoolRemoveCheck(address _sender, address _minipool) public returns (bool);

--- a/contracts/interface/RocketPoolInterface.sol
+++ b/contracts/interface/RocketPoolInterface.sol
@@ -2,6 +2,7 @@ pragma solidity 0.4.24;
 
 
 contract RocketPoolInterface {
+	function getRandomAvailableNode(uint256 _nonce) public view returns (address);
     function minipoolCreate(address _nodeOwner, string _durationID, uint256 _etherAmount, uint256 _rplAmount, bool _isTrustedNode) external returns (address);
     function minipoolRemove(address _minipool) public returns (bool);
     function minipoolRemoveCheck(address _sender, address _minipool) public returns (bool);

--- a/contracts/interface/minipool/RocketMinipoolInterface.sol
+++ b/contracts/interface/minipool/RocketMinipoolInterface.sol
@@ -7,6 +7,7 @@ contract RocketMinipoolInterface {
     function getNodeContract() public view returns(address);
     function getNodeDepositEther() public view returns(uint256);
     function getNodeDepositRPL() public view returns(uint256);
+    function getNodeTrusted() public view returns(bool);
     function getUserCount() public view returns(uint256);
     function getStatus() public view returns(uint8);
     function getStakingDuration() public view returns(uint256);

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -19,6 +19,7 @@ const contracts = {};
 // Core
 contracts.rocketPool = artifacts.require('./RocketPool.sol');
 contracts.rocketRole = artifacts.require('./RocketRole.sol');
+contracts.rocketNode = artifacts.require('./RocketNode.sol');
 contracts.rocketPIP = artifacts.require('./RocketPIP.sol');
 // API
 contracts.rocketDepositAPI = artifacts.require('./api/RocketDepositAPI.sol');


### PR DESCRIPTION
- The management of the "available nodes" indexes (for both trusted & untrusted) has been moved to a root RocketNode class
- The "getRandomAvailableNode" method has been moved there too
- Added a "getRandomAvailableMinipool" method to RocketPool which gets a random node and then its first minipool of the appropriate trusted/untrusted status
- Nodes can be in both the trusted & untrusted indexes at the same time
- RocketDeposit.assignChunks has been opened up publicly but is restricted to super users