### PR TITLE
Rocket two rpl

### DIFF
--- a/contracts/RocketPool.sol
+++ b/contracts/RocketPool.sol
@@ -9,7 +9,7 @@ import "./interface/minipool/RocketMinipoolFactoryInterface.sol";
 import "./interface/settings/RocketMinipoolSettingsInterface.sol";
 import "./interface/utils/lists/AddressSetStorageInterface.sol";
 // Libraries
-import "../../lib/SafeMath.sol";
+import "./lib/SafeMath.sol";
 
 
 

--- a/contracts/RocketPool.sol
+++ b/contracts/RocketPool.sol
@@ -110,7 +110,8 @@ contract RocketPool is RocketBase {
     function getNetworkUtilisation() public returns (uint256) {
         uint256 etherCapacity = getTotalEther("capacity");
         if (etherCapacity == 0) { return 1 ether; }
-        return (1 ether).mul(getTotalEther("assigned")).div(etherCapacity);
+        uint256 base = 1 ether;
+        return base.mul(getTotalEther("assigned")).div(etherCapacity);
     }
 
 

--- a/contracts/RocketPool.sol
+++ b/contracts/RocketPool.sol
@@ -107,7 +107,7 @@ contract RocketPool is RocketBase {
 
 
     /// @dev Get the current network utilisation (assigned ether / ether capacity) as a fraction of 1 ether
-    function getNetworkUtilisation() public returns (uint256) {
+    function getNetworkUtilisation() public view returns (uint256) {
         uint256 etherCapacity = getTotalEther("capacity");
         if (etherCapacity == 0) { return 1 ether; }
         uint256 base = 1 ether;

--- a/contracts/RocketPool.sol
+++ b/contracts/RocketPool.sol
@@ -106,6 +106,14 @@ contract RocketPool is RocketBase {
     }
 
 
+    /// @dev Get the current network utilisation (assigned ether / ether capacity) as a fraction of 1 ether
+    function getNetworkUtilisation() public returns (uint256) {
+        uint256 etherCapacity = getTotalEther("capacity");
+        if (etherCapacity == 0) { return 1 ether; }
+        return (1 ether).mul(getTotalEther("assigned")).div(etherCapacity);
+    }
+
+
     /*** Methods *************/
 
 

--- a/contracts/RocketPool.sol
+++ b/contracts/RocketPool.sol
@@ -1,17 +1,25 @@
 pragma solidity 0.4.24;
 
+// Contracts
 import "./RocketBase.sol";
+// Interfaces
 import "./interface/RocketNodeInterface.sol";
 import "./interface/minipool/RocketMinipoolInterface.sol";
 import "./interface/minipool/RocketMinipoolFactoryInterface.sol";
 import "./interface/settings/RocketMinipoolSettingsInterface.sol";
 import "./interface/utils/lists/AddressSetStorageInterface.sol";
+// Libraries
+import "../../lib/SafeMath.sol";
 
 
 
 /// @title First alpha of an Ethereum POS pool - Rocket Pool! - This is main pool management contract
 /// @author David Rugendyke
 contract RocketPool is RocketBase {
+
+    /*** Libs  ******************/
+
+    using SafeMath for uint;
 
     /*** Contracts **************/
 
@@ -214,6 +222,33 @@ contract RocketPool is RocketBase {
         }
         // Success
         return true;
+    }
+
+
+    /// @dev Get the total ether value of the network by key
+    /// @param _type The type of total ether value to retrieve (e.g. "capacity")
+    function getTotalEther(string _type) public view returns (uint256) {
+        return rocketStorage.getUint(keccak256(abi.encodePacked("ether.total", _type)));
+    }
+
+
+    /// @dev Increase the total ether value of the network by key
+    /// @param _type The type of total ether value to increase (e.g. "capacity")
+    /// @param _value The amount to increase the total ether value by
+    function increaseTotalEther(string _type, uint256 _value) public {
+        rocketStorage.setUint(keccak256(abi.encodePacked("ether.total", _type)),
+            rocketStorage.getUint(keccak256(abi.encodePacked("ether.total", _type))).add(_value)
+        );
+    }
+
+
+    /// @dev Decrease the total ether value of the network by key
+    /// @param _type The type of total ether value to decrease (e.g. "capacity")
+    /// @param _value The amount to decrease the total ether value by
+    function decreaseTotalEther(string _type, uint256 _value) public {
+        rocketStorage.setUint(keccak256(abi.encodePacked("ether.total", _type)),
+            rocketStorage.getUint(keccak256(abi.encodePacked("ether.total", _type))).sub(_value)
+        );
     }
 
 

--- a/contracts/contract/api/RocketNodeAPI.sol
+++ b/contracts/contract/api/RocketNodeAPI.sol
@@ -126,12 +126,13 @@ contract RocketNodeAPI is RocketBase {
 
     /// @dev Returns the amount of RPL required for a single ether
     /// @param _durationID The ID that determines which pool duration
-    function getRPLRatio(string _durationID) public onlyValidDuration(_durationID) returns(uint256) { 
+    function getRPLRatio(string _durationID, uint256 _utilisation) public onlyValidDuration(_durationID) returns(uint256) { 
         // Network utilisation as a fraction of 1 ether
-        uint256 utilisation = 0.5 ether;
+        //uint256 utilisation = 0.5 ether;
+        uint256 utilisation = _utilisation;
         // Calculate RPL ratio based on utilisation rate of 0 - 50%; yields a maximum ratio of 5:1
         if (utilisation < 0.5 ether) {
-            return -(utilisation / 314981000000 - 1587397) ** 3 + 1 ether;
+            return -(utilisation / 95200000000000 - 5252) ** 5 + 1 ether;
         }
         // Calculate RPL ratio based on utilisation rate of 50 - 100%; yields a minimum ratio of 0:1
         else {

--- a/contracts/contract/api/RocketNodeAPI.sol
+++ b/contracts/contract/api/RocketNodeAPI.sol
@@ -126,10 +126,9 @@ contract RocketNodeAPI is RocketBase {
 
     /// @dev Returns the amount of RPL required for a single ether
     /// @param _durationID The ID that determines which pool duration
-    function getRPLRatio(string _durationID, uint256 _utilisation) public onlyValidDuration(_durationID) returns(uint256) { 
+    function getRPLRatio(string _durationID) public onlyValidDuration(_durationID) returns(uint256) { 
         // Network utilisation as a fraction of 1 ether
-        //uint256 utilisation = 0.5 ether;
-        uint256 utilisation = _utilisation;
+        uint256 utilisation = 0.5 ether;
         // Calculate RPL ratio based on utilisation rate of 0 - 50%; yields a maximum ratio of 5:1
         if (utilisation < 0.5 ether) {
             return -(utilisation / 95200000000000 - 5252) ** 5 + 1 ether;

--- a/contracts/contract/api/RocketNodeAPI.sol
+++ b/contracts/contract/api/RocketNodeAPI.sol
@@ -129,7 +129,7 @@ contract RocketNodeAPI is RocketBase {
     function getRPLRatio(string _durationID) public onlyValidDuration(_durationID) returns(uint256) { 
         // Get network utilisation as a fraction of 1 ether
         rocketPool = RocketPoolInterface(getContractAddress("rocketPool"));
-        uint256 utilisation = rocketPool.getNetworkUtilisation();
+        uint256 utilisation = rocketPool.getNetworkUtilisation(_durationID);
         // Calculate RPL ratio based on utilisation rate of 0 - 50%; yields a maximum ratio of 5:1
         if (utilisation < 0.5 ether) {
             return -(utilisation / 95200000000000 - 5252) ** 5 + 1 ether;

--- a/contracts/contract/api/RocketNodeAPI.sol
+++ b/contracts/contract/api/RocketNodeAPI.sol
@@ -127,9 +127,16 @@ contract RocketNodeAPI is RocketBase {
     /// @dev Returns the amount of RPL required for a single ether
     /// @param _durationID The ID that determines which pool duration
     function getRPLRatio(string _durationID) public onlyValidDuration(_durationID) returns(uint256) { 
-        // TODO: Add in actual calculations using the quintic formula ratio - returns a 1:1.5 atm
-        uint256 rplRatio = 1.5 ether;
-        return rplRatio;
+        // Network utilisation as a fraction of 1 ether
+        uint256 utilisation = 0.5 ether;
+        // Calculate RPL ratio based on utilisation rate of 0 - 50%; yields a maximum ratio of 5:1
+        if (utilisation < 0.5 ether) {
+            return -(utilisation / 314981000000 - 1587397) ** 3 + 1 ether;
+        }
+        // Calculate RPL ratio based on utilisation rate of 50 - 100%; yields a minimum ratio of 0:1
+        else {
+            return -(utilisation / 500000000000 - 1000000) ** 3 + 1 ether;
+        }
     }
 
 

--- a/contracts/contract/api/RocketNodeAPI.sol
+++ b/contracts/contract/api/RocketNodeAPI.sol
@@ -169,7 +169,6 @@ contract RocketNodeAPI is RocketBase {
         // Check the node operator doesn't have a reservation that's current, must wait for that to expire first or cancel it.
         require(now > (_lastDepositReservedTime + rocketNodeSettings.getDepositReservationTime()), "Only one deposit reservation can be made at a time, the current deposit reservation will expire in under 24hrs.");
         // Check the rpl ratio is valid
-        require(_rplRatio > 0, "RPL Ratio for deposit reservation cannot be less than or equal to zero.");
         require(_rplRatio < 3 ether, "RPL Ratio is too high.");
         // All ok
         return true;

--- a/contracts/contract/api/RocketNodeAPI.sol
+++ b/contracts/contract/api/RocketNodeAPI.sol
@@ -127,8 +127,9 @@ contract RocketNodeAPI is RocketBase {
     /// @dev Returns the amount of RPL required for a single ether
     /// @param _durationID The ID that determines which pool duration
     function getRPLRatio(string _durationID) public onlyValidDuration(_durationID) returns(uint256) { 
-        // Network utilisation as a fraction of 1 ether
-        uint256 utilisation = 0.5 ether;
+        // Get network utilisation as a fraction of 1 ether
+        rocketPool = RocketPoolInterface(getContractAddress("rocketPool"));
+        uint256 utilisation = rocketPool.getNetworkUtilisation();
         // Calculate RPL ratio based on utilisation rate of 0 - 50%; yields a maximum ratio of 5:1
         if (utilisation < 0.5 ether) {
             return -(utilisation / 95200000000000 - 5252) ** 5 + 1 ether;

--- a/contracts/contract/api/RocketNodeAPI.sol
+++ b/contracts/contract/api/RocketNodeAPI.sol
@@ -169,7 +169,7 @@ contract RocketNodeAPI is RocketBase {
         // Check the node operator doesn't have a reservation that's current, must wait for that to expire first or cancel it.
         require(now > (_lastDepositReservedTime + rocketNodeSettings.getDepositReservationTime()), "Only one deposit reservation can be made at a time, the current deposit reservation will expire in under 24hrs.");
         // Check the rpl ratio is valid
-        require(_rplRatio < 3 ether, "RPL Ratio is too high.");
+        require(_rplRatio < 5 ether, "RPL Ratio is too high.");
         // All ok
         return true;
     }

--- a/contracts/contract/api/RocketNodeAPI.sol
+++ b/contracts/contract/api/RocketNodeAPI.sol
@@ -169,7 +169,7 @@ contract RocketNodeAPI is RocketBase {
         // Check the node operator doesn't have a reservation that's current, must wait for that to expire first or cancel it.
         require(now > (_lastDepositReservedTime + rocketNodeSettings.getDepositReservationTime()), "Only one deposit reservation can be made at a time, the current deposit reservation will expire in under 24hrs.");
         // Check the rpl ratio is valid
-        require(_rplRatio < 5 ether, "RPL Ratio is too high.");
+        require(_rplRatio <= 5 ether, "RPL Ratio is too high.");
         // All ok
         return true;
     }

--- a/contracts/contract/minipool/RocketMinipoolDelegate.sol
+++ b/contracts/contract/minipool/RocketMinipoolDelegate.sol
@@ -262,7 +262,7 @@ contract RocketMinipoolDelegate {
         // Add to their balance
         users[_user].balance = users[_user].balance.add(msg.value);
         // Increase total network assigned ether
-        rocketPool.increaseTotalEther("assigned", msg.value);
+        rocketPool.increaseTotalEther("assigned", staking.id, msg.value);
         // All good? Fire the event for the new deposit
         emit PoolTransfer(msg.sender, this, keccak256("deposit"), msg.value, users[_user].balance, now);
         // Update the status

--- a/contracts/contract/minipool/RocketMinipoolDelegate.sol
+++ b/contracts/contract/minipool/RocketMinipoolDelegate.sol
@@ -255,11 +255,14 @@ contract RocketMinipoolDelegate {
         // Add this user if they are not currently in this minipool
         addUser(_user, _groupID);
         // Load contracts
+        rocketPool = RocketPoolInterface(getContractAddress("rocketPool"));
         rocketMinipoolSettings = RocketMinipoolSettingsInterface(getContractAddress("rocketMinipoolSettings"));
         // Make sure we are accepting deposits
         require(status.current == 0 || status.current == 1, "Minipool is not currently allowing deposits.");
         // Add to their balance
         users[_user].balance = users[_user].balance.add(msg.value);
+        // Increase total network assigned ether
+        rocketPool.increaseTotalEther("assigned", msg.value);
         // All good? Fire the event for the new deposit
         emit PoolTransfer(msg.sender, this, keccak256("deposit"), msg.value, users[_user].balance, now);
         // Update the status

--- a/contracts/contract/minipool/RocketMinipoolFactory.sol
+++ b/contracts/contract/minipool/RocketMinipoolFactory.sol
@@ -56,8 +56,6 @@ contract RocketMinipoolFactory is RocketBase {
         rocketMinipoolSettings = RocketMinipoolSettingsInterface(getContractAddress("rocketMinipoolSettings"));
         // Can we create one?
         require(rocketMinipoolSettings.getMinipoolCanBeCreated() == true, "Minipool creation is currently disabled.");
-        // Always requires RPL
-        require(_rplDeposited > 0, "Invalide RPL amount given for new minipool creation");
         // Always requires some ether if not trusted
         if(!_trusted) {
             require(_etherDeposited == rocketMinipoolSettings.getMinipoolLaunchAmount().div(2), "Ether deposit size must be half required for a deposit with Casper eg 16 ether.");

--- a/contracts/interface/RocketPoolInterface.sol
+++ b/contracts/interface/RocketPoolInterface.sol
@@ -7,4 +7,7 @@ contract RocketPoolInterface {
     function minipoolRemove(address _minipool) public returns (bool);
     function minipoolRemoveCheck(address _sender, address _minipool) public returns (bool);
     function minipoolSetAvailable(bool _available) external returns (bool);
+    function getTotalEther(string _type) public view returns (uint256);
+    function increaseTotalEther(string _type, uint256 _value) external;
+    function decreaseTotalEther(string _type, uint256 _value) external;
 }

--- a/contracts/interface/RocketPoolInterface.sol
+++ b/contracts/interface/RocketPoolInterface.sol
@@ -3,6 +3,7 @@ pragma solidity 0.4.24;
 
 contract RocketPoolInterface {
     function getRandomAvailableMinipool(string _durationID, uint256 _nonce) public view returns (address);
+    function getNetworkUtilisation() public returns (uint256);
     function minipoolCreate(address _nodeOwner, string _durationID, uint256 _etherAmount, uint256 _rplAmount, bool _isTrustedNode) external returns (address);
     function minipoolRemove(address _minipool) public returns (bool);
     function minipoolRemoveCheck(address _sender, address _minipool) public returns (bool);

--- a/contracts/interface/RocketPoolInterface.sol
+++ b/contracts/interface/RocketPoolInterface.sol
@@ -3,7 +3,7 @@ pragma solidity 0.4.24;
 
 contract RocketPoolInterface {
     function getRandomAvailableMinipool(string _durationID, uint256 _nonce) public view returns (address);
-    function getNetworkUtilisation() public returns (uint256);
+    function getNetworkUtilisation() public view returns (uint256);
     function minipoolCreate(address _nodeOwner, string _durationID, uint256 _etherAmount, uint256 _rplAmount, bool _isTrustedNode) external returns (address);
     function minipoolRemove(address _minipool) public returns (bool);
     function minipoolRemoveCheck(address _sender, address _minipool) public returns (bool);

--- a/contracts/interface/RocketPoolInterface.sol
+++ b/contracts/interface/RocketPoolInterface.sol
@@ -3,12 +3,12 @@ pragma solidity 0.4.24;
 
 contract RocketPoolInterface {
     function getRandomAvailableMinipool(string _durationID, uint256 _nonce) public view returns (address);
-    function getNetworkUtilisation() public view returns (uint256);
+    function getNetworkUtilisation(string _durationID) public view returns (uint256);
     function minipoolCreate(address _nodeOwner, string _durationID, uint256 _etherAmount, uint256 _rplAmount, bool _isTrustedNode) external returns (address);
     function minipoolRemove(address _minipool) public returns (bool);
     function minipoolRemoveCheck(address _sender, address _minipool) public returns (bool);
     function minipoolSetAvailable(bool _available) external returns (bool);
-    function getTotalEther(string _type) public view returns (uint256);
-    function increaseTotalEther(string _type, uint256 _value) external;
-    function decreaseTotalEther(string _type, uint256 _value) external;
+    function getTotalEther(string _type, string _durationID) public view returns (uint256);
+    function increaseTotalEther(string _type, string _durationID, uint256 _value) external;
+    function decreaseTotalEther(string _type, string _durationID, uint256 _value) external;
 }

--- a/test/_helpers/rocket-deposit.js
+++ b/test/_helpers/rocket-deposit.js
@@ -11,3 +11,9 @@ export async function getQueuedDepositIDs({groupID, userID, durationID}) {
     return depositIDs;
 }
 
+
+// Make a user deposit
+export async function userDeposit({depositorContract, durationID, fromAddress, value}) {
+    await depositorContract.deposit(durationID, {from: fromAddress, value: value, gas: 7500000});
+}
+

--- a/test/_helpers/rocket-node.js
+++ b/test/_helpers/rocket-node.js
@@ -34,7 +34,7 @@ export async function createNodeMinipools({nodeContract, stakingDurationID, mini
 
         // Deposit RPL
         let rplRequired = await nodeContract.getDepositReserveRPLRequired.call();
-        await mintRpl({toAddress: nodeContract.address, rplAmount: rplRequired, fromAddress: owner});
+        if (rplRequired > 0) await mintRpl({toAddress: nodeContract.address, rplAmount: rplRequired, fromAddress: owner});
 
         // Complete deposit to create minipool
         await nodeContract.deposit({from: nodeOperator, gas: 7500000, value: nodeDepositAmount});

--- a/test/rocket-node/rocket-node-contract-scenarios.js
+++ b/test/rocket-node/rocket-node-contract-scenarios.js
@@ -1,6 +1,6 @@
 // Dependencies
 import { profileGasUsage } from '../_lib/utils/profiling';
-import { RocketMinipoolInterface, RocketMinipoolSettings, RocketPoolToken } from '../_lib/artifacts';
+import { RocketMinipoolInterface, RocketMinipoolSettings, RocketNodeAPI, RocketPoolToken } from '../_lib/artifacts';
 
 
 // Reserve a deposit
@@ -107,3 +107,14 @@ export async function scenarioDeposit({nodeContract, value, fromAddress, gas}) {
     }
 
 }
+
+
+// Attempt a deposit via the node API
+export async function scenarioAPIDeposit({nodeOperator}) {
+    const rocketNodeAPI = await RocketNodeAPI.deployed();
+
+    // Deposit
+    await rocketNodeAPI.deposit(nodeOperator, {from: nodeOperator, gas: 7500000});
+
+}
+

--- a/test/rocket-node/rocket-node-contract-scenarios.js
+++ b/test/rocket-node/rocket-node-contract-scenarios.js
@@ -49,30 +49,61 @@ export async function scenarioDeposit({nodeContract, value, fromAddress, gas}) {
     let miniPoolCreationAmount = Math.floor(miniPoolLaunchAmount / 2);
     let expectedMiniPools = Math.floor(value / miniPoolCreationAmount);
 
+    // Get deposits required
+    let nodeDepositEtherRequired = parseInt(await nodeContract.getDepositReserveEtherRequired.call());
+    let nodeDepositRPlRequired = parseInt(await nodeContract.getDepositReserveRPLRequired.call());
+
     // Deposit
     let result = await nodeContract.deposit({from: fromAddress, gas: gas, value: value});
     profileGasUsage('RocketNodeContract.deposit', result);
 
-    // Check deposited minipool count
-    let depositMiniPoolRPLLogs = result.logs.filter(log => (log.event == 'NodeDepositMinipool' && log.args.tokenType == 'RPL'));
-    let depositMiniPoolETHLogs = result.logs.filter(log => (log.event == 'NodeDepositMinipool' && log.args.tokenType == 'ETH'));
-    assert.equal(depositMiniPoolRPLLogs.length, expectedMiniPools, 'Required number of minipools were not deposited to successfully');
-    assert.equal(depositMiniPoolETHLogs.length, expectedMiniPools, 'Required number of minipools were not deposited to successfully');
-    depositMiniPoolRPLLogs.forEach((log, index) => {
-        assert.equal(depositMiniPoolRPLLogs[index].args._minipool, depositMiniPoolETHLogs[index].args._minipool, 'Deposited minipool addresses do not match');
-    });
+    // Logs
+    let depositMiniPoolETHLogs;
+    let depositMiniPoolRPLLogs;
 
-    // Check created minipool balances
-    let i, address, miniPool, ethRequired, rplRequired, ethBalance, rplBalance;
-    for (i = 0; i < expectedMiniPools; ++i) {
-        address = depositMiniPoolRPLLogs[i].args._minipool;
-        miniPool = await RocketMinipoolInterface.at(address);
-        ethRequired = parseInt(await miniPool.getNodeDepositEther.call());
-        rplRequired = parseInt(await miniPool.getNodeDepositRPL.call());
-        ethBalance = parseInt(await web3.eth.getBalance(address));
-        rplBalance = parseInt(await rocketPoolToken.balanceOf.call(address));
-        assert.equal(ethRequired, ethBalance, 'Created minipool has invalid ether balance');
-        assert.equal(rplRequired, rplBalance, 'Created minipool has invalid RPL balance');
+    // Check minipool ether deposits
+    if (nodeDepositEtherRequired > 0) {
+
+        // Check deposit events
+        depositMiniPoolETHLogs = result.logs.filter(log => (log.event == 'NodeDepositMinipool' && log.args.tokenType == 'ETH'));
+        assert.equal(depositMiniPoolETHLogs.length, expectedMiniPools, 'Required number of minipools were not deposited to successfully');
+
+        // Check created minipool balances
+        let i, address, miniPool, ethRequired, ethBalance;
+        for (i = 0; i < expectedMiniPools; ++i) {
+            address = depositMiniPoolETHLogs[i].args._minipool;
+            miniPool = await RocketMinipoolInterface.at(address);
+            ethRequired = parseInt(await miniPool.getNodeDepositEther.call());
+            ethBalance = parseInt(await web3.eth.getBalance(address));
+            assert.equal(ethRequired, ethBalance, 'Created minipool has invalid ether balance');
+        }
+
+    }
+
+    // Check minipool RPL deposits
+    if (nodeDepositRPlRequired > 0) {
+
+        // Check deposit events
+        depositMiniPoolRPLLogs = result.logs.filter(log => (log.event == 'NodeDepositMinipool' && log.args.tokenType == 'RPL'));
+        assert.equal(depositMiniPoolRPLLogs.length, expectedMiniPools, 'Required number of minipools were not deposited to successfully');
+
+        // Check created minipool balances
+        let i, address, miniPool, rplRequired, rplBalance;
+        for (i = 0; i < expectedMiniPools; ++i) {
+            address = depositMiniPoolRPLLogs[i].args._minipool;
+            miniPool = await RocketMinipoolInterface.at(address);
+            rplRequired = parseInt(await miniPool.getNodeDepositRPL.call());
+            rplBalance = parseInt(await rocketPoolToken.balanceOf.call(address));
+            assert.equal(rplRequired, rplBalance, 'Created minipool has invalid RPL balance');
+        }
+
+    }
+
+    // Check minipool ether & RPL deposits
+    if (nodeDepositEtherRequired > 0 && nodeDepositRPlRequired > 0) {
+        depositMiniPoolRPLLogs.forEach((log, index) => {
+            assert.equal(depositMiniPoolRPLLogs[index].args._minipool, depositMiniPoolETHLogs[index].args._minipool, 'Deposited minipool addresses do not match');
+        });
     }
 
 }

--- a/test/rocket-node/rocket-node-contract-tests.js
+++ b/test/rocket-node/rocket-node-contract-tests.js
@@ -1,8 +1,8 @@
 import { printTitle, assertThrows } from '../_lib/utils/general';
-import { RocketMinipoolSettings, RocketNodeAPI, RocketNodeSettings } from '../_lib/artifacts';
+import { RocketMinipoolSettings, RocketNodeSettings } from '../_lib/artifacts';
 import { createNodeContract } from '../_helpers/rocket-node';
 import { mintRpl } from '../_helpers/rocket-pool-token';
-import { scenarioDepositReserve, scenarioDepositReserveCancel, scenarioDeposit } from './rocket-node-contract-scenarios';
+import { scenarioDepositReserve, scenarioDepositReserveCancel, scenarioDeposit, scenarioAPIDeposit } from './rocket-node-contract-scenarios';
 
 export default function() {
 
@@ -15,7 +15,6 @@ export default function() {
 
 
         // Setup
-        let rocketNodeAPI;
         let rocketNodeSettings;
         let nodeContract;
         let minDepositAmount;
@@ -23,7 +22,6 @@ export default function() {
         before(async () => {
 
             // Initialise contracts
-            rocketNodeAPI = await RocketNodeAPI.deployed();
             rocketNodeSettings = await RocketNodeSettings.deployed();
 
             // Create node contract
@@ -218,9 +216,8 @@ export default function() {
 
         // Node operator cannot call API deposit method directly
         it(printTitle('node operator', 'cannot call API deposit method directly'), async () => {
-            await assertThrows(rocketNodeAPI.deposit(operator, {
-                from: operator,
-                gas: 7500000,
+            await assertThrows(scenarioAPIDeposit({
+                nodeOperator: operator,
             }), 'Called API deposit method directly');
         });
 

--- a/test/rocket-node/rocket-node-contract-tests.js
+++ b/test/rocket-node/rocket-node-contract-tests.js
@@ -264,7 +264,7 @@ export default function() {
             for (let di = 0; di <= chunksToAssign; ++di) {
 
                 // Get network utilisation & RPL ratio
-                let networkUtilisation = web3.utils.fromWei(await rocketPool.getNetworkUtilisation.call(), 'ether');
+                let networkUtilisation = web3.utils.fromWei(await rocketPool.getNetworkUtilisation.call('3m'), 'ether');
                 let rplRatio = web3.utils.fromWei(await rocketNodeAPI.getRPLRatio.call('3m'), 'ether');
 
                 // Check RPL ratio based on network utilisation


### PR DESCRIPTION
- Added network ether total getters and mutators to RocketPool
- Increasing and decreasing total network capacity based on minipool events (creation, removal)
- Increasing total network assigned balance based on minipool events (user deposits)
- Added network utilisation getter to RocketPool
- Updated RocketNodeAPI RPL ratio getter to return correct value based on utilisation & formula
- Made minor adjustments to RPL ratio checks
- Updated unit tests to account for new RPL ratio formula
- Added network utilisation and RPL ratio value tests