### PR TITLE
Rocket two tests

### DIFF
--- a/contracts/RocketPool.sol
+++ b/contracts/RocketPool.sol
@@ -74,11 +74,18 @@ contract RocketPool is RocketBase {
         return rocketStorage.getBool(keccak256(abi.encodePacked("minipool.exists", _miniPoolAddress)));
     }
 
+
     /// @dev Returns a count of the current minipools
-    /// @param _miniPoolList They key of a minipool list to return the count of eg minipools.list.node or minipools.list.duration
-    function getPoolsCount(string _miniPoolList) public returns(uint256) {
+    function getPoolsCount() public returns(uint256) {
         addressSetStorage = AddressSetStorageInterface(getContractAddress("utilAddressSetStorage"));
-        return addressSetStorage.getCount(keccak256(abi.encodePacked("minipools", _miniPoolList)));
+        return addressSetStorage.getCount(keccak256(abi.encodePacked("minipools", "list")));
+    }
+
+
+    /// @dev Return a current minipool by index
+    function getPoolAt(uint256 _index) public returns (address) {
+        addressSetStorage = AddressSetStorageInterface(getContractAddress("utilAddressSetStorage"));
+        return addressSetStorage.getItem(keccak256(abi.encodePacked("minipools", "list")), _index);
     }
 
 

--- a/contracts/RocketPool.sol
+++ b/contracts/RocketPool.sol
@@ -156,7 +156,7 @@ contract RocketPool is RocketBase {
         // Get some common attributes
         uint8 status = rocketMinipool.getStatus();
         // A priority initial check - If a minipool is widowed or stuck for a long time, it is classed as timed out (it has users, not enough to begin staking, but the node owner cannot close it), it can be closed by anyone so users get their funds back
-        if(status == 1 && rocketMinipool.getStatusChanged() <= (now + rocketMinipoolSettings.getMinipoolTimeout())) {
+        if(status == 1 && rocketMinipool.getStatusChanged() <= (now - rocketMinipoolSettings.getMinipoolTimeout())) {
             return true;
         }
         // Do some common global checks

--- a/contracts/contract/api/RocketDepositAPI.sol
+++ b/contracts/contract/api/RocketDepositAPI.sol
@@ -135,6 +135,12 @@ contract RocketDepositAPI is RocketBase {
     }
 
 
+    /// @dev Get the queued balance of a user deposit
+    function getUserQueuedDepositBalance(bytes32 _depositID) public view returns (uint256) {
+        return rocketStorage.getUint(keccak256(abi.encodePacked("deposit.queuedAmount", _depositID)));
+    }
+
+
     /*** Methods *************/
 
    

--- a/contracts/contract/deposit/RocketDepositQueue.sol
+++ b/contracts/contract/deposit/RocketDepositQueue.sol
@@ -82,9 +82,7 @@ contract RocketDepositQueue is RocketBase {
 
     event DepositChunkAssign (
         bytes32 indexed _depositID,
-        address indexed _userID,
-        address indexed _groupID,
-        string  durationID,
+        address indexed _minipoolAddress,
         uint256 value,
         uint256 created
     );
@@ -266,7 +264,7 @@ contract RocketDepositQueue is RocketBase {
         require(miniPool.deposit.value(matchAmount)(userID, groupID), "Deposit could not be transferred to minipool");
 
         // Emit chunk assignment event
-        emit DepositChunkAssign(depositID, userID, groupID, _durationID, matchAmount, now);
+        emit DepositChunkAssign(depositID, _miniPoolAddress, matchAmount, now);
 
         // Dequeue deposit if queued amount depleted
         if (queuedAmount == 0) { dequeueDeposit(userID, groupID, _durationID, depositID); }

--- a/contracts/contract/deposit/RocketDepositQueue.sol
+++ b/contracts/contract/deposit/RocketDepositQueue.sol
@@ -80,7 +80,7 @@ contract RocketDepositQueue is RocketBase {
         uint256 created
     );
 
-    event DepositChunkAssign (
+    event DepositChunkFragmentAssign (
         bytes32 indexed _depositID,
         address indexed _minipoolAddress,
         uint256 value,
@@ -263,8 +263,8 @@ contract RocketDepositQueue is RocketBase {
         // Transfer matched amount to minipool contract
         require(miniPool.deposit.value(matchAmount)(userID, groupID), "Deposit could not be transferred to minipool");
 
-        // Emit chunk assignment event
-        emit DepositChunkAssign(depositID, _miniPoolAddress, matchAmount, now);
+        // Emit chunk fragment assignment event
+        emit DepositChunkFragmentAssign(depositID, _miniPoolAddress, matchAmount, now);
 
         // Dequeue deposit if queued amount depleted
         if (queuedAmount == 0) { dequeueDeposit(userID, groupID, _durationID, depositID); }

--- a/contracts/contract/minipool/RocketMinipoolDelegate.sol
+++ b/contracts/contract/minipool/RocketMinipoolDelegate.sol
@@ -62,7 +62,7 @@ contract RocketMinipoolDelegate {
         address contractAddress;                                // The nodes Rocket Pool contract
         uint256 depositEther;                                   // The nodes ether contribution
         uint256 depositRPL;                                     // The nodes RPL contribution
-        bool    trusted;                                        // Is this a trusted node?
+        bool    trusted;                                        // Was the node trusted at the time of minipool creation?
     }
 
     struct Staking {
@@ -394,10 +394,13 @@ contract RocketMinipoolDelegate {
         rocketPool = RocketPoolInterface(getContractAddress("rocketPool"));
         // Set our status now - see RocketMinipoolSettings.sol for pool statuses and keys
         rocketMinipoolSettings = RocketMinipoolSettingsInterface(getContractAddress("rocketMinipoolSettings"));
+        /*
         // Check to see if we can close the pool
+        // TODO: Fix minipool removal check and uncomment
         if (closePool()) {
             return true;
         }
+        */
         // Set to Initialised - The last user has withdrawn their deposit after it there was previous users, revert minipool status to 0 to allow node operator to retrieve funds if desired
         if (getUserCount() == 0 && status.current <= 1) {
             // No users, reset the status to awaiting deposits

--- a/contracts/contract/minipool/RocketMinipoolDelegate.sol
+++ b/contracts/contract/minipool/RocketMinipoolDelegate.sol
@@ -258,8 +258,6 @@ contract RocketMinipoolDelegate {
         rocketMinipoolSettings = RocketMinipoolSettingsInterface(getContractAddress("rocketMinipoolSettings"));
         // Make sure we are accepting deposits
         require(status.current == 0 || status.current == 1, "Minipool is not currently allowing deposits.");
-        // Make sure this deposit won't put us over the amount needed by casper, this shouldn't happen if chunking is working correctly, but double check
-        require(address(this).balance <= rocketMinipoolSettings.getMinipoolLaunchAmount(), "Deposit will overload minipools ether requirement for Casper.");
         // Add to their balance
         users[_user].balance = users[_user].balance.add(msg.value);
         // All good? Fire the event for the new deposit

--- a/contracts/interface/api/RocketDepositAPIInterface.sol
+++ b/contracts/interface/api/RocketDepositAPIInterface.sol
@@ -8,6 +8,7 @@ contract RocketDepositAPIInterface {
     function getDepositRefundIsValid(address _from, address _groupID, address _userID, string _durationID) public returns(bool);
     function getUserQueuedDepositCount(address _groupID, address _userID, string _durationID) public returns (uint256);
     function getUserQueuedDepositAt(address _groupID, address _userID, string _durationID, uint256 _index) public returns (bytes32);
+    function getUserQueuedDepositBalance(bytes32 _depositID) public view returns (uint256);
     // Methods
     function deposit(address _groupID, address _userID, string _durationID) public payable returns(bool);
     function refundDeposit(address _groupID, address _userID, string _durationID, bytes32 _depositID) public returns(uint256);

--- a/test/_helpers/rocket-deposit.js
+++ b/test/_helpers/rocket-deposit.js
@@ -1,0 +1,13 @@
+// Dependencies
+import { RocketDepositAPI } from '../_lib/artifacts';
+
+
+// Get a user's queued deposit IDs
+export async function getQueuedDepositIDs({groupID, userID, durationID}) {
+    const rocketDepositAPI = await RocketDepositAPI.deployed();
+    let depositCount = parseInt(await rocketDepositAPI.getUserQueuedDepositCount.call(groupID, userID, durationID));
+    let depositIDs = [], di;
+    for (di = 0; di < depositCount; ++di) depositIDs.push(await rocketDepositAPI.getUserQueuedDepositAt.call(groupID, userID, durationID, di));
+    return depositIDs;
+}
+

--- a/test/_helpers/rocket-group.js
+++ b/test/_helpers/rocket-group.js
@@ -1,5 +1,5 @@
 // Dependencies
-import { RocketGroupAPI, RocketGroupContract, RocketGroupSettings } from '../_lib/artifacts';
+import { RocketGroupAPI, RocketGroupContract, RocketGroupAccessorContract, RocketGroupSettings } from '../_lib/artifacts';
 
 
 // Create a new group contract
@@ -28,8 +28,10 @@ export async function createGroupAccessorContract({groupContractAddress, groupOw
     let rocketGroupAPI = await RocketGroupAPI.deployed();
     let accessorCreateResult = await rocketGroupAPI.createDefaultAccessor(groupContractAddress, {from: groupOwner, gas: 7500000});
 
-    // Return accessor address
-    return accessorCreateResult.logs.filter(log => (log.event == 'GroupCreateDefaultAccessor'))[0].args.accessorAddress;
+    // Get & return accessor contract
+    let accessorContractAddress = accessorCreateResult.logs.filter(log => (log.event == 'GroupCreateDefaultAccessor'))[0].args.accessorAddress;
+    let accessorContract = await RocketGroupAccessorContract.at(accessorContractAddress);
+    return accessorContract;
 
 }
 

--- a/test/_helpers/rocket-node-task.js
+++ b/test/_helpers/rocket-node-task.js
@@ -1,0 +1,37 @@
+// Dependencies
+import { RocketNodeTasks, RocketStorage, TestNodeTask } from '../_lib/artifacts';
+
+
+// Create a test node task contract
+export async function createTestNodeTaskContract({name, owner}) {
+
+    // Get storage
+    let rocketStorage = await RocketStorage.deployed();
+
+    // Create and return test node task contract
+    let nodeTask = await TestNodeTask.new(rocketStorage.address, name, {gas: 5000000, gasPrice: 10000000000, from: owner});
+    return nodeTask;
+
+}
+
+
+// Add a node task
+export async function addNodeTask({taskAddress, owner}) {
+    let rocketNodeTasks = await RocketNodeTasks.deployed();
+    await rocketNodeTasks.add(taskAddress, {from: owner, gas: 500000});
+}
+
+
+// Remove a node task
+export async function removeNodeTask({taskAddress, owner}) {
+    let rocketNodeTasks = await RocketNodeTasks.deployed();
+    await rocketNodeTasks.remove(taskAddress, {from: owner, gas: 500000});
+}
+
+
+// Update a node task
+export async function updateNodeTask({oldAddress, newAddress, owner}) {
+    let rocketNodeTasks = await RocketNodeTasks.deployed();
+    await rocketNodeTasks.update(oldAddress, newAddress, {from: owner, gas: 500000});
+}
+

--- a/test/_lib/artifacts.js
+++ b/test/_lib/artifacts.js
@@ -3,6 +3,7 @@ const $web3 = new $Web3('http://localhost:8545');
 
 export const RocketDepositAPI = artifacts.require('./contract/RocketDepositAPI');
 export const RocketDepositSettings = artifacts.require('./contract/RocketDepositSettings');
+export const RocketDepositQueue = artifacts.require('./contract/RocketDepositQueue');
 export const RocketGroupAPI = artifacts.require('./contract/RocketGroupAPI');
 export const RocketGroupAccessorContract = artifacts.require('./contract/RocketGroupAccessorContract');
 export const RocketGroupContract = artifacts.require('./contract/RocketGroupContract');

--- a/test/_lib/utils/general.js
+++ b/test/_lib/utils/general.js
@@ -169,3 +169,17 @@ export const TimeController = (() => {
     };
 
 })();
+
+
+// Get arbitrary contract events from a transaction result
+// txResult is the result returned from the transaction call
+// contractAddress is the address of the contract to retrieve events for
+// eventName is the name of the event to retrieve
+// eventParams is an array of objects with string 'type' and 'name' keys and an optional boolean 'indexed' key
+export function getTransactionContractEvents(txResult, contractAddress, eventName, eventParams) {
+    return txResult.receipt.logs
+        .filter(log => (log.address.toLowerCase() == contractAddress.toLowerCase()))
+        .filter(log => (log.topics[0] == web3.utils.soliditySha3(eventName + '(' + eventParams.map(param => param.type).join(',') + ')')))
+        .map(log => web3.eth.abi.decodeLog(eventParams, log.data, log.topics));
+}
+

--- a/test/_lib/utils/general.js
+++ b/test/_lib/utils/general.js
@@ -180,6 +180,6 @@ export function getTransactionContractEvents(txResult, contractAddress, eventNam
     return txResult.receipt.logs
         .filter(log => (log.address.toLowerCase() == contractAddress.toLowerCase()))
         .filter(log => (log.topics[0] == web3.utils.soliditySha3(eventName + '(' + eventParams.map(param => param.type).join(',') + ')')))
-        .map(log => web3.eth.abi.decodeLog(eventParams, log.data, log.topics));
+        .map(log => web3.eth.abi.decodeLog(eventParams, log.data, log.topics.slice(1)));
 }
 

--- a/test/rocket-deposit/rocket-deposit-api-scenarios.js
+++ b/test/rocket-deposit/rocket-deposit-api-scenarios.js
@@ -1,20 +1,124 @@
 // Dependencies
+import { getTransactionContractEvents } from '../_lib/utils/general';
 import { profileGasUsage } from '../_lib/utils/profiling';
-import { RocketDepositAPI } from '../_lib/artifacts';
+import { RocketDepositAPI, RocketDepositQueue, RocketDepositSettings, RocketMinipoolInterface, RocketMinipoolSettings, RocketPool } from '../_lib/artifacts';
+
+
+// Get all available minipools
+async function getAvailableMinipools() {
+    const rocketPool = await RocketPool.deployed();
+
+    // Get minipool count
+    let minipoolCount = parseInt(await rocketPool.getPoolsCount.call());
+
+    // Get available minipools
+    let mi, minipoolAddress, minipool, status, availableMinipools = [];
+    for (mi = 0; mi < minipoolCount; ++mi) {
+        minipoolAddress = await rocketPool.getPoolAt.call(mi);
+        minipool = await RocketMinipoolInterface.at(minipoolAddress);
+        status = parseInt(await minipool.getStatus.call());
+        if (status == 0 || status == 1) availableMinipools.push(minipool);
+    }
+
+    // Return
+    return availableMinipools;
+
+}
+
+
+// Get total minipool deposit capacity
+async function getTotalMinipoolCapacity(minipools) {
+    const rocketMinipoolSettings = await RocketMinipoolSettings.deployed();
+
+    // Get minipool launch amount
+    let launchAmount = parseInt(await rocketMinipoolSettings.getMinipoolLaunchAmount.call());
+
+    // Get capacity
+    let mi, balance, capacity = 0;
+    for (mi = 0; mi < minipools.length; ++mi) {
+        balance = parseInt(await web3.eth.getBalance(minipools[mi].address));
+        capacity += (launchAmount - balance);
+    }
+
+    // Return
+    return capacity;
+
+}
+
+
+// Get minipool balances
+async function getMinipoolBalances(minipools) {
+
+    // Get balances
+    let mi, address, balances = {};
+    for (mi = 0; mi < minipools.length; ++mi) {
+        address = minipools[mi].address;
+        balances[address.toLowerCase()] = parseInt(await web3.eth.getBalance(address));
+    }
+
+    // Return
+    return balances;
+
+}
 
 
 // Make a deposit
 export async function scenarioDeposit({depositorContract, durationID, fromAddress, value, gas}) {
+    const rocketDepositQueue = await RocketDepositQueue.deployed();
+    const rocketDepositSettings = await RocketDepositSettings.deployed();
+
+    // Get deposit settings
+    let chunkSize = parseInt(await rocketDepositSettings.getDepositChunkSize.call());
+    let maxChunkAssignments = parseInt(await rocketDepositSettings.getChunkAssignMax.call());
+
+    // Get current and expected queue balance
+    let queueBalance = parseInt(await rocketDepositQueue.getBalance(durationID));
+    let newQueueBalance = queueBalance + parseInt(value);
+
+    // Get available minipools and deposit capacity
+    let availableMinipools = await getAvailableMinipools();
+    let minipoolCapacity = await getTotalMinipoolCapacity(availableMinipools);
+
+    // Get expected number of chunk assignments
+    let expectedChunkAssignments = Math.min(maxChunkAssignments, Math.floor(Math.min(newQueueBalance, minipoolCapacity) / chunkSize));
+
+    // Get initial minipool balances
+    let minipoolBalances1 = await getMinipoolBalances(availableMinipools);
 
     // Deposit
     let result = await depositorContract.deposit(durationID, {from: fromAddress, value: value, gas: gas});
     profileGasUsage('RocketGroupAccessorContract.deposit', result);
 
-    // TODO:
-    // - calculate expected number of chunk assignments to minipools, based on deposit size and available minipool capacity
-    // - check chunk assignment events
-    // - check balances of minipools assigned chunks
-    // - check balance of fromAddress
+    // Get updated minipool balances
+    let minipoolBalances2 = await getMinipoolBalances(availableMinipools);
+
+    // Get chunk fragment assignment events
+    let chunkFragmentAssignEvents = getTransactionContractEvents(result, rocketDepositQueue.address, 'DepositChunkFragmentAssign', [
+        {type: 'bytes32', name: '_depositID', indexed: true},
+        {type: 'address', name: '_minipoolAddress', indexed: true},
+        {type: 'uint256', name: 'value'},
+        {type: 'uint256', name: 'created'},
+    ]);
+
+    // Get total ether assigned in chunk fragments
+    let etherAssigned = chunkFragmentAssignEvents.reduce((acc, val) => (acc + parseInt(val.value)), 0);
+
+    // Get total ether assigned in chunk fragments per minipool
+    let minipoolEtherAssigned = {};
+    chunkFragmentAssignEvents.forEach(event => {
+        let address = event._minipoolAddress.toLowerCase();
+        if (minipoolEtherAssigned[address] === undefined) minipoolEtherAssigned[address] = 0;
+        minipoolEtherAssigned[address] += parseInt(event.value);
+    });
+
+    // Check total ether assigned
+    assert.equal(etherAssigned, chunkSize * expectedChunkAssignments, 'Expected number of chunk assignments not performed');
+
+    // Check assigned minipool balances
+    for (let address in minipoolEtherAssigned) {
+        let amount = minipoolEtherAssigned[address];
+        assert.equal(minipoolBalances2[address], minipoolBalances1[address] + amount, 'Assigned minipool balance was not updated correctly');
+    }
 
 }
 

--- a/test/rocket-deposit/rocket-deposit-api-tests.js
+++ b/test/rocket-deposit/rocket-deposit-api-tests.js
@@ -322,6 +322,7 @@ export default function() {
             // Request refund
             await scenarioRefundDeposit({
                 depositorContract: groupAccessorContract,
+                groupID: groupContract.address,
                 durationID: '3m',
                 depositID,
                 fromAddress: user1,
@@ -349,6 +350,7 @@ export default function() {
             // Request refund
             await assertThrows(scenarioRefundDeposit({
                 depositorContract: groupAccessorContract,
+                groupID: groupContract.address,
                 durationID: 'beer',
                 depositID,
                 fromAddress: user1,
@@ -362,6 +364,7 @@ export default function() {
         it(printTitle('staker', 'cannot refund a deposit with an invalid ID'), async () => {
             await assertThrows(scenarioRefundDeposit({
                 depositorContract: groupAccessorContract,
+                groupID: groupContract.address,
                 durationID: '3m',
                 depositID: '0x0000000000000000000000000000000000000000000000000000000000000000',
                 fromAddress: user1,
@@ -379,6 +382,7 @@ export default function() {
             // Request refund
             await assertThrows(scenarioRefundDeposit({
                 depositorContract: groupAccessorContract,
+                groupID: groupContract.address,
                 durationID: '3m',
                 depositID,
                 fromAddress: user1,
@@ -397,6 +401,7 @@ export default function() {
             // Nonexistant deposit ID
             await assertThrows(scenarioRefundDeposit({
                 depositorContract: groupAccessorContract,
+                groupID: groupContract.address,
                 durationID: '3m',
                 depositID: '0x0000000000000000000000000000000000000000000000000000000000000001',
                 fromAddress: user1,
@@ -406,6 +411,7 @@ export default function() {
             // Nonexistant user
             await assertThrows(scenarioRefundDeposit({
                 depositorContract: groupAccessorContract,
+                groupID: groupContract.address,
                 durationID: '3m',
                 depositID,
                 fromAddress: user3,

--- a/test/rocket-deposit/rocket-deposit-api-tests.js
+++ b/test/rocket-deposit/rocket-deposit-api-tests.js
@@ -4,17 +4,6 @@ import { createGroupContract, createGroupAccessorContract, addGroupAccessor } fr
 import { createNodeContract, createNodeMinipools } from '../_helpers/rocket-node';
 import { scenarioDeposit, scenarioRefundDeposit, scenarioAPIDeposit, scenarioAPIRefundDeposit } from './rocket-deposit-api-scenarios';
 
-
-// Get user's queued deposit IDs
-async function getQueuedDepositIDs(groupID, userID, durationID) {
-    const rocketDepositAPI = await RocketDepositAPI.deployed();
-    let depositCount = parseInt(await rocketDepositAPI.getUserQueuedDepositCount.call(groupID, userID, durationID));
-    let depositIDs = [], di;
-    for (di = 0; di < depositCount; ++di) depositIDs.push(await rocketDepositAPI.getUserQueuedDepositAt.call(groupID, userID, durationID, di));
-    return depositIDs;
-}
-
-
 export default function() {
 
     contract('RocketDepositAPI', async (accounts) => {

--- a/test/rocket-group/rocket-group-contract-tests.js
+++ b/test/rocket-group/rocket-group-contract-tests.js
@@ -14,18 +14,18 @@ export default function() {
 
         // Setup
         let groupContract;
-        let accessor1Address;
-        let accessor2Address;
-        let accessor3Address;
+        let accessor1Contract;
+        let accessor2Contract;
+        let accessor3Contract;
         before(async () => {
 
             // Create group contract
             groupContract = await createGroupContract({name: 'Group 1', stakingFee: web3.utils.toWei('0', 'ether'), groupOwner});
 
             // Create default accessor contracts
-            accessor1Address = await createGroupAccessorContract({groupContractAddress: groupContract.address, groupOwner});
-            accessor2Address = await createGroupAccessorContract({groupContractAddress: groupContract.address, groupOwner});
-            accessor3Address = await createGroupAccessorContract({groupContractAddress: groupContract.address, groupOwner});
+            accessor1Contract = await createGroupAccessorContract({groupContractAddress: groupContract.address, groupOwner});
+            accessor2Contract = await createGroupAccessorContract({groupContractAddress: groupContract.address, groupOwner});
+            accessor3Contract = await createGroupAccessorContract({groupContractAddress: groupContract.address, groupOwner});
 
         });
 
@@ -67,13 +67,13 @@ export default function() {
         it(printTitle('group owner', 'can add a depositor to the group'), async () => {
             await scenarioAddDepositor({
                 groupContract,
-                depositorAddress: accessor1Address,
+                depositorAddress: accessor1Contract.address,
                 fromAddress: groupOwner,
                 gas: 500000,
             });
             await scenarioAddDepositor({
                 groupContract,
-                depositorAddress: accessor2Address,
+                depositorAddress: accessor2Contract.address,
                 fromAddress: groupOwner,
                 gas: 500000,
             });
@@ -84,7 +84,7 @@ export default function() {
         it(printTitle('group owner', 'cannot add an existing depositor to the group'), async () => {
             await assertThrows(scenarioAddDepositor({
                 groupContract,
-                depositorAddress: accessor1Address,
+                depositorAddress: accessor1Contract.address,
                 fromAddress: groupOwner,
                 gas: 500000,
             }), 'Added an existing depositor to the group');
@@ -95,7 +95,7 @@ export default function() {
         it(printTitle('random account', 'cannot add a depositor to the group'), async () => {
             await assertThrows(scenarioAddDepositor({
                 groupContract,
-                depositorAddress: accessor3Address,
+                depositorAddress: accessor3Contract.address,
                 fromAddress: accounts[9],
                 gas: 500000,
             }), 'Random account added a depositor to the group');
@@ -106,7 +106,7 @@ export default function() {
         it(printTitle('group owner', 'can remove a depositor from the group'), async () => {
             await scenarioRemoveDepositor({
                 groupContract,
-                depositorAddress: accessor2Address,
+                depositorAddress: accessor2Contract.address,
                 fromAddress: groupOwner,
                 gas: 500000,
             });
@@ -117,7 +117,7 @@ export default function() {
         it(printTitle('group owner', 'cannot remove a nonexistant depositor from the group'), async () => {
             await assertThrows(scenarioRemoveDepositor({
                 groupContract,
-                depositorAddress: accessor2Address,
+                depositorAddress: accessor2Contract.address,
                 fromAddress: groupOwner,
                 gas: 500000,
             }), 'Removed a nonexistant depositor from the group');
@@ -128,7 +128,7 @@ export default function() {
         it(printTitle('random account', 'cannot remove a depositor from the group'), async () => {
             await assertThrows(scenarioRemoveDepositor({
                 groupContract,
-                depositorAddress: accessor1Address,
+                depositorAddress: accessor1Contract.address,
                 fromAddress: accounts[9],
                 gas: 500000,
             }), 'Random account removed a depositor from the group');
@@ -139,13 +139,13 @@ export default function() {
         it(printTitle('group owner', 'can add a withdrawer to the group'), async () => {
             await scenarioAddWithdrawer({
                 groupContract,
-                withdrawerAddress: accessor1Address,
+                withdrawerAddress: accessor1Contract.address,
                 fromAddress: groupOwner,
                 gas: 500000,
             });
             await scenarioAddWithdrawer({
                 groupContract,
-                withdrawerAddress: accessor2Address,
+                withdrawerAddress: accessor2Contract.address,
                 fromAddress: groupOwner,
                 gas: 500000,
             });
@@ -156,7 +156,7 @@ export default function() {
         it(printTitle('group owner', 'cannot add an existing withdrawer to the group'), async () => {
             await assertThrows(scenarioAddWithdrawer({
                 groupContract,
-                withdrawerAddress: accessor1Address,
+                withdrawerAddress: accessor1Contract.address,
                 fromAddress: groupOwner,
                 gas: 500000,
             }), 'Added an existing withdrawer to the group');
@@ -167,7 +167,7 @@ export default function() {
         it(printTitle('random account', 'cannot add a withdrawer to the group'), async () => {
             await assertThrows(scenarioAddWithdrawer({
                 groupContract,
-                withdrawerAddress: accessor3Address,
+                withdrawerAddress: accessor3Contract.address,
                 fromAddress: accounts[9],
                 gas: 500000,
             }), 'Random account added a withdrawer to the group');
@@ -178,7 +178,7 @@ export default function() {
         it(printTitle('group owner', 'can remove a withdrawer from the group'), async () => {
             await scenarioRemoveWithdrawer({
                 groupContract,
-                withdrawerAddress: accessor2Address,
+                withdrawerAddress: accessor2Contract.address,
                 fromAddress: groupOwner,
                 gas: 500000,
             });
@@ -191,7 +191,7 @@ export default function() {
             // Attempt removal
             await assertThrows(scenarioRemoveWithdrawer({
                 groupContract,
-                withdrawerAddress: accessor1Address,
+                withdrawerAddress: accessor1Contract.address,
                 fromAddress: groupOwner,
                 gas: 500000,
             }), 'Removed the last withdrawer from the group');
@@ -199,7 +199,7 @@ export default function() {
             // Add withdrawer
             await scenarioAddWithdrawer({
                 groupContract,
-                withdrawerAddress: accessor3Address,
+                withdrawerAddress: accessor3Contract.address,
                 fromAddress: groupOwner,
                 gas: 500000,
             });
@@ -211,7 +211,7 @@ export default function() {
         it(printTitle('group owner', 'cannot remove a nonexistant withdrawer from the group'), async () => {
             await assertThrows(scenarioRemoveWithdrawer({
                 groupContract,
-                withdrawerAddress: accessor2Address,
+                withdrawerAddress: accessor2Contract.address,
                 fromAddress: groupOwner,
                 gas: 500000,
             }), 'Removed a nonexistant withdrawer from the group');
@@ -222,7 +222,7 @@ export default function() {
         it(printTitle('random account', 'cannot remove a withdrawer from the group'), async () => {
             await assertThrows(scenarioRemoveWithdrawer({
                 groupContract,
-                withdrawerAddress: accessor1Address,
+                withdrawerAddress: accessor1Contract.address,
                 fromAddress: accounts[9],
                 gas: 500000,
             }), 'Random account removed a withdrawer from the group');

--- a/test/rocket-node/rocket-node-task-admin-tests.js
+++ b/test/rocket-node/rocket-node-task-admin-tests.js
@@ -1,5 +1,5 @@
 import { printTitle, assertThrows } from '../_lib/utils/general';
-import { RocketStorage, TestNodeTask } from '../_lib/artifacts';
+import { createTestNodeTaskContract } from '../_helpers/rocket-node-task';
 import { scenarioAddNodeTask, scenarioRemoveNodeTask, scenarioUpdateNodeTask } from './rocket-node-task-admin-scenarios';
 
 export default function() {
@@ -12,7 +12,6 @@ export default function() {
 
 
         // Deploy test node tasks
-        let rocketStorage;
         let testNodeTask1;
         let testNodeTask2;
         let testNodeTask3;
@@ -20,13 +19,12 @@ export default function() {
         let testNodeTask1v2;
         let testNodeTask1v3;
         before(async () => {
-            rocketStorage = await RocketStorage.deployed();
-            testNodeTask1 = await TestNodeTask.new(rocketStorage.address, 'NodeTask1', {gas: 5000000, gasPrice: 10000000000, from: owner});
-            testNodeTask2 = await TestNodeTask.new(rocketStorage.address, 'NodeTask2', {gas: 5000000, gasPrice: 10000000000, from: owner});
-            testNodeTask3 = await TestNodeTask.new(rocketStorage.address, 'NodeTask3', {gas: 5000000, gasPrice: 10000000000, from: owner});
-            testNodeTask4 = await TestNodeTask.new(rocketStorage.address, 'NodeTask4', {gas: 5000000, gasPrice: 10000000000, from: owner});
-            testNodeTask1v2 = await TestNodeTask.new(rocketStorage.address, 'NodeTask1v2', {gas: 5000000, gasPrice: 10000000000, from: owner});
-            testNodeTask1v3 = await TestNodeTask.new(rocketStorage.address, 'NodeTask1v3', {gas: 5000000, gasPrice: 10000000000, from: owner});
+            testNodeTask1 = await createTestNodeTaskContract({name: 'NodeTask1', owner});
+            testNodeTask2 = await createTestNodeTaskContract({name: 'NodeTask2', owner});
+            testNodeTask3 = await createTestNodeTaskContract({name: 'NodeTask3', owner});
+            testNodeTask4 = await createTestNodeTaskContract({name: 'NodeTask4', owner});
+            testNodeTask1v2 = await createTestNodeTaskContract({name: 'NodeTask1v2', owner});
+            testNodeTask1v3 = await createTestNodeTaskContract({name: 'NodeTask1v3', owner});
         });
 
 

--- a/test/rocket-node/rocket-node-task-node-tests.js
+++ b/test/rocket-node/rocket-node-task-node-tests.js
@@ -1,6 +1,5 @@
 import { printTitle, assertThrows } from '../_lib/utils/general';
-import { RocketStorage, TestNodeTask } from '../_lib/artifacts';
-import { scenarioAddNodeTask, scenarioRemoveNodeTask, scenarioUpdateNodeTask } from './rocket-node-task-admin-scenarios';
+import { createTestNodeTaskContract, addNodeTask, removeNodeTask, updateNodeTask } from '../_helpers/rocket-node-task';
 import { scenarioRunTasks, scenarioRunOneTask } from './rocket-node-task-node-scenarios';
 
 export default function() {
@@ -19,37 +18,23 @@ export default function() {
 
 
         // Deploy test node tasks
-        let rocketStorage;
         let testNodeTask1;
         let testNodeTask2;
         let testNodeTask3;
         let testNodeTask1v2;
         before(async () => {
-            rocketStorage = await RocketStorage.deployed();
-            testNodeTask1 = await TestNodeTask.new(rocketStorage.address, 'NodeTask1', {gas: 5000000, gasPrice: 10000000000, from: owner});
-            testNodeTask2 = await TestNodeTask.new(rocketStorage.address, 'NodeTask2', {gas: 5000000, gasPrice: 10000000000, from: owner});
-            testNodeTask3 = await TestNodeTask.new(rocketStorage.address, 'NodeTask3', {gas: 5000000, gasPrice: 10000000000, from: owner});
-            testNodeTask1v2 = await TestNodeTask.new(rocketStorage.address, 'NodeTask1v2', {gas: 5000000, gasPrice: 10000000000, from: owner});
+            testNodeTask1 = await createTestNodeTaskContract({name: 'NodeTask1', owner});
+            testNodeTask2 = await createTestNodeTaskContract({name: 'NodeTask2', owner});
+            testNodeTask3 = await createTestNodeTaskContract({name: 'NodeTask3', owner});
+            testNodeTask1v2 = await createTestNodeTaskContract({name: 'NodeTask1v2', owner});
         });
 
 
         // Add node tasks
         it(printTitle('-----', 'add node tasks'), async () => {
-            await scenarioAddNodeTask({
-                taskAddress: testNodeTask1.address,
-                fromAddress: owner,
-                gas: 500000,
-            });
-            await scenarioAddNodeTask({
-                taskAddress: testNodeTask2.address,
-                fromAddress: owner,
-                gas: 500000,
-            });
-            await scenarioAddNodeTask({
-                taskAddress: testNodeTask3.address,
-                fromAddress: owner,
-                gas: 500000,
-            });
+            await addNodeTask({taskAddress: testNodeTask1.address, owner});
+            await addNodeTask({taskAddress: testNodeTask2.address, owner});
+            await addNodeTask({taskAddress: testNodeTask3.address, owner});
         });
 
 
@@ -73,11 +58,7 @@ export default function() {
 
         // Remove node tasks
         it(printTitle('-----', 'remove node tasks'), async () => {
-            await scenarioRemoveNodeTask({
-                taskAddress: testNodeTask2.address,
-                fromAddress: owner,
-                gas: 500000,
-            });
+            await removeNodeTask({taskAddress: testNodeTask2.address, owner});
         });
 
 
@@ -101,12 +82,7 @@ export default function() {
 
         // Update node tasks
         it(printTitle('-----', 'update node tasks'), async () => {
-            await scenarioUpdateNodeTask({
-                oldAddress: testNodeTask1.address,
-                newAddress: testNodeTask1v2.address,
-                fromAddress: owner,
-                gas: 500000,
-            });
+            await updateNodeTask({oldAddress: testNodeTask1.address, newAddress: testNodeTask1v2.address, owner});
         });
 
 


### PR DESCRIPTION
RocketPool:
- Updated minipool (& node) availability setter logic; moved to standalone method
- Fixed widowed minipool timeout check

RocketMinipool & RocketMinipoolDelegate:
- Updated RocketMinipool memory layout to be inline with delegate's
- Fixed delegate contract calls
- Initialise status change time on construction
- Don't enforce minipool launch amount check on user deposit
- Disabled closePool() status check temporarily due to errors
- Fixed launch amount check for staking status
- Set minipool unavailable when status progresses to staking

Unit tests:
- Added deposit helpers
- Added node task helpers
- Fixed group helpers
- Cleaned up deposit tests
