### PR TITLE
Rocket two group

### DIFF
--- a/contracts/RocketNode.sol
+++ b/contracts/RocketNode.sol
@@ -28,26 +28,26 @@ contract RocketNode is RocketBase {
 
 
     /// @dev Get the total number of available nodes (must have one or more available minipools)
-    function getAvailableNodeCount() public returns (uint256) {
+    function getAvailableNodeCount(string _durationID) public returns (uint256) {
         addressSetStorage = AddressSetStorageInterface(getContractAddress("utilAddressSetStorage"));
         return
-            addressSetStorage.getCount(keccak256(abi.encodePacked("nodes.available", "trusted", false))) +
-            addressSetStorage.getCount(keccak256(abi.encodePacked("nodes.available", "trusted", true)));
+            addressSetStorage.getCount(keccak256(abi.encodePacked("nodes.available", false, _durationID))) +
+            addressSetStorage.getCount(keccak256(abi.encodePacked("nodes.available", true, _durationID)));
     }
 
 
     /// @dev Get the address of a pseudorandom available node
     /// @return The node address and trusted status
-    function getRandomAvailableNode(uint256 _nonce) public returns (address, bool) {
+    function getRandomAvailableNode(string _durationID, uint256 _nonce) public returns (address, bool) {
         // Get contracts
         addressSetStorage = AddressSetStorageInterface(getContractAddress("utilAddressSetStorage"));
         // Get node set type
         bool trusted;
-        if (addressSetStorage.getCount(keccak256(abi.encodePacked("nodes.available", "trusted", false))) > 0) { trusted = false; } // Use untrusted nodes if available
-        else if (addressSetStorage.getCount(keccak256(abi.encodePacked("nodes.available", "trusted", true))) > 0) { trusted = true; } // Use trusted nodes if available
+        if (addressSetStorage.getCount(keccak256(abi.encodePacked("nodes.available", false, _durationID))) > 0) { trusted = false; } // Use untrusted nodes if available
+        else if (addressSetStorage.getCount(keccak256(abi.encodePacked("nodes.available", true, _durationID))) > 0) { trusted = true; } // Use trusted nodes if available
         else { return (0x0, false); } // No nodes available
         // Get random node from set
-        bytes32 key = keccak256(abi.encodePacked("nodes.available", "trusted", trusted));
+        bytes32 key = keccak256(abi.encodePacked("nodes.available", trusted, _durationID));
         uint256 nodeCount = addressSetStorage.getCount(key);
         uint256 randIndex = uint256(keccak256(abi.encodePacked(block.number, block.timestamp, _nonce))) % nodeCount;
         return (addressSetStorage.getItem(key, randIndex), trusted);
@@ -59,20 +59,20 @@ contract RocketNode is RocketBase {
 
     /// @dev Set node availabile
     /// @dev Adds the node to the available index if not already present
-    function setNodeAvailable(address _nodeOwner, bool _trusted) public onlyLatestContract("rocketPool", msg.sender) {
+    function setNodeAvailable(address _nodeOwner, bool _trusted, string _durationID) public onlyLatestContract("rocketPool", msg.sender) {
         addressSetStorage = AddressSetStorageInterface(getContractAddress("utilAddressSetStorage"));
-        if (addressSetStorage.getIndexOf(keccak256(abi.encodePacked("nodes.available", "trusted", _trusted)), _nodeOwner) == -1) {
-            addressSetStorage.addItem(keccak256(abi.encodePacked("nodes.available", "trusted", _trusted)), _nodeOwner);
+        if (addressSetStorage.getIndexOf(keccak256(abi.encodePacked("nodes.available", _trusted, _durationID)), _nodeOwner) == -1) {
+            addressSetStorage.addItem(keccak256(abi.encodePacked("nodes.available", _trusted, _durationID)), _nodeOwner);
         }
     }
 
 
     /// @dev Set node unavailabile
     /// @dev Removes the node from the available index if already present
-    function setNodeUnavailable(address _nodeOwner, bool _trusted) public onlyLatestContract("rocketPool", msg.sender) {
+    function setNodeUnavailable(address _nodeOwner, bool _trusted, string _durationID) public onlyLatestContract("rocketPool", msg.sender) {
         addressSetStorage = AddressSetStorageInterface(getContractAddress("utilAddressSetStorage"));
-        if (addressSetStorage.getIndexOf(keccak256(abi.encodePacked("nodes.available", "trusted", _trusted)), _nodeOwner) != -1) {
-            addressSetStorage.removeItem(keccak256(abi.encodePacked("nodes.available", "trusted", _trusted)), _nodeOwner);
+        if (addressSetStorage.getIndexOf(keccak256(abi.encodePacked("nodes.available", _trusted, _durationID)), _nodeOwner) != -1) {
+            addressSetStorage.removeItem(keccak256(abi.encodePacked("nodes.available", _trusted, _durationID)), _nodeOwner);
         }
     }
 

--- a/contracts/RocketNode.sol
+++ b/contracts/RocketNode.sol
@@ -27,6 +27,15 @@ contract RocketNode is RocketBase {
     /*** Getters *************/
 
 
+    /// @dev Get the total number of available nodes (must have one or more available minipools)
+    function getAvailableNodeCount() public returns (uint256) {
+        addressSetStorage = AddressSetStorageInterface(getContractAddress("utilAddressSetStorage"));
+        return
+            addressSetStorage.getCount(keccak256(abi.encodePacked("nodes.available", "trusted", false))) +
+            addressSetStorage.getCount(keccak256(abi.encodePacked("nodes.available", "trusted", true)));
+    }
+
+
     /// @dev Get the address of a pseudorandom available node
     /// @return The node address and trusted status
     function getRandomAvailableNode(uint256 _nonce) public returns (address, bool) {

--- a/contracts/contract/api/RocketDepositAPI.sol
+++ b/contracts/contract/api/RocketDepositAPI.sol
@@ -4,6 +4,7 @@ pragma solidity 0.4.24;
 import "../../RocketBase.sol";
 import "../../interface/api/RocketGroupAPIInterface.sol";
 import "../../interface/deposit/RocketDepositInterface.sol";
+import "../../interface/group/RocketGroupContractInterface.sol";
 import "../../interface/settings/RocketDepositSettingsInterface.sol";
 import "../../interface/settings/RocketMinipoolSettingsInterface.sol";
 
@@ -79,8 +80,9 @@ contract RocketDepositAPI is RocketBase {
         require(address(_userID) != address(0x0), "UserID address is not a correct address");
         // Verify the groupID exists
         require(bytes(rocketGroupAPI.getGroupName(_groupID)).length > 0, "Group ID specified does not match a group name or does not exist");
-        // Verify the _from belongs to the groupID, only these addresses that belong to the group can interact with RP
-        require(rocketStorage.getAddress(keccak256(abi.encodePacked("group.address", _from))) != address(0x0), "Group ID specified does not have any address that matches the sender.");
+        // Verify that _from is a depositor of the group
+        RocketGroupContractInterface rocketGroup = RocketGroupContractInterface(_groupID);
+        require(rocketGroup.hasDepositor(_from), "Group ID specified does not have a depositor matching the sender.");
         // All good
         return true;
     }

--- a/contracts/contract/api/RocketGroupAPI.sol
+++ b/contracts/contract/api/RocketGroupAPI.sol
@@ -73,12 +73,6 @@ contract RocketGroupAPI is RocketBase {
         // Get the group name
         return rocketStorage.getString(keccak256(abi.encodePacked("group.name", _ID)));
     }
-
-    /// @dev Get a verified address for the group that's allowed to interact with RP
-    function getGroupDepositAddress(address _ID) public view returns(address) { 
-        // Get the deposit address
-        return rocketStorage.getAddress(keccak256(abi.encodePacked("group.deposit.address", _ID)));
-    }
     
 
     /*** Methods *************/
@@ -114,8 +108,6 @@ contract RocketGroupAPI is RocketBase {
         rocketStorage.setAddress(keccak256(abi.encodePacked("group.id", newContractAddress)), newContractAddress);
         rocketStorage.setString(keccak256(abi.encodePacked("group.name", newContractAddress)), _name);
         rocketStorage.setUint(keccak256(abi.encodePacked("group.fee", newContractAddress)), rocketGroupSettings.getDefaultFee());
-        // Add msg.sender as a depositer for this group initially
-        rocketStorage.setAddress(keccak256(abi.encodePacked("group.deposit.address", msg.sender)), msg.sender);
         // We store our data in an key/value array, so set its index so we can use an array to find it if needed
         rocketStorage.setUint(keccak256(abi.encodePacked("group.index", newContractAddress)), groupCountTotal);
         // Update total partners

--- a/contracts/contract/api/RocketGroupAPI.sol
+++ b/contracts/contract/api/RocketGroupAPI.sol
@@ -3,6 +3,7 @@ pragma solidity 0.4.24;
 // Contracts
 import "../../RocketBase.sol";
 import "../../contract/group/RocketGroupContract.sol";
+import "../../contract/group/RocketGroupAccessorContract.sol";
 // Interfaces
 import "../../interface/settings/RocketGroupSettingsInterface.sol";
 import "../../interface/utils/lists/AddressSetStorageInterface.sol";
@@ -42,6 +43,12 @@ contract RocketGroupAPI is RocketBase {
         string name,
         uint256 amount,
         address sentAddress,
+        uint256 created
+    );
+
+    event GroupCreateDefaultAccessor (
+        address indexed ID,
+        address accessorAddress,
         uint256 created
     );
 
@@ -112,11 +119,25 @@ contract RocketGroupAPI is RocketBase {
         // Set the name as being used now
         rocketStorage.setString(keccak256(abi.encodePacked("group.name", _name)), _name);
         // Store our group address as an index set
-        addressSetStorage.addItem(keccak256(abi.encodePacked("groups", "list")), newContractAddress); 
+        addressSetStorage.addItem(keccak256("groups.list"), newContractAddress); 
         // Log it
         emit GroupAdd(newContractAddress, _name, _stakingFee, now);
         // Done
         return true;
     }
+
+
+    /// @dev Create a new default group accessor contract
+    function createDefaultAccessor(address _ID) public onlyLatestContract("rocketGroupAPI", address(this)) returns (bool) {
+        // Check that the group exists
+        require(rocketStorage.getAddress(keccak256(abi.encodePacked("group.id", _ID))) != 0x0);
+        // Create accessor contract
+        RocketGroupAccessorContract newAccessorAddress = new RocketGroupAccessorContract(address(rocketStorage), _ID);
+        // Emit creation event
+        emit GroupCreateDefaultAccessor(_ID, newAccessorAddress, now);
+        // Success
+        return true;
+    }
+
 
 }

--- a/contracts/contract/api/RocketNodeAPI.sol
+++ b/contracts/contract/api/RocketNodeAPI.sol
@@ -222,8 +222,6 @@ contract RocketNodeAPI is RocketBase {
         require(!rocketStorage.getBool(keccak256(abi.encodePacked("node.exists", msg.sender))), "Node address already exists in the Rocket Pool network.");
         // Ok create the nodes contract now, this is the address where their ether/rpl deposits will reside
         address newContractAddress = rocketNodeFactory.createRocketNodeContract(msg.sender);
-        // Get how many nodes we currently have  
-        uint256 nodeCountTotal = rocketStorage.getUint(keccak256("nodes.total")); 
         // Make sure we can find the node contract address via its owner
         rocketStorage.setAddress(keccak256(abi.encodePacked("node.contract", msg.sender)), newContractAddress);
         // Ok now set our node data to key/value pair storage

--- a/contracts/contract/deposit/RocketDeposit.sol
+++ b/contracts/contract/deposit/RocketDeposit.sol
@@ -85,7 +85,7 @@ contract RocketDeposit is RocketBase {
         uint256 chunkAssignments = 0;
         while (
             rocketStorage.getUint(keccak256(abi.encodePacked("deposits.queue.balance", _durationID))) >= chunkSize && // Duration queue balance high enough to assign chunk
-            rocketNode.getAvailableNodeCount() > 0 && // Nodes (and minipools) are available for assignment
+            rocketNode.getAvailableNodeCount(_durationID) > 0 && // Nodes (and minipools) with duration are available for assignment
             chunkAssignments++ < maxChunkAssignments // Only assign up to maximum number of chunks
         ) {
             assignChunk(_durationID);
@@ -105,8 +105,7 @@ contract RocketDeposit is RocketBase {
         bytes32QueueStorage = Bytes32QueueStorageInterface(getContractAddress("utilBytes32QueueStorage"));
 
         // Get random available minipool to assign chunk to
-        // TODO: ensure minipool has matching staking duration
-        address miniPoolAddress = rocketPool.getRandomAvailableMinipool(msg.value);
+        address miniPoolAddress = rocketPool.getRandomAvailableMinipool(_durationID, msg.value);
         RocketMinipoolInterface miniPool = RocketMinipoolInterface(miniPoolAddress);
 
         // Check available minipool address

--- a/contracts/contract/group/RocketGroupAccessorContract.sol
+++ b/contracts/contract/group/RocketGroupAccessorContract.sol
@@ -1,0 +1,62 @@
+pragma solidity 0.4.24;
+
+
+import "./../../interface/RocketStorageInterface.sol";
+import "../../interface/api/RocketDepositAPIInterface.sol";
+
+
+/// @dev The contract for a default group accessor (depositor & withdrawer) implementation
+/// @dev Allows any address to deposit to and withdraw from Rocket Pool through the group
+/// @dev Must be manually assigned to the group as a depositor and withdrawer
+/// @author Jake Pospischil
+
+contract RocketGroupAccessorContract {
+
+
+    /**** Properties ***********/
+
+
+    uint8 public version;                                                       // Version of this contract
+    address public groupID;                                                     // The address of the associated group contract
+
+
+    /*** Contracts ***************/
+
+
+    RocketStorageInterface rocketStorage = RocketStorageInterface(0);           // The main Rocket Pool storage contract where primary persistant storage is maintained
+    RocketDepositAPIInterface rocketDepositAPI = RocketDepositAPIInterface(0);  // The Rocket Pool Deposit API
+
+
+    /*** Constructor *************/
+
+
+    /// @dev RocketGroupAccessorContract Constructor
+    constructor(address _rocketStorageAddress, address _groupID) {
+        // Initialise properties
+        version = 1;
+        groupID = _groupID;
+        // Initialise RocketStorage
+        rocketStorage = RocketStorageInterface(_rocketStorageAddress);
+    }
+
+
+    /*** Methods *************/
+
+
+    /// @dev Make a deposit through the Rocket Pool Deposit API
+    /// @param _durationID The ID of the staking duration that the user wishes to stake for (3 months, 6 months etc)
+    function deposit(string _durationID) public payable returns (bool) {
+        // Get deposit API
+        rocketDepositAPI = RocketDepositAPIInterface(rocketStorage.getAddress(keccak256(abi.encodePacked("contract.name", "rocketDepositAPI"))));
+        // Perform deposit
+        require(rocketDepositAPI.deposit.value(msg.value)(groupID, msg.sender, _durationID), "The deposit was not made successfully");
+        // Return success flag
+        return true;
+    }
+
+
+    /// @dev Make a withdrawal through the Rocket Pool Withdrawal API
+    /// TODO: implement
+
+
+}

--- a/contracts/contract/group/RocketGroupAccessorContract.sol
+++ b/contracts/contract/group/RocketGroupAccessorContract.sol
@@ -31,7 +31,7 @@ contract RocketGroupAccessorContract {
 
 
     /// @dev RocketGroupAccessorContract Constructor
-    constructor(address _rocketStorageAddress, address _groupID) {
+    constructor(address _rocketStorageAddress, address _groupID) public {
         // Initialise properties
         version = 1;
         groupID = _groupID;

--- a/contracts/contract/minipool/RocketMinipool.sol
+++ b/contracts/contract/minipool/RocketMinipool.sol
@@ -275,8 +275,7 @@ contract RocketMinipool {
     /// @dev Deposit a users ether to this contract. Will register the user if they don't exist in this contract already.
     /// @param _user New user address
     /// @param _groupID The 3rd party group the user belongs too
-    /// @param _groupDepositor The 3rd party group address that is making this deposit
-    function deposit(address _user, address _groupID, address _groupDepositor) public payable onlyLatestContract("rocketDeposit") returns(bool) {
+    function deposit(address _user, address _groupID) public payable onlyLatestContract("rocketDeposit") returns(bool) {
         // Will throw if conditions are not met in delegate or call fails
         require(getContractAddress("rocketPoolMiniDelegate").delegatecall(getDelegateSignature("deposit(address,address,address)"), _user, _groupID, _groupDepositor), "Delegate call failed.");
     }

--- a/contracts/contract/minipool/RocketMinipool.sol
+++ b/contracts/contract/minipool/RocketMinipool.sol
@@ -307,6 +307,11 @@ contract RocketMinipool {
         return status.changed;
     }
 
+    /// @dev Returns the current staking duration ID
+    function getStakingDurationID() public view returns(string) {
+        return staking.id;
+    }
+
     /// @dev Returns the current staking duration in blocks
     function getStakingDuration() public view returns(uint256) {
         return staking.duration;

--- a/contracts/contract/minipool/RocketMinipool.sol
+++ b/contracts/contract/minipool/RocketMinipool.sol
@@ -277,7 +277,7 @@ contract RocketMinipool {
     /// @param _groupID The 3rd party group the user belongs too
     function deposit(address _user, address _groupID) public payable onlyLatestContract("rocketDeposit") returns(bool) {
         // Will throw if conditions are not met in delegate or call fails
-        require(getContractAddress("rocketPoolMiniDelegate").delegatecall(getDelegateSignature("deposit(address,address,address)"), _user, _groupID, _groupDepositor), "Delegate call failed.");
+        require(getContractAddress("rocketPoolMiniDelegate").delegatecall(getDelegateSignature("deposit(address,address,address)"), _user, _groupID), "Delegate call failed.");
     }
 
     

--- a/contracts/interface/RocketNodeInterface.sol
+++ b/contracts/interface/RocketNodeInterface.sol
@@ -1,7 +1,8 @@
 pragma solidity 0.4.24;
 
 contract RocketNodeInterface {
-    function getRandomAvailableNode(uint256 _nonce) public view returns (address, bool);
+	function getAvailableNodeCount() public returns (uint256);
+    function getRandomAvailableNode(uint256 _nonce) public returns (address, bool);
     function setNodeAvailable(address _nodeOwner, bool _trusted) public;
     function setNodeUnavailable(address _nodeOwner, bool _trusted) public;
 }

--- a/contracts/interface/RocketNodeInterface.sol
+++ b/contracts/interface/RocketNodeInterface.sol
@@ -1,8 +1,8 @@
 pragma solidity 0.4.24;
 
 contract RocketNodeInterface {
-	function getAvailableNodeCount() public returns (uint256);
-    function getRandomAvailableNode(uint256 _nonce) public returns (address, bool);
-    function setNodeAvailable(address _nodeOwner, bool _trusted) public;
-    function setNodeUnavailable(address _nodeOwner, bool _trusted) public;
+	function getAvailableNodeCount(string _durationID) public returns (uint256);
+    function getRandomAvailableNode(string _durationID, uint256 _nonce) public returns (address, bool);
+    function setNodeAvailable(address _nodeOwner, bool _trusted, string _durationID) public;
+    function setNodeUnavailable(address _nodeOwner, bool _trusted, string _durationID) public;
 }

--- a/contracts/interface/RocketPoolInterface.sol
+++ b/contracts/interface/RocketPoolInterface.sol
@@ -2,7 +2,7 @@ pragma solidity 0.4.24;
 
 
 contract RocketPoolInterface {
-    function getRandomAvailableMinipool(uint256 _nonce) public view returns (address);
+    function getRandomAvailableMinipool(string _durationID, uint256 _nonce) public view returns (address);
     function minipoolCreate(address _nodeOwner, string _durationID, uint256 _etherAmount, uint256 _rplAmount, bool _isTrustedNode) external returns (address);
     function minipoolRemove(address _minipool) public returns (bool);
     function minipoolRemoveCheck(address _sender, address _minipool) public returns (bool);

--- a/contracts/interface/api/RocketDepositAPIInterface.sol
+++ b/contracts/interface/api/RocketDepositAPIInterface.sol
@@ -5,4 +5,6 @@ pragma solidity 0.4.24;
 contract RocketDepositAPIInterface {
     // Getters
     function getDepositIsValid(uint256 _value, address _from, address _groupID, address _userID, string _durationID) public returns(bool);
+    // Methods
+    function deposit(address _groupID, address _userID, string _durationID) public payable returns(bool);
 }

--- a/contracts/interface/group/RocketGroupContractInterface.sol
+++ b/contracts/interface/group/RocketGroupContractInterface.sol
@@ -5,4 +5,6 @@ pragma solidity 0.4.24;
 contract RocketGroupContractInterface {
     // Getters
     function getFeePerc() public view returns(uint256);
+    function hasDepositor(address _depositorAddress) public view returns (bool);
+    function hasWithdrawer(address _withdrawerAddress) public view returns (bool);
 }

--- a/contracts/interface/minipool/RocketMinipoolInterface.sol
+++ b/contracts/interface/minipool/RocketMinipoolInterface.sol
@@ -11,6 +11,7 @@ contract RocketMinipoolInterface {
     function getUserCount() public view returns(uint256);
     function getStatus() public view returns(uint8);
     function getStatusChanged() public view returns(uint256);
+    function getStakingDurationID() public view returns(string);
     function getStakingDuration() public view returns(uint256);
     // Methods
     function nodeDeposit() public payable returns(bool);

--- a/contracts/interface/minipool/RocketMinipoolInterface.sol
+++ b/contracts/interface/minipool/RocketMinipoolInterface.sol
@@ -13,5 +13,6 @@ contract RocketMinipoolInterface {
     function getStakingDuration() public view returns(uint256);
     // Methods
     function nodeDeposit() public payable returns(bool);
+    function deposit(address _user, address _groupID) public payable returns(bool);
     function closePool() public returns(bool);
 }

--- a/test/rocket-group/rocket-group-api-scenarios.js
+++ b/test/rocket-group/rocket-group-api-scenarios.js
@@ -22,7 +22,30 @@ export async function scenarioAddGroup({name, stakingFee, value, fromAddress, ga
     let feeBalance2 = parseInt(await web3.eth.getBalance(feeAddress));
 
     // Asserts
-    assert.equal(result.logs.filter(log => (log.event == 'GroupAdd')).length, 1, 'Group was not created successfully');
+    let groupAddEvents = result.logs.filter(log => (log.event == 'GroupAdd'));
+    assert.equal(groupAddEvents.length, 1, 'Group was not created successfully');
     assert.isTrue(feeBalance2 > feeBalance1, 'Creation fee balance was not transferred successfully');
 
+    // Return group ID
+    return groupAddEvents[0].args.ID;
+
 }
+
+
+// Create a default group accessor
+export async function scenarioCreateDefaultGroupAccessor({groupID, fromAddress, gas}) {
+    const rocketGroupAPI = await RocketGroupAPI.deployed();
+
+    // Create accessor
+    let result = await rocketGroupAPI.createDefaultAccessor(groupID, {from: fromAddress, gas: gas});
+    profileGasUsage('RocketGroupAPI.createDefaultAccessor', result);
+
+    // Asserts
+    let groupCreateAccessorEvents = result.logs.filter(log => (log.event == 'GroupCreateDefaultAccessor'));
+    assert.equal(groupCreateAccessorEvents.length, 1, 'Accessor was not created successfully');
+
+    // Return accessor address
+    return groupCreateAccessorEvents[0].args.accessorAddress;
+
+}
+

--- a/test/rocket-group/rocket-group-api-tests.js
+++ b/test/rocket-group/rocket-group-api-tests.js
@@ -1,6 +1,6 @@
 import { printTitle, assertThrows } from '../_lib/utils/general';
 import { RocketGroupSettings } from '../_lib/artifacts';
-import { scenarioAddGroup } from './rocket-group-api-scenarios';
+import { scenarioAddGroup, scenarioCreateDefaultGroupAccessor } from './rocket-group-api-scenarios';
 
 export default function() {
 
@@ -10,6 +10,11 @@ export default function() {
         // Accounts
         const owner = accounts[0];
         const groupOwner = accounts[1];
+        const groupAdmin = accounts[2];
+
+
+        // Group
+        let groupID;
 
 
         // Setup
@@ -28,7 +33,7 @@ export default function() {
 
         // Group owner can add a group
         it(printTitle('group owner', 'can add a group'), async () => {
-            await scenarioAddGroup({
+            groupID = await scenarioAddGroup({
                 name: 'Group 1',
                 stakingFee: web3.utils.toWei('0.05', 'ether'),
                 value: newGroupFee,
@@ -116,6 +121,26 @@ export default function() {
             // Re-enable registrations
             rocketGroupSettings.setNewAllowed(true, {from: owner, gas: 500000});
 
+        });
+
+
+        // Random account can create a default group accessor
+        it(printTitle('random account', 'can create a default group accessor'), async () => {
+            await scenarioCreateDefaultGroupAccessor({
+                groupID,
+                fromAddress: groupAdmin,
+                gas: 7500000,
+            });
+        });
+
+
+        // Random account cannot create a default group accessor with an invalid group ID
+        it(printTitle('random account', 'cannot create a default group accessor with an invalid group ID'), async () => {
+            await assertThrows(scenarioCreateDefaultGroupAccessor({
+                groupID: accounts[9],
+                fromAddress: groupAdmin,
+                gas: 7500000,
+            }));
         });
 
 

--- a/test/rocket-group/rocket-group-contract-scenarios.js
+++ b/test/rocket-group/rocket-group-contract-scenarios.js
@@ -11,3 +11,64 @@ export async function scenarioSetFeePerc({groupContract, stakingFee, fromAddress
     assert.equal(feePerc, stakingFee, 'Staking fee was not successfully updated');
 
 }
+
+
+// Add a depositor to the group
+export async function scenarioAddDepositor({groupContract, depositorAddress, fromAddress, gas}) {
+
+    // Add depositor
+    await groupContract.addDepositor(depositorAddress, {from: fromAddress, gas: gas});
+
+    // Check depositor
+    let hasDepositor = await groupContract.hasDepositor.call(depositorAddress);
+
+    // Asserts
+    assert.isTrue(hasDepositor, 'Depositor was not added successfully');
+
+}
+
+
+// Remove a depositor from the group
+export async function scenarioRemoveDepositor({groupContract, depositorAddress, fromAddress, gas}) {
+
+    // Remove depositor
+    await groupContract.removeDepositor(depositorAddress, {from: fromAddress, gas: gas});
+
+    // Check depositor
+    let hasDepositor = await groupContract.hasDepositor.call(depositorAddress);
+
+    // Asserts
+    assert.isFalse(hasDepositor, 'Depositor was not removed successfully');
+
+}
+
+
+// Add a withdrawer to the group
+export async function scenarioAddWithdrawer({groupContract, withdrawerAddress, fromAddress, gas}) {
+
+    // Add withdrawer
+    await groupContract.addWithdrawer(withdrawerAddress, {from: fromAddress, gas: gas});
+
+    // Check withdrawer
+    let hasWithdrawer = await groupContract.hasWithdrawer.call(withdrawerAddress);
+
+    // Asserts
+    assert.isTrue(hasWithdrawer, 'Withdrawer was not added successfully');
+
+}
+
+
+// Remove a withdrawer from the group
+export async function scenarioRemoveWithdrawer({groupContract, withdrawerAddress, fromAddress, gas}) {
+
+    // Remove withdrawer
+    await groupContract.removeWithdrawer(withdrawerAddress, {from: fromAddress, gas: gas});
+
+    // Check withdrawer
+    let hasWithdrawer = await groupContract.hasWithdrawer.call(withdrawerAddress);
+
+    // Asserts
+    assert.isFalse(hasWithdrawer, 'Withdrawer was not removed successfully');
+
+}
+

--- a/test/rocket-group/rocket-group-contract-tests.js
+++ b/test/rocket-group/rocket-group-contract-tests.js
@@ -1,6 +1,6 @@
 import { printTitle, assertThrows } from '../_lib/utils/general';
 import { RocketGroupAPI, RocketGroupContract, RocketGroupSettings } from '../_lib/artifacts';
-import { scenarioSetFeePerc } from './rocket-group-contract-scenarios';
+import { scenarioSetFeePerc, scenarioAddDepositor, scenarioRemoveDepositor, scenarioAddWithdrawer, scenarioRemoveWithdrawer } from './rocket-group-contract-scenarios';
 
 export default function() {
 
@@ -14,6 +14,9 @@ export default function() {
 
         // Setup
         let groupContract;
+        let accessor1Address;
+        let accessor2Address;
+        let accessor3Address;
         before(async () => {
 
             // Get new group fee
@@ -22,11 +25,21 @@ export default function() {
 
             // Create group
             let rocketGroupAPI = await RocketGroupAPI.deployed();
-            let result = await rocketGroupAPI.add('Group 1', web3.utils.toWei('0', 'ether'), {from: groupOwner, gas: 7500000, value: newGroupFee});
+            let groupResult = await rocketGroupAPI.add('Group 1', web3.utils.toWei('0', 'ether'), {from: groupOwner, gas: 7500000, value: newGroupFee});
 
             // Get group contract
-            let groupContractAddress = result.logs.filter(log => (log.event == 'GroupAdd'))[0].args.ID;
+            let groupContractAddress = groupResult.logs.filter(log => (log.event == 'GroupAdd'))[0].args.ID;
             groupContract = await RocketGroupContract.at(groupContractAddress);
+
+            // Create default accessor contracts
+            let accessorResult1 = await rocketGroupAPI.createDefaultAccessor(groupContractAddress, {from: groupOwner, gas: 7500000});
+            let accessorResult2 = await rocketGroupAPI.createDefaultAccessor(groupContractAddress, {from: groupOwner, gas: 7500000});
+            let accessorResult3 = await rocketGroupAPI.createDefaultAccessor(groupContractAddress, {from: groupOwner, gas: 7500000});
+
+            // Get accessor contract addresses
+            accessor1Address = accessorResult1.logs.filter(log => (log.event == 'GroupCreateDefaultAccessor'))[0].args.accessorAddress;
+            accessor2Address = accessorResult2.logs.filter(log => (log.event == 'GroupCreateDefaultAccessor'))[0].args.accessorAddress;
+            accessor3Address = accessorResult3.logs.filter(log => (log.event == 'GroupCreateDefaultAccessor'))[0].args.accessorAddress;
 
         });
 
@@ -50,6 +63,183 @@ export default function() {
                 fromAddress: groupOwner,
                 gas: 500000,
             }), 'Set an invalid fee percentage');
+        });
+
+
+        // Random account cannot set the group's fee percentage
+        it(printTitle('random account', 'cannot set the group\'s fee percentage'), async () => {
+            await assertThrows(scenarioSetFeePerc({
+                groupContract,
+                stakingFee: web3.utils.toWei('0.1', 'ether'),
+                fromAddress: accounts[9],
+                gas: 500000,
+            }), 'Random account set the group\'s fee percentage');
+        });
+
+
+        // Group owner can add a depositor to the group
+        it(printTitle('group owner', 'can add a depositor to the group'), async () => {
+            await scenarioAddDepositor({
+                groupContract,
+                depositorAddress: accessor1Address,
+                fromAddress: groupOwner,
+                gas: 500000,
+            });
+            await scenarioAddDepositor({
+                groupContract,
+                depositorAddress: accessor2Address,
+                fromAddress: groupOwner,
+                gas: 500000,
+            });
+        });
+
+
+        // Group owner cannot add an existing depositor to the group
+        it(printTitle('group owner', 'cannot add an existing depositor to the group'), async () => {
+            await assertThrows(scenarioAddDepositor({
+                groupContract,
+                depositorAddress: accessor1Address,
+                fromAddress: groupOwner,
+                gas: 500000,
+            }), 'Added an existing depositor to the group');
+        });
+
+
+        // Random account cannot add a depositor to the group
+        it(printTitle('random account', 'cannot add a depositor to the group'), async () => {
+            await assertThrows(scenarioAddDepositor({
+                groupContract,
+                depositorAddress: accessor3Address,
+                fromAddress: accounts[9],
+                gas: 500000,
+            }), 'Random account added a depositor to the group');
+        });
+
+
+        // Group owner can remove a depositor from the group
+        it(printTitle('group owner', 'can remove a depositor from the group'), async () => {
+            await scenarioRemoveDepositor({
+                groupContract,
+                depositorAddress: accessor2Address,
+                fromAddress: groupOwner,
+                gas: 500000,
+            });
+        });
+
+
+        // Group owner cannot remove a nonexistant depositor from the group
+        it(printTitle('group owner', 'cannot remove a nonexistant depositor from the group'), async () => {
+            await assertThrows(scenarioRemoveDepositor({
+                groupContract,
+                depositorAddress: accessor2Address,
+                fromAddress: groupOwner,
+                gas: 500000,
+            }), 'Removed a nonexistant depositor from the group');
+        });
+
+
+        // Random account cannot remove a depositor from the group
+        it(printTitle('random account', 'cannot remove a depositor from the group'), async () => {
+            await assertThrows(scenarioRemoveDepositor({
+                groupContract,
+                depositorAddress: accessor1Address,
+                fromAddress: accounts[9],
+                gas: 500000,
+            }), 'Random account removed a depositor from the group');
+        });
+
+
+        // Group owner can add a withdrawer to the group
+        it(printTitle('group owner', 'can add a withdrawer to the group'), async () => {
+            await scenarioAddWithdrawer({
+                groupContract,
+                withdrawerAddress: accessor1Address,
+                fromAddress: groupOwner,
+                gas: 500000,
+            });
+            await scenarioAddWithdrawer({
+                groupContract,
+                withdrawerAddress: accessor2Address,
+                fromAddress: groupOwner,
+                gas: 500000,
+            });
+        });
+
+
+        // Group owner cannot add an existing withdrawer to the group
+        it(printTitle('group owner', 'cannot add an existing withdrawer to the group'), async () => {
+            await assertThrows(scenarioAddWithdrawer({
+                groupContract,
+                withdrawerAddress: accessor1Address,
+                fromAddress: groupOwner,
+                gas: 500000,
+            }), 'Added an existing withdrawer to the group');
+        });
+
+
+        // Random account cannot add a withdrawer to the group
+        it(printTitle('random account', 'cannot add a withdrawer to the group'), async () => {
+            await assertThrows(scenarioAddWithdrawer({
+                groupContract,
+                withdrawerAddress: accessor3Address,
+                fromAddress: accounts[9],
+                gas: 500000,
+            }), 'Random account added a withdrawer to the group');
+        });
+
+
+        // Group owner can remove a withdrawer from the group
+        it(printTitle('group owner', 'can remove a withdrawer from the group'), async () => {
+            await scenarioRemoveWithdrawer({
+                groupContract,
+                withdrawerAddress: accessor2Address,
+                fromAddress: groupOwner,
+                gas: 500000,
+            });
+        });
+
+
+        // Group owner cannot remove the last withdrawer from the group
+        it(printTitle('group owner', 'cannot remove the last withdrawer from the group'), async () => {
+
+            // Attempt removal
+            await assertThrows(scenarioRemoveWithdrawer({
+                groupContract,
+                withdrawerAddress: accessor1Address,
+                fromAddress: groupOwner,
+                gas: 500000,
+            }), 'Removed the last withdrawer from the group');
+
+            // Add withdrawer
+            await scenarioAddWithdrawer({
+                groupContract,
+                withdrawerAddress: accessor3Address,
+                fromAddress: groupOwner,
+                gas: 500000,
+            });
+
+        });
+
+
+        // Group owner cannot remove a nonexistant withdrawer from the group
+        it(printTitle('group owner', 'cannot remove a nonexistant withdrawer from the group'), async () => {
+            await assertThrows(scenarioRemoveWithdrawer({
+                groupContract,
+                withdrawerAddress: accessor2Address,
+                fromAddress: groupOwner,
+                gas: 500000,
+            }), 'Removed a nonexistant withdrawer from the group');
+        });
+
+
+        // Random account cannot remove a withdrawer from the group
+        it(printTitle('random account', 'cannot remove a withdrawer from the group'), async () => {
+            await assertThrows(scenarioRemoveWithdrawer({
+                groupContract,
+                withdrawerAddress: accessor1Address,
+                fromAddress: accounts[9],
+                gas: 500000,
+            }), 'Random account removed a withdrawer from the group');
         });
 
 


### PR DESCRIPTION
Group:
- Implemented default group accessor (depositor / withdrawer) contract
- Added Group API create accessor method
- Added Group Contract depositor / withdrawer management methods
- Implemented group accessor creation & management unit tests

Minipool:
- Removed group depositor param and DepositAPI "valid deposit" check from minipool deposit method

Node:
- Updated available node & minipool indexes to index by staking duration
- Added available node count accessor

Deposit:
- Fixed deposit API group depositor check
- Updated deposit logic to correctly deposit chunked ether to minipools

