### PR TITLE
Reworked pubsub system

### DIFF
--- a/contracts/RocketNode.sol
+++ b/contracts/RocketNode.sol
@@ -26,26 +26,19 @@ contract RocketNode is RocketBase {
     }
 
 
-    /*** Subscription ************/
+    /*** Subscriptions ***********/
 
 
-    /// @dev Pubsub event notifications
-    function notify(bytes32 _event, bytes memory _data) public onlyLatestContract("utilPublisher", msg.sender) {
+    /// @dev Minipool available status changed
+    function onMinipoolAvailableChange(address, bool _available, address _nodeOwner, bool _trusted, string memory _durationID) public onlyLatestContract("utilPublisher", msg.sender) {
 
-        // Minipool available status change
-        if (_event == keccak256("minipool.available.change")) {
-            (, bool available, address nodeOwner, bool trusted, string memory durationID) = abi.decode(_data, (address, bool, address, bool, string));
+        // Set node available if minipool available
+        if (_available) { setNodeAvailable(_nodeOwner, _trusted, _durationID); }
 
-            // Set node available if minipool available
-            if (available) { setNodeAvailable(nodeOwner, trusted, durationID); }
-
-            // Set node unavailable if last minipool made unavailable
-            else {
-                rocketPool = RocketPoolInterface(getContractAddress("rocketPool"));
-                if (rocketPool.getAvailableNodePoolsCount(nodeOwner, trusted, durationID) == 0) { setNodeUnavailable(nodeOwner, trusted, durationID); }
-            }
-
-            return;
+        // Set node unavailable if last minipool made unavailable
+        else {
+            rocketPool = RocketPoolInterface(getContractAddress("rocketPool"));
+            if (rocketPool.getAvailableNodePoolsCount(_nodeOwner, _trusted, _durationID) == 0) { setNodeUnavailable(_nodeOwner, _trusted, _durationID); }
         }
 
     }

--- a/contracts/RocketPool.sol
+++ b/contracts/RocketPool.sol
@@ -76,35 +76,24 @@ contract RocketPool is RocketBase {
     }
 
 
-    /*** Subscription ************/
+    /*** Subscriptions ***********/
 
-    /// @dev Pubsub event notifications
-    function notify(bytes32 _event, bytes memory _data) public onlyLatestContract("utilPublisher", msg.sender) {
+    /// @dev Minipool status changed
+    function onMinipoolStatusChange(address _minipoolAddress, uint8 _newStatus) public onlyLatestContract("utilPublisher", msg.sender) {
 
-        // Minipool status change
-        if (_event == keccak256("minipool.status.change")) {
-            (address minipoolAddress, uint8 newStatus) = abi.decode(_data, (address, uint8));
+        // Staking / timed out - set minipool unavailable
+        if (_newStatus == uint8(2) || _newStatus == uint8(6)) { minipoolAvailable(_minipoolAddress, false); }
 
-            // Staking / timed out - set minipool unavailable
-            if (newStatus == uint8(2) || newStatus == uint8(6)) { minipoolAvailable(minipoolAddress, false); }
+    }
 
-            return;
-        }
+    /// @dev Minipool user deposit made
+    function onMinipoolUserDeposit(string memory _durationID, uint256 _depositAmount) public onlyLatestContract("utilPublisher", msg.sender) {
+        networkIncreaseTotalEther("assigned", _durationID, _depositAmount);
+    }
 
-        // Minipool user deposit - increase total assigned ether
-        if (_event == keccak256("minipool.user.deposit")) {
-            (string memory durationID, uint256 depositAmount) = abi.decode(_data, (string, uint256));
-            networkIncreaseTotalEther("assigned", durationID, depositAmount);
-            return;
-        }
-
-        // Minipool user withdrawal - decrease total assigned ether
-        if (_event == keccak256("minipool.user.withdraw")) {
-            (string memory durationID, uint256 withdrawalAmount) = abi.decode(_data, (string, uint256));
-            networkDecreaseTotalEther("assigned", durationID, withdrawalAmount);
-            return;
-        }
-
+    /// @dev Minipool user withdrawal made
+    function onMinipoolUserWithdraw(string memory _durationID, uint256 _withdrawalAmount) public onlyLatestContract("utilPublisher", msg.sender) {
+        networkDecreaseTotalEther("assigned", _durationID, _withdrawalAmount);
     }
 
 
@@ -256,7 +245,7 @@ contract RocketPool is RocketBase {
         if (_available) { addressSetStorage.addItem(keccak256(abi.encodePacked("minipools", "list.node.available", nodeOwner, trusted, durationID)), _minipool); }
         else { addressSetStorage.removeItem(keccak256(abi.encodePacked("minipools", "list.node.available", nodeOwner, trusted, durationID)), _minipool); }
         // Publish available status event
-        publisher.publish(keccak256("minipool.available.change"), abi.encode(_minipool, _available, nodeOwner, trusted, durationID));
+        publisher.publish(keccak256("minipool.available.change"), abi.encodeWithSignature("onMinipoolAvailableChange(address,bool,address,bool,string)", _minipool, _available, nodeOwner, trusted, durationID));
         // Success
         return true;
     }

--- a/contracts/contract/minipool/RocketMinipoolDelegate.sol
+++ b/contracts/contract/minipool/RocketMinipoolDelegate.sol
@@ -282,7 +282,7 @@ contract RocketMinipoolDelegate {
         users[_user].balance = users[_user].balance.add(msg.value);
         // Publish deposit event
         publisher = PublisherInterface(getContractAddress("utilPublisher"));
-        publisher.publish(keccak256("minipool.user.deposit"), abi.encode(staking.id, msg.value));
+        publisher.publish(keccak256("minipool.user.deposit"), abi.encodeWithSignature("onMinipoolUserDeposit(string,uint256)", staking.id, msg.value));
         // All good? Fire the event for the new deposit
         emit PoolTransfer(msg.sender, address(this), keccak256("deposit"), msg.value, users[_user].balance, now);
         // Update the status
@@ -311,7 +311,7 @@ contract RocketMinipoolDelegate {
         require(success, "Withdrawal amount could not be transferred to withdrawal address");
         // Publish withdrawal event
         publisher = PublisherInterface(getContractAddress("utilPublisher"));
-        publisher.publish(keccak256("minipool.user.withdraw"), abi.encode(staking.id, amount));
+        publisher.publish(keccak256("minipool.user.withdraw"), abi.encodeWithSignature("onMinipoolUserWithdraw(string,uint256)", staking.id, amount));
         // All good? Fire the event for the withdrawal
         emit PoolTransfer(address(this), _withdrawalAddress, keccak256("withdrawal"), amount, 0, now);
         // Update the status
@@ -394,7 +394,7 @@ contract RocketMinipoolDelegate {
             emit StatusChange(status.current, status.previous, status.time, status.block);
             // Publish status change event
             publisher = PublisherInterface(getContractAddress("utilPublisher"));
-            publisher.publish(keccak256("minipool.status.change"), abi.encode(address(this), _newStatus));
+            publisher.publish(keccak256("minipool.status.change"), abi.encodeWithSignature("onMinipoolStatusChange(address,uint8)", address(this), _newStatus));
         }
     }
     

--- a/contracts/contract/minipool/RocketMinipoolSet.sol
+++ b/contracts/contract/minipool/RocketMinipoolSet.sol
@@ -32,21 +32,14 @@ contract RocketMinipoolSet is RocketBase {
     }
 
 
-    /*** Subscription ************/
+    /*** Subscriptions ***********/
 
 
-    /// @dev Pubsub event notifications
-    function notify(bytes32 _event, bytes memory _data) public onlyLatestContract("utilPublisher", msg.sender) {
+    /// @dev Minipool available status changed
+    function onMinipoolAvailableChange(address _minipool, bool _available, address, bool, string memory _durationID) public onlyLatestContract("utilPublisher", msg.sender) {
 
-        // Minipool available status change
-        if (_event == keccak256("minipool.available.change")) {
-            (address minipool, bool available, , , string memory durationID) = abi.decode(_data, (address, bool, address, bool, string));
-
-            // Remove minipool from active set if unavailable
-            if (!available) { removeActiveMinipool(durationID, minipool); }
-
-            return;
-        }
+        // Remove minipool from active set if unavailable
+        if (!_available) { removeActiveMinipool(_durationID, _minipool); }
 
     }
 

--- a/contracts/contract/utils/pubsub/Publisher.sol
+++ b/contracts/contract/utils/pubsub/Publisher.sol
@@ -3,7 +3,6 @@ pragma solidity 0.5.0;
 
 import "../../../RocketBase.sol";
 import "../../../interface/utils/lists/StringSetStorageInterface.sol";
-import "../../../interface/utils/pubsub/SubscriberInterface.sol";
 
 
 /// @title PubSub system event publisher
@@ -43,13 +42,13 @@ contract Publisher is RocketBase {
 
     /// @dev Publish event
     /// @param _event The key of the event to publish
-    /// @param _data The ABI encoded data of the event
-    function publish(bytes32 _event, bytes memory _data) public onlyLatestRocketNetwork() {
+    /// @param _payload The ABI encoded subscriber method call payload
+    function publish(bytes32 _event, bytes memory _payload) public onlyLatestRocketNetwork() {
         stringSetStorage = StringSetStorageInterface(getContractAddress("utilStringSetStorage"));
         uint256 count = stringSetStorage.getCount(keccak256(abi.encodePacked("publisher.event", _event)));
         for (uint256 i = 0; i < count; ++i) {
-            SubscriberInterface subscriber = SubscriberInterface(getContractAddress(stringSetStorage.getItem(keccak256(abi.encodePacked("publisher.event", _event)), i)));
-            subscriber.notify(_event, _data);
+            (bool success,) = getContractAddress(stringSetStorage.getItem(keccak256(abi.encodePacked("publisher.event", _event)), i)).call(_payload);
+            require(success, "Subscriber call failed.");
         }
     }
 

--- a/contracts/interface/utils/pubsub/PublisherInterface.sol
+++ b/contracts/interface/utils/pubsub/PublisherInterface.sol
@@ -1,7 +1,7 @@
 pragma solidity 0.5.0;
 
 contract PublisherInterface {
-    function publish(bytes32 _event, bytes memory _data) public;
+    function publish(bytes32 _event, bytes memory _payload) public;
     function addSubscriber(bytes32 _event, string memory _subscriber) public;
     function removeSubscriber(bytes32 _event, string memory _subscriber) public;
 }

--- a/contracts/interface/utils/pubsub/SubscriberInterface.sol
+++ b/contracts/interface/utils/pubsub/SubscriberInterface.sol
@@ -1,5 +1,0 @@
-pragma solidity 0.5.0;
-
-contract SubscriberInterface {
-    function notify(bytes32 _event, bytes memory _data) public;
-}


### PR DESCRIPTION
Had an idea & made some alterations to the PubSub system to make it slightly more safe & reliant on static typing instead of decoding too much at runtime. Basically, instead of having a single notify method, subscribers can have multiple listener methods named like `onMinipoolStatusChange`, `onMinipoolUserDeposit`, etc. `The Publisher.publish` method now takes a `payload` parameter and uses it to make an `address.call` call. The `SubscriberInterface` is no longer needed, as the listener method called is defined in the `payload` param.

Pros:
- A bit safer than the previous approach - we are doing dynamic dispatch with `address.call`, but since the parameter decoding is handled by the EVM internally and will fail if the method call is incorrect, it's impossible to decode incorrectly
- We get to have multiple listener methods in a contract rather than grouping them all into a single `notify` method and switching on the event name, which looks a bit cleaner now imo
- Listener methods will consume a little less gas when run due to slightly simplified logic
- No need to cast contract addresses to a `SubscriberInterface` within the `Publisher.publish` method loop

Cons:
- Calls to `Publisher.publish` now look more verbose as we have to include the listener method signature in the payload, using `abi.encodeWithSignature`
- Contracts with many different listener methods will have a slightly larger ABI, and potentially marginally heavier bytecode, due to more methods

I think I like this approach better but it's pretty subjective and I could go either way. See what you think and feel free to merge this in if you like it or knock it back otherwise!