### PR TITLE
Rocket beth token

### DIFF
--- a/contracts/contract/api/RocketGroupAPI.sol
+++ b/contracts/contract/api/RocketGroupAPI.sol
@@ -3,7 +3,7 @@ pragma solidity 0.5.0;
 // Contracts
 import "../../RocketBase.sol";
 import "../../contract/group/RocketGroupContract.sol";
-import "../../contract/group/RocketGroupAccessorContract.sol";
+import "../../contract/group/RocketGroupAccessorFactory.sol";
 // Interfaces
 import "../../interface/settings/RocketGroupSettingsInterface.sol";
 import "../../interface/utils/lists/AddressSetStorageInterface.sol";
@@ -24,6 +24,7 @@ contract RocketGroupAPI is RocketBase {
 
     /*** Contracts *************/
 
+    RocketGroupAccessorFactory rocketGroupAccessorFactory = RocketGroupAccessorFactory(0);        // The default Rocket Group Accessor factory
     RocketGroupSettingsInterface rocketGroupSettings = RocketGroupSettingsInterface(0);           // Settings for the groups
     AddressSetStorageInterface addressSetStorage = AddressSetStorageInterface(0);                 // Address list utility
    
@@ -132,7 +133,8 @@ contract RocketGroupAPI is RocketBase {
         // Check that the group exists
         require(rocketStorage.getAddress(keccak256(abi.encodePacked("group.id", _ID))) != address(0x0), "Invalid group ID");
         // Create accessor contract
-        address newAccessorAddress = address(new RocketGroupAccessorContract(address(rocketStorage), _ID));
+        rocketGroupAccessorFactory = RocketGroupAccessorFactory(getContractAddress("rocketGroupAccessorFactory"));
+        address newAccessorAddress = rocketGroupAccessorFactory.createDefaultAccessor(_ID);
         // Emit creation event
         emit GroupCreateDefaultAccessor(_ID, newAccessorAddress, now);
         // Success

--- a/contracts/contract/casper/DummyWithdraw.sol
+++ b/contracts/contract/casper/DummyWithdraw.sol
@@ -44,7 +44,7 @@ contract DummyWithdraw is RocketBase {
         rocketBETHToken = RocketBETHTokenInterface(getContractAddress("rocketBETHToken"));
         rocketBETHToken.mint(_to, _amount);
         // Transfer withdrawal amount to RPB contract
-        address(rocketBETHToken).transfer(_amount);
+        address(uint160(address(rocketBETHToken))).transfer(_amount);
         // Emit withdrawal event
         emit Withdrawal(_to, _amount, now);
     }

--- a/contracts/contract/casper/DummyWithdraw.sol
+++ b/contracts/contract/casper/DummyWithdraw.sol
@@ -1,53 +1,5 @@
-pragma solidity 0.5.0;
+pragma solidity ^0.5.0;
 
+import "beacon-chain-simulator/contracts/Withdraw.sol";
 
-import "../../RocketBase.sol";
-import "../../interface/token/RocketBETHTokenInterface.sol";
-
-
-contract DummyWithdraw is RocketBase {
-
-
-    /*** Contracts **************/
-
-
-    RocketBETHTokenInterface rocketBETHToken = RocketBETHTokenInterface(0);
-
-
-    /*** Events *****************/
-
-
-    /// @dev Validator withdrawal
-    event Withdrawal(address indexed to, uint256 amount, uint256 time);
-
-
-    /*** Methods ****************/
-
-
-    /// @dev DummyWithdraw constructor
-    constructor(address _rocketStorageAddress) RocketBase(_rocketStorageAddress) public {}
-
-
-    /// @dev Default payable function
-    function() external payable {}
-
-
-    /// @dev Withdraw from Casper
-    /// @dev _to The address to mint RPB tokens to
-    /// @dev _amount The amount of ether to transfer to the RPB contract and mint tokens for
-    function withdraw(address payable _to, uint256 _amount) external onlySuperUser {
-        // Check arguments
-        require(_to != address(0x0), "Invalid to address");
-        require(_amount > 0, "Invalid withdrawal amount");
-        require(_amount <= address(this).balance, "Insufficient contract balance for withdrawal");
-        // Mint RPB tokens to address
-        rocketBETHToken = RocketBETHTokenInterface(getContractAddress("rocketBETHToken"));
-        rocketBETHToken.mint(_to, _amount);
-        // Transfer withdrawal amount to RPB contract
-        address(uint160(address(rocketBETHToken))).transfer(_amount);
-        // Emit withdrawal event
-        emit Withdrawal(_to, _amount, now);
-    }
-
-
-}
+contract DummyWithdraw is Withdraw {}

--- a/contracts/contract/casper/DummyWithdraw.sol
+++ b/contracts/contract/casper/DummyWithdraw.sol
@@ -1,5 +1,53 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.5.0;
 
-import "beacon-chain-simulator/contracts/Withdraw.sol";
 
-contract DummyWithdraw is Withdraw {}
+import "../../RocketBase.sol";
+import "../../interface/token/RocketBETHTokenInterface.sol";
+
+
+contract DummyWithdraw is RocketBase {
+
+
+    /*** Contracts **************/
+
+
+    RocketBETHTokenInterface rocketBETHToken = RocketBETHTokenInterface(0);
+
+
+    /*** Events *****************/
+
+
+    /// @dev Validator withdrawal
+    event Withdrawal(address indexed to, uint256 amount, uint256 time);
+
+
+    /*** Methods ****************/
+
+
+    /// @dev DummyWithdraw constructor
+    constructor(address _rocketStorageAddress) RocketBase(_rocketStorageAddress) public {}
+
+
+    /// @dev Default payable function
+    function() external payable {}
+
+
+    /// @dev Withdraw from Casper
+    /// @dev _to The address to mint RPB tokens to
+    /// @dev _amount The amount of ether to transfer to the RPB contract and mint tokens for
+    function withdraw(address payable _to, uint256 _amount) external onlySuperUser {
+        // Check arguments
+        require(_to != address(0x0), "Invalid to address");
+        require(_amount > 0, "Invalid withdrawal amount");
+        require(_amount <= address(this).balance, "Insufficient contract balance for withdrawal");
+        // Mint RPB tokens to address
+        rocketBETHToken = RocketBETHTokenInterface(getContractAddress("rocketBETHToken"));
+        rocketBETHToken.mint(_to, _amount);
+        // Transfer withdrawal amount to RPB contract
+        address(rocketBETHToken).transfer(_amount);
+        // Emit withdrawal event
+        emit Withdrawal(_to, _amount, now);
+    }
+
+
+}

--- a/contracts/contract/deposit/RocketDeposit.sol
+++ b/contracts/contract/deposit/RocketDeposit.sol
@@ -7,7 +7,7 @@ import "../../interface/deposit/RocketDepositVaultInterface.sol";
 import "../../interface/group/RocketGroupAccessorContractInterface.sol";
 import "../../interface/minipool/RocketMinipoolInterface.sol";
 import "../../interface/settings/RocketDepositSettingsInterface.sol";
-import "../../interface/tokens/RocketBETHTokenInterface.sol";
+import "../../interface/token/RocketBETHTokenInterface.sol";
 import "../../interface/utils/lists/AddressSetStorageInterface.sol";
 import "../../interface/utils/lists/Bytes32SetStorageInterface.sol";
 import "../../lib/SafeMath.sol";
@@ -160,7 +160,7 @@ contract RocketDeposit is RocketBase {
         uint256 tokenAmount = _amount.mul(calcBase.sub(rocketDepositSettings.getStakingWithdrawalFeePerc())).div(calcBase);
 
         // Mint RPB tokens to withdrawer address
-        RocketBETHTokenInterface rocketBETHToken = RocketBETHTokenInterface(getContractAddress("rocketBETHToken"));
+        rocketBETHToken = RocketBETHTokenInterface(getContractAddress("rocketBETHToken"));
         rocketBETHToken.mint(_withdrawerAddress, tokenAmount);
 
         // Withdraw amount from minipool

--- a/contracts/contract/deposit/RocketDeposit.sol
+++ b/contracts/contract/deposit/RocketDeposit.sol
@@ -6,6 +6,8 @@ import "../../interface/deposit/RocketDepositQueueInterface.sol";
 import "../../interface/deposit/RocketDepositVaultInterface.sol";
 import "../../interface/group/RocketGroupAccessorContractInterface.sol";
 import "../../interface/minipool/RocketMinipoolInterface.sol";
+import "../../interface/settings/RocketDepositSettingsInterface.sol";
+import "../../interface/tokens/RocketBETHTokenInterface.sol";
 import "../../interface/utils/lists/AddressSetStorageInterface.sol";
 import "../../interface/utils/lists/Bytes32SetStorageInterface.sol";
 import "../../lib/SafeMath.sol";
@@ -23,11 +25,19 @@ contract RocketDeposit is RocketBase {
     using SafeMath for uint256;
 
 
+    /**** Properties ************/
+
+
+    uint256 private calcBase = 1 ether;
+
+
     /*** Contracts **************/
 
 
     RocketDepositQueueInterface rocketDepositQueue = RocketDepositQueueInterface(0);
     RocketDepositVaultInterface rocketDepositVault = RocketDepositVaultInterface(0);
+    RocketDepositSettingsInterface rocketDepositSettings = RocketDepositSettingsInterface(0);
+    RocketBETHTokenInterface rocketBETHToken = RocketBETHTokenInterface(0);
     AddressSetStorageInterface addressSetStorage = AddressSetStorageInterface(0);
     Bytes32SetStorageInterface bytes32SetStorage = Bytes32SetStorageInterface(0);
 
@@ -55,7 +65,7 @@ contract RocketDeposit is RocketBase {
     }
 
 
-    // Default payable function - for deposit vault or minipool withdrawals
+    // Default payable function - for deposit vault withdrawals or minipool refunds
     function() external payable onlyDepositVaultOrMinipool() {}
 
 
@@ -85,7 +95,7 @@ contract RocketDeposit is RocketBase {
     }
 
 
-    // Refund a deposit
+    // Refund a queued deposit
     function refund(address _userID, address _groupID, string memory _durationID, bytes32 _depositID, address _depositorAddress) public onlyLatestContract("rocketDepositAPI", msg.sender) returns (uint256) {
 
         // Get remaining queued amount to refund
@@ -113,34 +123,90 @@ contract RocketDeposit is RocketBase {
     }
 
 
-    // Withdraw a deposit fragment from a withdrawn or timed out minipool
-    function withdraw(address _userID, address _groupID, bytes32 _depositID, address _minipool, address _withdrawerAddress) public returns (uint256) {
-
-        // Get contracts
-        addressSetStorage = AddressSetStorageInterface(getContractAddress("utilAddressSetStorage"));
+    // Refund a deposit fragment from a stalled minipool
+    function refundFromStalledMinipool(address _userID, address _groupID, bytes32 _depositID, address _minipool, address _depositorAddress) public onlyLatestContract("rocketDepositAPI", msg.sender) returns (uint256) {
 
         // Check deposit details
-        require(rocketStorage.getBool(keccak256(abi.encodePacked("deposit.exists", _depositID))), "Deposit does not exist");
-        require(rocketStorage.getAddress(keccak256(abi.encodePacked("deposit.userID", _depositID))) == _userID, "Incorrect deposit user ID");
-        require(rocketStorage.getAddress(keccak256(abi.encodePacked("deposit.groupID", _depositID))) == _groupID, "Incorrect deposit group ID");
-        require(addressSetStorage.getIndexOf(keccak256(abi.encodePacked("deposit.stakingPools", _depositID)), _minipool) != -1, "Deposit is not staking under minipool");
+        checkDepositDetails(_userID, _groupID, _depositID, _minipool);
 
-        // Get minipool user balance & Withdraw deposit from minipool
+        // Get minipool user balance & refund deposit from minipool
         RocketMinipoolInterface minipool = RocketMinipoolInterface(_minipool);
-        uint256 withdrawalAmount = minipool.getUserDeposit(_userID);
-        minipool.withdraw(_userID, _groupID, address(this));
+        uint256 refundAmount = minipool.getUserDeposit(_userID);
+        minipool.refund(_userID, _groupID, address(this));
 
         // Update deposit pool details
+        addressSetStorage = AddressSetStorageInterface(getContractAddress("utilAddressSetStorage"));
         addressSetStorage.removeItem(keccak256(abi.encodePacked("deposit.stakingPools", _depositID)), _minipool);
         rocketStorage.setUint(keccak256(abi.encodePacked("deposit.stakingPoolAmount", _depositID, _minipool)), 0);
 
-        // Transfer refund amount to withdrawer
-        RocketGroupAccessorContractInterface withdrawer = RocketGroupAccessorContractInterface(_withdrawerAddress);
-        require(withdrawer.rocketpoolEtherDeposit.value(withdrawalAmount)(), "Minipool deposit could not be sent to group withdrawer");
+        // Transfer refund amount to depositor
+        RocketGroupAccessorContractInterface depositor = RocketGroupAccessorContractInterface(_depositorAddress);
+        require(depositor.rocketpoolEtherDeposit.value(refundAmount)(), "Minipool deposit refund could not be sent to group depositor");
+
+        // Return refunded amount
+        return refundAmount;
+
+    }
+
+
+    // Withdraw some amount of a deposit fragment from a staking minipool as RPB tokens
+    function withdrawFromStakingMinipool(address _userID, address _groupID, bytes32 _depositID, address _minipool, uint256 _amount, address _withdrawerAddress) public onlyLatestContract("rocketDepositAPI", msg.sender) returns (uint256) {
+
+        // Check deposit details
+        checkDepositDetails(_userID, _groupID, _depositID, _minipool);
+
+        // Get RPB token amount to withdraw
+        rocketDepositSettings = RocketDepositSettingsInterface(getContractAddress("rocketDepositSettings"));
+        uint256 tokenAmount = _amount.mul(calcBase.sub(rocketDepositSettings.getStakingWithdrawalFeePerc())).div(calcBase);
+
+        // Mint RPB tokens to withdrawer address
+        RocketBETHTokenInterface rocketBETHToken = RocketBETHTokenInterface(getContractAddress("rocketBETHToken"));
+        rocketBETHToken.mint(_withdrawerAddress, tokenAmount);
+
+        // Withdraw amount from minipool
+        RocketMinipoolInterface minipool = RocketMinipoolInterface(_minipool);
+        minipool.withdrawStaking(_userID, _groupID, _amount, tokenAmount, _withdrawerAddress);
+
+        // Update deposit pool details
+        if (!minipool.getUserHasDeposit(_userID)) { addressSetStorage.removeItem(keccak256(abi.encodePacked("deposit.stakingPools", _depositID)), _minipool); }
+        uint256 stakingPoolAmount = rocketStorage.getUint(keccak256(abi.encodePacked("deposit.stakingPoolAmount", _depositID, _minipool)));
+        rocketStorage.setUint(keccak256(abi.encodePacked("deposit.stakingPoolAmount", _depositID, _minipool)), stakingPoolAmount.sub(_amount));
+
+        // Return token amount withdrawn
+        return tokenAmount;
+
+    }
+
+
+    // Withdraw a deposit fragment from a withdrawn minipool as RPB tokens
+    function withdrawFromWithdrawnMinipool(address _userID, address _groupID, bytes32 _depositID, address _minipool, address _withdrawerAddress) public onlyLatestContract("rocketDepositAPI", msg.sender) returns (uint256) {
+
+        // Check deposit details
+        checkDepositDetails(_userID, _groupID, _depositID, _minipool);
+
+        // Get minipool user balance & withdraw deposit from minipool
+        RocketMinipoolInterface minipool = RocketMinipoolInterface(_minipool);
+        uint256 withdrawalAmount = minipool.getUserDeposit(_userID);
+        minipool.withdraw(_userID, _groupID, _withdrawerAddress);
+
+        // Update deposit pool details
+        addressSetStorage = AddressSetStorageInterface(getContractAddress("utilAddressSetStorage"));
+        addressSetStorage.removeItem(keccak256(abi.encodePacked("deposit.stakingPools", _depositID)), _minipool);
+        rocketStorage.setUint(keccak256(abi.encodePacked("deposit.stakingPoolAmount", _depositID, _minipool)), 0);
 
         // Return withdrawn amount
         return withdrawalAmount;
 
+    }
+
+
+    // Check deposit details are valid
+    function checkDepositDetails(address _userID, address _groupID, bytes32 _depositID, address _minipool) private {
+        addressSetStorage = AddressSetStorageInterface(getContractAddress("utilAddressSetStorage"));
+        require(rocketStorage.getBool(keccak256(abi.encodePacked("deposit.exists", _depositID))), "Deposit does not exist");
+        require(rocketStorage.getAddress(keccak256(abi.encodePacked("deposit.userID", _depositID))) == _userID, "Incorrect deposit user ID");
+        require(rocketStorage.getAddress(keccak256(abi.encodePacked("deposit.groupID", _depositID))) == _groupID, "Incorrect deposit group ID");
+        require(addressSetStorage.getIndexOf(keccak256(abi.encodePacked("deposit.stakingPools", _depositID)), _minipool) != -1, "Deposit is not staking under minipool");
     }
 
 

--- a/contracts/contract/group/RocketGroupAccessorContract.sol
+++ b/contracts/contract/group/RocketGroupAccessorContract.sol
@@ -1,7 +1,7 @@
 pragma solidity 0.5.0;
 
 
-import "./../../interface/RocketStorageInterface.sol";
+import "../../interface/RocketStorageInterface.sol";
 import "../../interface/api/RocketDepositAPIInterface.sol";
 
 

--- a/contracts/contract/group/RocketGroupAccessorFactory.sol
+++ b/contracts/contract/group/RocketGroupAccessorFactory.sol
@@ -1,0 +1,32 @@
+pragma solidity 0.5.0;
+
+
+import "../../RocketBase.sol";
+import "../../contract/group/RocketGroupAccessorContract.sol";
+
+
+/// @dev Creates default Rocket Group Accessor contracts
+/// @author Jake Pospischil
+
+contract RocketGroupAccessorFactory is RocketBase {
+
+
+    /*** Constructor ************/
+
+
+    /// @dev rocketGroup constructor
+    constructor(address _rocketStorageAddress) RocketBase(_rocketStorageAddress) public {
+        version = 1;
+    }
+
+
+    /*** Methods ****************/
+
+
+    /// @dev Create a new default group accessor contract
+    function createDefaultAccessor(address _ID) public onlyLatestContract("rocketGroupAPI", msg.sender) returns (address) {
+        return address(new RocketGroupAccessorContract(address(rocketStorage), _ID));
+    }
+
+
+}

--- a/contracts/contract/group/RocketGroupContract.sol
+++ b/contracts/contract/group/RocketGroupContract.sol
@@ -1,8 +1,8 @@
 pragma solidity 0.5.0;
 
 // Interfaces
-import "./../../interface/RocketStorageInterface.sol";
-import "./../../interface/settings/RocketGroupSettingsInterface.sol";
+import "../../interface/RocketStorageInterface.sol";
+import "../../interface/settings/RocketGroupSettingsInterface.sol";
 
 
 /// @title The contract for a group that operates in Rocket Pool, holds the entities fees and more

--- a/contracts/contract/minipool/RocketMinipool.sol
+++ b/contracts/contract/minipool/RocketMinipool.sol
@@ -33,7 +33,7 @@ contract RocketMinipool {
     Staking private staking;                                    // Staking properties of the minipool to track
     uint256 private userDepositCapacity;                        // Total capacity for user deposits
     uint256 private userDepositTotal;                           // Total value of all assigned user deposits
-    uint256 private rpbWithdrawnStakingTotal;                   // The total RPB withdrawn while staking
+    uint256 private stakingTokensWithdrawnTotal;                // Total RPB tokens withdrawn during staking
 
     // Users
     mapping (address => User) private users;                    // Users in this pool
@@ -88,7 +88,7 @@ contract RocketMinipool {
         address groupID;                                        // Address ID of the users group
         uint256 balance;                                        // Chunk balance deposited
         int256  rewards;                                        // Rewards received after Casper
-        uint256 depositTokens;                                  // Rocket Pool deposit tokens withdrawn by the user on this minipool
+        uint256 stakingTokensWithdrawn;                         // RPB tokens withdrawn by the user during staking
         uint256 feeRP;                                          // Rocket Pools fee
         uint256 feeGroup;                                       // Group fee
         uint256 created;                                        // Creation timestamp
@@ -316,8 +316,8 @@ contract RocketMinipool {
     }
 
     /// @dev Returns the amount of the deposit tokens the user has taken out
-    function getUserDepositTokens(address _user) public view isPoolUser(_user) returns(uint256) {
-        return users[_user].depositTokens;
+    function getUserStakingTokensWithdrawn(address _user) public view isPoolUser(_user) returns(uint256) {
+        return users[_user].stakingTokensWithdrawn;
     }
 
 

--- a/contracts/contract/minipool/RocketMinipoolDelegate.sol
+++ b/contracts/contract/minipool/RocketMinipoolDelegate.sol
@@ -33,7 +33,7 @@ contract RocketMinipoolDelegate {
     Staking private staking;                                    // Staking properties of the minipool to track
     uint256 private userDepositCapacity;                        // Total capacity for user deposits
     uint256 private userDepositTotal;                           // Total value of all assigned user deposits
-    uint256 private rpbWithdrawnStakingTotal;                   // The total RPB withdrawn while staking
+    uint256 private stakingTokensWithdrawnTotal;                // Total RPB tokens withdrawn during staking
 
     // Users
     mapping (address => User) private users;                    // Users in this pool
@@ -88,7 +88,7 @@ contract RocketMinipoolDelegate {
         address groupID;                                        // Address ID of the users group
         uint256 balance;                                        // Chunk balance deposited
         int256  rewards;                                        // Rewards received after Casper
-        uint256 depositTokens;                                  // Rocket Pool deposit tokens withdrawn by the user on this minipool
+        uint256 stakingTokensWithdrawn;                         // RPB tokens withdrawn by the user during staking
         uint256 feeRP;                                          // Rocket Pools fee
         uint256 feeGroup;                                       // Group fee
         uint256 created;                                        // Creation timestamp
@@ -150,12 +150,6 @@ contract RocketMinipoolDelegate {
         uint256 indexed _statusCodeOld,                         // Pools status code - old
         uint256 time,                                           // The last time the status changed
         uint256 block                                           // The last block number the status changed
-    );
-
-    event DepositTokenFundSent (
-        address indexed _tokenContractAddress,                  // RPD Token Funds Sent
-        uint256 amount,                                         // The amount sent
-        uint256 created                                         // Creation timestamp
     );
 
 
@@ -344,11 +338,11 @@ contract RocketMinipoolDelegate {
         require(users[_user].groupID == _groupID, "User does not exist in group.");
         require(users[_user].balance >= _withdrawnAmount, "Insufficient balance for withdrawal.");
         // Update total RPB withdrawn while staking
-        rpbWithdrawnStakingTotal = rpbWithdrawnStakingTotal.add(_tokenAmount);
+        stakingTokensWithdrawnTotal = stakingTokensWithdrawnTotal.add(_tokenAmount);
         // Decrement user's balance
         users[_user].balance = users[_user].balance.sub(_withdrawnAmount);
         // Increment user's deposit token balance
-        users[_user].depositTokens = users[_user].depositTokens.add(_tokenAmount);
+        users[_user].stakingTokensWithdrawn = users[_user].stakingTokensWithdrawn.add(_tokenAmount);
         // Remove user if balance depleted
         if (users[_user].balance == 0) { removeUser(_user); }
         // Publish withdrawal event
@@ -413,7 +407,7 @@ contract RocketMinipoolDelegate {
                 groupID: _groupID,
                 balance: 0,
                 rewards: 0,
-                depositTokens: 0,
+                stakingTokensWithdrawn: 0,
                 feeRP: rocketGroupSettings.getDefaultFee(),
                 feeGroup: rocketGroupContract.getFeePerc(),
                 exists: true,

--- a/contracts/contract/minipool/RocketMinipoolDelegate.sol
+++ b/contracts/contract/minipool/RocketMinipoolDelegate.sol
@@ -33,6 +33,7 @@ contract RocketMinipoolDelegate {
     Staking private staking;                                    // Staking properties of the minipool to track
     uint256 private userDepositCapacity;                        // Total capacity for user deposits
     uint256 private userDepositTotal;                           // Total value of all assigned user deposits
+    uint256 private rpbWithdrawnStakingTotal;                   // The total RPB withdrawn while staking
 
     // Users
     mapping (address => User) private users;                    // Users in this pool
@@ -44,6 +45,7 @@ contract RocketMinipoolDelegate {
     /*** Contracts **************/
 
     ERC20 rplContract = ERC20(0);                                                                   // The address of our RPL ERC20 token contract
+    ERC20 rpbContract = ERC20(0);                                                                   // The address of our RPB ERC20 token contract
     DepositInterface casperDeposit = DepositInterface(0);                                           // Interface of the Casper deposit contract
     RocketGroupContractInterface rocketGroupContract = RocketGroupContractInterface(0);             // The users group contract that they belong too
     RocketGroupSettingsInterface rocketGroupSettings = RocketGroupSettingsInterface(0);             // The settings for groups
@@ -238,6 +240,7 @@ contract RocketMinipoolDelegate {
     }
 
     /// @dev Withdraw ether / rpl deposit from the minipool if initialised, timed out or withdrawn
+    // TODO: update node withdrawals to withdraw ETH pre-staking and RPB post-staking
     function nodeWithdraw() public isNodeContract(msg.sender) returns(bool) {
         // Check current status
         require(status.current == 0 || status.current == 4 || status.current == 6, "Minipool is not currently allowing node withdrawals.");
@@ -296,13 +299,77 @@ contract RocketMinipoolDelegate {
         return true;
     }
 
-    /// @dev Withdraw a user's deposit and remove them from this contract.
+    /// @dev Refund a user's deposit and remove them from this contract (if minipool stalled).
+    /// @param _user User address
+    /// @param _groupID The 3rd party group the user belongs to
+    /// @param _refundAddress The address to refund the user's deposit to
+    function refund(address _user, address _groupID, address _refundAddress) public onlyLatestContract("rocketDeposit") returns(bool) {
+        // Check current status
+        require(status.current == 6, "Minipool is not currently allowing refunds.");
+        // Check user address, group ID and balance
+        require(users[_user].exists, "User does not exist in minipool.");
+        require(users[_user].groupID == _groupID, "User does not exist in group.");
+        require(users[_user].balance > 0, "User does not have remaining balance in minipool.");
+        // Get remaining balance as refund amount
+        uint256 amount = users[_user].balance;
+        // Update total user deposit balance
+        userDepositTotal = userDepositTotal.sub(amount);
+        // Remove user
+        removeUser(_user);
+        // Transfer refund amount to refund address
+        (bool success,) = _refundAddress.call.value(amount)("");
+        require(success, "Refund amount could not be transferred to refund address");
+        // Publish refund event
+        publisher = PublisherInterface(getContractAddress("utilPublisher"));
+        publisher.publish(keccak256("minipool.user.refund"), abi.encodeWithSignature("onMinipoolUserRefund(string,uint256)", staking.id, amount));
+        // All good? Fire the event for the refund
+        emit PoolTransfer(address(this), _refundAddress, keccak256("refund"), amount, 0, now);
+        // Update the status
+        updateStatus();
+        // Success
+        return true;
+    }
+
+    /// @dev Withdraw some amount of a user's deposit as RPB tokens, forfeiting rewards for that amount, and remove them if entire deposit is withdrawn (if minipool staking).
+    /// @param _user User address
+    /// @param _groupID The 3rd party group the user belongs to
+    /// @param _withdrawnAmount The amount of the user's deposit withdrawn
+    /// @param _tokenAmount The amount of RPB tokens withdrawn
+    /// @param _withdrawnAddress The address the user's deposit was withdrawn to
+    function withdrawStaking(address _user, address _groupID, uint256 _withdrawnAmount, uint256 _tokenAmount, address _withdrawnAddress) public onlyLatestContract("rocketDeposit") returns(bool) {
+        // Check current status
+        require(status.current == 2 || status.current == 3, "Minipool is not currently allowing early withdrawals.");
+        // Check user address, group ID and withdrawn amount
+        require(users[_user].exists, "User does not exist in minipool.");
+        require(users[_user].groupID == _groupID, "User does not exist in group.");
+        require(users[_user].balance >= _withdrawnAmount, "Insufficient balance for withdrawal.");
+        // Update total RPB withdrawn while staking
+        rpbWithdrawnStakingTotal = rpbWithdrawnStakingTotal.add(_tokenAmount);
+        // Decrement user's balance
+        users[_user].balance = users[_user].balance.sub(_withdrawnAmount);
+        // Increment user's deposit token balance
+        users[_user].depositTokens = users[_user].depositTokens.add(_tokenAmount);
+        // Remove user if balance depleted
+        if (users[_user].balance == 0) { removeUser(_user); }
+        // Publish withdrawal event
+        publisher = PublisherInterface(getContractAddress("utilPublisher"));
+        publisher.publish(keccak256("minipool.user.withdraw"), abi.encodeWithSignature("onMinipoolUserWithdraw(string,uint256)", staking.id, _withdrawnAmount));
+        // All good? Fire the event for the withdrawal
+        emit PoolTransfer(address(this), _withdrawnAddress, keccak256("withdrawal"), _withdrawnAmount, 0, now);
+        // Update the status
+        updateStatus();
+        // Success
+        return true;
+    }
+
+    /// @dev Withdraw a user's deposit as RPB tokens and remove them from this contract (if minipool withdrawn).
     /// @param _user User address
     /// @param _groupID The 3rd party group the user belongs to
     /// @param _withdrawalAddress The address to withdraw the user's deposit to
+    // TODO: update to account for rewards instead of only matching deposit amount
     function withdraw(address _user, address _groupID, address _withdrawalAddress) public onlyLatestContract("rocketDeposit") returns(bool) {
         // Check current status
-        require(status.current == 4 || status.current == 6, "Minipool is not currently allowing withdrawals.");
+        require(status.current == 4, "Minipool is not currently allowing withdrawals.");
         // Check user address, group ID and balance
         require(users[_user].exists, "User does not exist in minipool.");
         require(users[_user].groupID == _groupID, "User does not exist in group.");
@@ -313,9 +380,9 @@ contract RocketMinipoolDelegate {
         userDepositTotal = userDepositTotal.sub(amount);
         // Remove user
         removeUser(_user);
-        // Transfer withdrawal amount to withdrawal address
-        (bool success,) = _withdrawalAddress.call.value(amount)("");
-        require(success, "Withdrawal amount could not be transferred to withdrawal address");
+        // Transfer withdrawal amount to withdrawal address as RPB tokens
+        rpbContract = ERC20(getContractAddress("rocketBETHToken"));
+        require(rpbContract.transfer(_withdrawalAddress, amount), "Withdrawal amount could not be transferred to withdrawal address as RPB tokens");
         // Publish withdrawal event
         publisher = PublisherInterface(getContractAddress("utilPublisher"));
         publisher.publish(keccak256("minipool.user.withdraw"), abi.encodeWithSignature("onMinipoolUserWithdraw(string,uint256)", staking.id, amount));

--- a/contracts/contract/node/RocketNodeContract.sol
+++ b/contracts/contract/node/RocketNodeContract.sol
@@ -1,15 +1,15 @@
 pragma solidity 0.5.0;
 
 // Interfaces
-import "./../../interface/token/ERC20.sol";
-import "./../../interface/RocketStorageInterface.sol";
-import "./../../interface/api/RocketNodeAPIInterface.sol";
-import "./../../interface/node/RocketNodeKeysInterface.sol";
-import "./../../interface/minipool/RocketMinipoolInterface.sol";
-import "./../../interface/settings/RocketNodeSettingsInterface.sol";
-import "./../../interface/settings/RocketMinipoolSettingsInterface.sol";
+import "../../interface/token/ERC20.sol";
+import "../../interface/RocketStorageInterface.sol";
+import "../../interface/api/RocketNodeAPIInterface.sol";
+import "../../interface/node/RocketNodeKeysInterface.sol";
+import "../../interface/minipool/RocketMinipoolInterface.sol";
+import "../../interface/settings/RocketNodeSettingsInterface.sol";
+import "../../interface/settings/RocketMinipoolSettingsInterface.sol";
 // Libraries
-import "./../../lib/SafeMath.sol";
+import "../../lib/SafeMath.sol";
 
 
 /// @title The contract for a node that operates in Rocket Pool, holds the entities ether/rpl deposits and more

--- a/contracts/contract/settings/RocketDepositSettings.sol
+++ b/contracts/contract/settings/RocketDepositSettings.sol
@@ -39,7 +39,8 @@ contract RocketDepositSettings is RocketBase {
             setRefundDepositAllowed(true);                                                  // Are user deposit refunds currently allowed?
             setWithdrawalAllowed(true);                                                     // Are withdrawals allowed?
             setWithdrawalMin(0);                                                            // Min allowed to be withdrawn in Wei, 0 = all
-            setWithdrawalMax(10 ether);                                                     // Max allowed to be withdrawn in Wei     
+            setWithdrawalMax(10 ether);                                                     // Max allowed to be withdrawn in Wei
+            setStakingWithdrawalFeePerc(0.0025 ether);                                      // The staking withdrawal fee given as a % of 1 Ether (eg 0.25%)
             // Initialise settings
             rocketStorage.setBool(keccak256(abi.encodePacked("settings.deposit.init")), true);
         }
@@ -120,6 +121,11 @@ contract RocketDepositSettings is RocketBase {
         return rocketStorage.getUint(keccak256(abi.encodePacked("settings.withdrawal.max"))); 
     }
 
+    /// @dev The staking withdrawal fee given as a % of 1 Ether (eg 0.25%)
+    function getStakingWithdrawalFeePerc() public view returns (uint256) {
+        return rocketStorage.getUint(keccak256(abi.encodePacked("settings.withdrawal.staking.fee"))); 
+    }
+
 
 
     /*** Setters ****************/
@@ -180,6 +186,11 @@ contract RocketDepositSettings is RocketBase {
     /// @dev Max allowed to be withdrawn in Wei
     function setWithdrawalMax(uint256 _weiAmount) public onlySuperUser {
         rocketStorage.setUint(keccak256(abi.encodePacked("settings.withdrawal.max")), _weiAmount); 
+    }
+
+    /// @dev The staking withdrawal fee given as a % of 1 Ether (eg 0.25%)
+    function setStakingWithdrawalFeePerc(uint256 _amount) public onlySuperUser {
+        rocketStorage.setUint(keccak256(abi.encodePacked("settings.withdrawal.staking.fee")), _amount);
     }
 
 

--- a/contracts/contract/token/DummyRocketPoolToken.sol
+++ b/contracts/contract/token/DummyRocketPoolToken.sol
@@ -1,9 +1,9 @@
 pragma solidity 0.5.0;
 
 
-import "./../../contract/utils/Ownable.sol";
-import "./StandardToken.sol"; 
-import "./../../lib/SafeMath.sol";
+import "../utils/Ownable.sol";
+import "./StandardToken.sol";
+import "../../lib/SafeMath.sol";
 
 
 /// @title Dummy Rocket Pool Token (RPL) contract

--- a/contracts/contract/token/RocketBETHToken.sol
+++ b/contracts/contract/token/RocketBETHToken.sol
@@ -1,0 +1,101 @@
+pragma solidity 0.5.0;
+
+
+import "../../RocketBase.sol";
+import "./StandardToken.sol";
+
+
+contract RocketBETHToken is StandardToken, RocketBase {
+
+
+    /**** Properties ************/
+
+
+    string public name = "Rocket Pool BETH";
+    string public symbol = "RPB";
+    string public version = "1.0";
+    uint8 public constant decimals = 18;
+    uint256 public totalSupply = 0;
+
+
+    /*** Events *****************/
+
+
+    event Mint(
+        address indexed _to,
+        uint256 value,
+        uint256 created
+    );
+
+    event Burn(
+        address indexed _owner,
+        uint256 value,
+        uint256 created
+    );
+
+    event Deposit(
+        address indexed _sender,
+        uint256 value,
+        uint256 created
+    );
+
+
+    /*** Methods ****************/
+
+
+    /// @dev RocketBETHToken constructor
+    constructor(address _rocketStorageAddress) RocketBase(_rocketStorageAddress) public {}
+
+
+    /// @dev Fallback payable function, receives ether from beacon chain withdrawals
+    function() public payable {
+        emit Deposit(msg.sender, msg.value, now);
+    }
+
+
+    /**
+     * @dev Mint RPB Tokens
+     * @param _to The address that will recieve the minted tokens
+     * @param _amount The amount of tokens to mint
+     * @return A boolean that indicates if the operation was successful
+     */
+    function mint(address _to, uint256 _amount) public returns (bool) {
+        // Check burn amount
+        require(_amount > 0, "Invalid token mint amount");
+        // Mint tokens
+        balances[_to] = balances[_to].add(_amount);
+        // Update total token supply
+        totalSupply = totalSupply.add(_amount);
+        // Fire mint event
+        emit Mint(_to, _amount, now);
+        // Success
+        return true;
+    }
+
+
+    /**
+     * @dev Burn RPB tokens in exchange for ether
+     * @param _amount The amount of tokens to burn
+     * @return A boolean that indicates if the operation was successful
+     */
+    function burnTokensForEther(uint256 _amount) public returns (bool) {
+        // Check burn amount
+        require(_amount > 0, "Invalid token burn amount");
+        // Check sender's token balance
+        require(balances[msg.sender] >= _amount, "Insufficient token balance");
+        // Check contract ether balance
+        require(address(this).balance >= _amount, "Insufficient ether balance for exchange");
+        // Subtract tokens from sender's balance
+        balances[msg.sender] = balances[msg.sender].sub(_amount);
+        // Update total token supply
+        totalSupply = totalSupply.sub(_amount);
+        // Transfer the exchange amount to the sender
+        msg.sender.transfer(_amount);
+        // Fire burn event
+        emit Burn(msg.sender, _amount, now);
+        // Success
+        return true;
+    }
+
+
+}

--- a/contracts/contract/token/RocketBETHToken.sol
+++ b/contracts/contract/token/RocketBETHToken.sol
@@ -40,6 +40,16 @@ contract RocketBETHToken is StandardToken, RocketBase {
     );
 
 
+    /*** Modifiers **************/
+
+
+    // Sender must be Casper withdrawal contract
+    modifier onlyCasperWithdraw() {
+        require(msg.sender == rocketStorage.getAddress(keccak256(abi.encodePacked("contract.name", "casperWithdraw"))), "Sender is not Casper withdrawal contract");
+        _;
+    }
+
+
     /*** Methods ****************/
 
 
@@ -59,7 +69,7 @@ contract RocketBETHToken is StandardToken, RocketBase {
      * @param _amount The amount of tokens to mint
      * @return A boolean that indicates if the operation was successful
      */
-    function mint(address _to, uint256 _amount) public returns (bool) {
+    function mint(address _to, uint256 _amount) public onlyCasperWithdraw returns (bool) {
         // Check burn amount
         require(_amount > 0, "Invalid token mint amount");
         // Mint tokens

--- a/contracts/contract/token/RocketBETHToken.sol
+++ b/contracts/contract/token/RocketBETHToken.sol
@@ -58,7 +58,7 @@ contract RocketBETHToken is StandardToken, RocketBase {
 
 
     /// @dev Fallback payable function, receives ether from beacon chain withdrawals
-    function() public payable {
+    function() external payable {
         emit Deposit(msg.sender, msg.value, now);
     }
 

--- a/contracts/contract/token/RocketBETHToken.sol
+++ b/contracts/contract/token/RocketBETHToken.sol
@@ -43,9 +43,13 @@ contract RocketBETHToken is StandardToken, RocketBase {
     /*** Modifiers **************/
 
 
-    // Sender must be Casper withdrawal contract
-    modifier onlyCasperWithdraw() {
-        require(msg.sender == rocketStorage.getAddress(keccak256(abi.encodePacked("contract.name", "casperWithdraw"))), "Sender is not Casper withdrawal contract");
+    // Sender must be a super user or RocketDeposit
+    modifier onlySuperUserOrDeposit() {
+        require(
+            (roleHas("owner", msg.sender) || roleHas("admin", msg.sender)) ||
+            msg.sender == rocketStorage.getAddress(keccak256(abi.encodePacked("contract.name", "rocketDeposit"))),
+            "Sender is not a super user or RocketDeposit"
+        );
         _;
     }
 
@@ -69,7 +73,7 @@ contract RocketBETHToken is StandardToken, RocketBase {
      * @param _amount The amount of tokens to mint
      * @return A boolean that indicates if the operation was successful
      */
-    function mint(address _to, uint256 _amount) public onlyCasperWithdraw returns (bool) {
+    function mint(address _to, uint256 _amount) public onlySuperUserOrDeposit returns (bool) {
         // Check burn amount
         require(_amount > 0, "Invalid token mint amount");
         // Mint tokens

--- a/contracts/contract/token/StandardToken.sol
+++ b/contracts/contract/token/StandardToken.sol
@@ -1,7 +1,7 @@
 pragma solidity 0.5.0;
 
 
-import "../../interface/token//ERC20.sol";
+import "../../interface/token/ERC20.sol";
 import "../../lib/SafeMath.sol";
 
 

--- a/contracts/interface/api/RocketDepositAPIInterface.sol
+++ b/contracts/interface/api/RocketDepositAPIInterface.sol
@@ -9,6 +9,8 @@ contract RocketDepositAPIInterface {
     function getUserQueuedDepositBalance(bytes32 _depositID) public view returns (uint256);
     // Methods
     function deposit(address _groupID, address _userID, string memory _durationID) public payable returns(bool);
-    function refundDeposit(address _groupID, address _userID, string memory _durationID, bytes32 _depositID) public returns(uint256);
-    function withdrawMinipoolDeposit(address _groupID, address _userID, bytes32 _depositID, address _minipool) public returns(uint256);
+    function refundDepositQueued(address _groupID, address _userID, string memory _durationID, bytes32 _depositID) public returns(uint256);
+    function refundDepositMinipoolStalled(address _groupID, address _userID, bytes32 _depositID, address _minipool) public returns(uint256);
+    function withdrawDepositMinipoolStaking(address _groupID, address _userID, bytes32 _depositID, address _minipool, uint256 _amount) public returns(uint256);
+    function withdrawDepositMinipool(address _groupID, address _userID, bytes32 _depositID, address _minipool) public returns(uint256);
 }

--- a/contracts/interface/casper/DepositInterface.sol
+++ b/contracts/interface/casper/DepositInterface.sol
@@ -1,7 +1,5 @@
-pragma solidity 0.5.0; 
+pragma solidity 0.5.0;
 
-
-// Casper deposit contract interface
 contract DepositInterface {
     function deposit(bytes memory _depositInput) public payable;
 }

--- a/contracts/interface/deposit/RocketDepositInterface.sol
+++ b/contracts/interface/deposit/RocketDepositInterface.sol
@@ -4,5 +4,7 @@ pragma solidity 0.5.0;
 contract RocketDepositInterface {
     function create(address _userID, address _groupID, string memory _durationID) payable public returns (bool);
     function refund(address _userID, address _groupID, string memory _durationID, bytes32 _depositID, address _depositorAddress) public returns (uint256);
-    function withdraw(address _userID, address _groupID, bytes32 _depositID, address _minipool, address _withdrawerAddress) public returns (uint256);
+    function refundFromStalledMinipool(address _userID, address _groupID, bytes32 _depositID, address _minipool, address _withdrawerAddress) public returns (uint256);
+    function withdrawFromStakingMinipool(address _userID, address _groupID, bytes32 _depositID, address _minipool, uint256 _amount, address _withdrawerAddress) public returns (uint256);
+    function withdrawFromWithdrawnMinipool(address _userID, address _groupID, bytes32 _depositID, address _minipool, address _withdrawerAddress) public returns (uint256);
 }

--- a/contracts/interface/minipool/RocketMinipoolInterface.sol
+++ b/contracts/interface/minipool/RocketMinipoolInterface.sol
@@ -25,6 +25,8 @@ contract RocketMinipoolInterface {
     function nodeDeposit() public payable returns(bool);
     function nodeWithdraw() public returns(bool);
     function deposit(address _user, address _groupID) public payable returns(bool);
+    function refund(address _user, address _groupID, address _refundAddress) public returns(bool);
+    function withdrawStaking(address _user, address _groupID, uint256 _withdrawnAmount, uint256 _tokenAmount, address _withdrawnAddress) public returns(bool);
     function withdraw(address _user, address _groupID, address _withdrawalAddress) public returns(bool);
     function updateStatus() public returns(bool);
 }

--- a/contracts/interface/minipool/RocketMinipoolInterface.sol
+++ b/contracts/interface/minipool/RocketMinipoolInterface.sol
@@ -12,6 +12,7 @@ contract RocketMinipoolInterface {
     function getNodeBalance() public view returns(uint256);
     function getUserCount() public view returns(uint256);
     function getUserExists(address _user) public view returns(bool);
+    function getUserHasDeposit(address _user) public view returns(bool);
     function getUserDeposit(address _user) public view returns(uint256);
     function getStatus() public view returns(uint8);
     function getStatusChangedTime() public view returns(uint256);

--- a/contracts/interface/settings/RocketDepositSettingsInterface.sol
+++ b/contracts/interface/settings/RocketDepositSettingsInterface.sol
@@ -15,4 +15,5 @@ contract RocketDepositSettingsInterface {
     function getWithdrawalAllowed() public view returns (bool);
     function getWithdrawalMin() public view returns (uint256);
     function getWithdrawalMax() public view returns (uint256);
+    function getStakingWithdrawalFeePerc() public view returns (uint256);
 }

--- a/contracts/interface/token/RocketBETHTokenInterface.sol
+++ b/contracts/interface/token/RocketBETHTokenInterface.sol
@@ -1,5 +1,7 @@
 pragma solidity 0.5.0;
 
-contract RocketBETHTokenInterface {
+import "./ERC20.sol";
+
+contract RocketBETHTokenInterface is ERC20 {
     function mint(address _to, uint256 _amount) public returns (bool);
 }

--- a/contracts/interface/token/RocketBETHTokenInterface.sol
+++ b/contracts/interface/token/RocketBETHTokenInterface.sol
@@ -1,0 +1,5 @@
+pragma solidity 0.5.0;
+
+contract RocketBETHTokenInterface {
+    function mint(address _to, uint256 _amount) public returns (bool);
+}

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -33,6 +33,8 @@ contracts.rocketNodeAPI = artifacts.require('./api/RocketNodeAPI.sol');
 contracts.rocketDeposit = artifacts.require('./deposit/RocketDeposit.sol');
 contracts.rocketDepositQueue = artifacts.require('./deposit/RocketDepositQueue.sol');
 contracts.rocketDepositVault = artifacts.require('./deposit/RocketDepositVault.sol');
+// Group
+contracts.rocketGroupAccessorFactory = artifacts.require('./group/RocketGroupAccessorFactory.sol');
 // Node
 contracts.rocketNodeFactory = artifacts.require('./node/RocketNodeFactory.sol');
 contracts.rocketNodeKeys = artifacts.require('./node/RocketNodeKeys.sol');

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -48,6 +48,7 @@ contracts.rocketGroupSettings = artifacts.require('./settings/RocketGroupSetting
 contracts.rocketNodeSettings = artifacts.require('./settings/RocketNodeSettings.sol');
 // Dummy Contracts
 contracts.rocketPoolToken = artifacts.require('./token/DummyRocketPoolToken.sol');
+contracts.rocketBETHToken = artifacts.require('./token/RocketBETHToken.sol');
 // Node tasks
 contracts.taskDisableInactiveNodes = artifacts.require('./tasks/DisableInactiveNodes.sol');
 contracts.taskCalculateNodeFee = artifacts.require('./tasks/CalculateNodeFee.sol');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1501,7 +1501,7 @@
         "@chainsafesystems/ssz": "1.6.0",
         "commander": "2.19.0",
         "lowdb": "1.0.0",
-        "truffle": "5.0.4",
+        "truffle": "5.0.6",
         "web3": "1.0.0-beta.37",
         "ws": "6.1.3"
       },
@@ -1512,9 +1512,9 @@
           "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
         },
         "truffle": {
-          "version": "5.0.4",
-          "resolved": "https://registry.npmjs.org/truffle/-/truffle-5.0.4.tgz",
-          "integrity": "sha512-pZYFbU10Hb6PiTalJm+dB6s1qIZjE5qc0ux5fIgQ7Nj24zDrlYmOYruP3yhuqywwzr3PUHGPxr6hXuje0BFYoA==",
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/truffle/-/truffle-5.0.6.tgz",
+          "integrity": "sha512-SBk42qft5ElzdAoolHzy3TIzIrh/GmbEiI+kKoj2nj4GYZtHdXePWA+cp7AwzhNuXiMaR4UwYqVVhn8yxOiAXg==",
           "requires": {
             "app-module-path": "2.2.0",
             "mocha": "4.1.0",
@@ -4265,9 +4265,9 @@
       }
     },
     "ganache-cli": {
-      "version": "6.2.5",
-      "resolved": "https://registry.npmjs.org/ganache-cli/-/ganache-cli-6.2.5.tgz",
-      "integrity": "sha512-E4SP8QNeuc2N/ojFoCK+08OYHX8yrtGeFtipZmJPPTQ6U8Hmq3JcbXZDxQfChPQUY5mtbRSwptJa4EtiQyJjAQ==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/ganache-cli/-/ganache-cli-6.4.1.tgz",
+      "integrity": "sha512-MUZ1DNnmlTrXnH6EuINuew75AI9d/wbIC0WpZCJo5Endsf6ZwEvfnfxGMpEnVizRri1mon2WWxLGAmALDxVcRQ==",
       "dev": true,
       "requires": {
         "bn.js": "4.11.8",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "babel-preset-stage-2": "^6.24.1",
     "babel-preset-stage-3": "^6.24.1",
     "babel-register": "^6.26.0",
-    "ganache-cli": "^6.1.8",
+    "ganache-cli": "^6.4.1",
     "prettier": "^1.10.2",
     "solidity-coverage": "^0.5.11",
     "truffle": "^5.0.1",

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -26,7 +26,7 @@ fi
 # Beacon chain simulator config
 beacon_port=9545
 deposit_contract_address=0xb50eA9565646e5Ed39688694b283cb185A3CC130
-withdrawal_contract_address=0x75261102F55D523718Fa7A1d82111b8fAf3eCE0E
+withdrawal_contract_address=0xF2493ACAE21783dc004b17B633331AeCe69Aa6d3
 withdrawal_from_address=0xe6ed92d26573c67af5eca7fb2a49a807fb8f88db
 
 ganache_running() {

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -26,7 +26,7 @@ fi
 # Beacon chain simulator config
 beacon_port=9545
 deposit_contract_address=0xb50eA9565646e5Ed39688694b283cb185A3CC130
-withdrawal_contract_address=0xF2493ACAE21783dc004b17B633331AeCe69Aa6d3
+withdrawal_contract_address=0xE73E4F83471fFA4e5b7A626f4cf0906Eb4cA7265
 withdrawal_from_address=0xe6ed92d26573c67af5eca7fb2a49a807fb8f88db
 
 ganache_running() {

--- a/test/_lib/artifacts.js
+++ b/test/_lib/artifacts.js
@@ -2,6 +2,7 @@ const $Web3 = require('web3');
 const $web3 = new $Web3('http://localhost:8545');
 
 export const RocketAdmin = artifacts.require('./contract/RocketAdmin');
+export const RocketBETHToken = artifacts.require('./contract/RocketBETHToken.sol');
 export const RocketDepositAPI = artifacts.require('./contract/RocketDepositAPI');
 export const RocketDepositSettings = artifacts.require('./contract/RocketDepositSettings');
 export const RocketDepositQueue = artifacts.require('./contract/RocketDepositQueue');

--- a/test/rocket-deposit/rocket-deposit-api-deposit-tests.js
+++ b/test/rocket-deposit/rocket-deposit-api-deposit-tests.js
@@ -2,7 +2,7 @@ import { printTitle, assertThrows } from '../_lib/utils/general';
 import { RocketDepositAPI, RocketDepositSettings, RocketMinipoolSettings } from '../_lib/artifacts';
 import { createGroupContract, createGroupAccessorContract, addGroupAccessor } from '../_helpers/rocket-group';
 import { createNodeContract, createNodeMinipools } from '../_helpers/rocket-node';
-import { scenarioDeposit, scenarioRefundDeposit, scenarioRocketpoolEtherDeposit, scenarioAPIDeposit } from './rocket-deposit-api-scenarios';
+import { scenarioDeposit, scenarioRefundQueuedDeposit, scenarioRocketpoolEtherDeposit, scenarioAPIDeposit } from './rocket-deposit-api-scenarios';
 
 export default function() {
 
@@ -165,7 +165,7 @@ export default function() {
             });
 
             // Refund deposit made to fill queue
-            await scenarioRefundDeposit({
+            await scenarioRefundQueuedDeposit({
                 depositorContract: groupAccessorContract,
                 groupID: groupContract.address,
                 durationID: '3m',

--- a/test/rocket-deposit/rocket-deposit-api-refund-minipool-tests.js
+++ b/test/rocket-deposit/rocket-deposit-api-refund-minipool-tests.js
@@ -118,7 +118,7 @@ export default function() {
             // Get deposit ID
             depositID = await rocketDepositAPI.getUserQueuedDepositAt.call(groupContract.address, user2, '3m', 0);
 
-            // Attempt to Refund minipool deposit
+            // Attempt to refund minipool deposit
             await assertThrows(scenarioRefundStalledMinipoolDeposit({
                 depositorContract: groupAccessorContract,
                 depositID: '0x0000000000000000000000000000000000000000000000000000000000000000',

--- a/test/rocket-deposit/rocket-deposit-api-refund-minipool-tests.js
+++ b/test/rocket-deposit/rocket-deposit-api-refund-minipool-tests.js
@@ -7,7 +7,7 @@ import { scenarioDeposit, scenarioRefundStalledMinipoolDeposit, scenarioAPIRefun
 
 export default function() {
 
-    contract('RocketDepositAPI - Withdrawals', async (accounts) => {
+    contract('RocketDepositAPI - Minipool Refunds', async (accounts) => {
 
 
         // Accounts
@@ -47,8 +47,8 @@ export default function() {
         });
 
 
-        // Staker cannot withdraw from a minipool that has not timed out
-        it(printTitle('staker', 'cannot withdraw from a minipool that has not timed out'), async () => {
+        // Staker cannot get refund from a minipool that has not timed out
+        it(printTitle('staker', 'cannot get refund from a minipool that has not timed out'), async () => {
 
             // Create single minipool
             minipoolAddresses = await createNodeMinipools({nodeContract, stakingDurationID: '3m', minipoolCount: 2, nodeOperator, owner});
@@ -78,20 +78,20 @@ export default function() {
             // Get deposit ID
             depositID = await rocketDepositAPI.getUserQueuedDepositAt.call(groupContract.address, user1, '3m', 0);
 
-            // Attempt to withdraw minipool deposit
+            // Attempt to refund minipool deposit
             await assertThrows(scenarioRefundStalledMinipoolDeposit({
-                withdrawerContract: groupAccessorContract,
+                depositorContract: groupAccessorContract,
                 depositID,
                 minipoolAddress: minipool.address,
                 fromAddress: user1,
                 gas: 5000000,
-            }), 'Withdrew from a minipool that has not timed out');
+            }), 'Got a refund from a minipool that has not timed out');
 
         });
 
 
-        // Staker can withdraw from a timed out minipool
-        it(printTitle('staker', 'can withdraw from a timed out minipool'), async () => {
+        // Staker can get refund from a timed out minipool
+        it(printTitle('staker', 'can get refund from a timed out minipool'), async () => {
 
             // Time out minipool
             await timeoutMinipool({minipoolAddress: minipool.address, owner});
@@ -100,9 +100,9 @@ export default function() {
             let status = parseInt(await minipool.getStatus.call());
             assert.equal(status, 6, 'Pre-check failed: minipool is not at TimedOut status');
 
-            // Withdraw minipool deposit
+            // Refund minipool deposit
             await scenarioRefundStalledMinipoolDeposit({
-                withdrawerContract: groupAccessorContract,
+                depositorContract: groupAccessorContract,
                 depositID,
                 minipoolAddress: minipool.address,
                 fromAddress: user1,
@@ -112,38 +112,38 @@ export default function() {
         });
 
 
-        // Staker cannot withdraw a deposit with an invalid ID
-        it(printTitle('staker', 'cannot withdraw a deposit with an invalid ID'), async () => {
+        // Staker cannot get refund for a deposit with an invalid ID
+        it(printTitle('staker', 'cannot get refund for a deposit with an invalid ID'), async () => {
 
             // Get deposit ID
             depositID = await rocketDepositAPI.getUserQueuedDepositAt.call(groupContract.address, user2, '3m', 0);
 
-            // Attempt to withdraw minipool deposit
+            // Attempt to Refund minipool deposit
             await assertThrows(scenarioRefundStalledMinipoolDeposit({
-                withdrawerContract: groupAccessorContract,
+                depositorContract: groupAccessorContract,
                 depositID: '0x0000000000000000000000000000000000000000000000000000000000000000',
                 minipoolAddress: minipool.address,
                 fromAddress: user2,
                 gas: 5000000,
-            }), 'Withdrew from a minipool with an invalid deposit ID');
+            }), 'Got a refund from a minipool with an invalid deposit ID');
 
         });
 
 
-        // Staker cannot withdraw a deposit while refunds are disabled
-        it(printTitle('staker', 'cannot withdraw a deposit while refunds are disabled'), async () => {
+        // Staker cannot get refund for a deposit while refunds are disabled
+        it(printTitle('staker', 'cannot get refund for a deposit while refunds are disabled'), async () => {
 
             // Disable refunds
             await rocketDepositSettings.setRefundDepositAllowed(false, {from: owner, gas: 500000});
 
-            // Attempt to withdraw minipool deposit
+            // Attempt to refund minipool deposit
             await assertThrows(scenarioRefundStalledMinipoolDeposit({
-                withdrawerContract: groupAccessorContract,
+                depositorContract: groupAccessorContract,
                 depositID,
                 minipoolAddress: minipool.address,
                 fromAddress: user2,
                 gas: 5000000,
-            }), 'Withdrew from a minipool while refunds were disabled');
+            }), 'Got a refund from a minipool while refunds were disabled');
 
             // Re-enable refunds
             await rocketDepositSettings.setRefundDepositAllowed(true, {from: owner, gas: 500000});
@@ -151,41 +151,41 @@ export default function() {
         });
 
 
-        // Staker cannot withdraw a nonexistant deposit
-        it(printTitle('staker', 'cannot withdraw a nonexistant deposit'), async () => {
+        // Staker cannot get refund for a nonexistant deposit
+        it(printTitle('staker', 'cannot get refund for a nonexistant deposit'), async () => {
 
             // Nonexistant deposit ID
             await assertThrows(scenarioRefundStalledMinipoolDeposit({
-                withdrawerContract: groupAccessorContract,
+                depositorContract: groupAccessorContract,
                 depositID: '0x0000000000000000000000000000000000000000000000000000000000000001',
                 minipoolAddress: minipool.address,
                 fromAddress: user2,
                 gas: 5000000,
-            }), 'Withdrew from a minipool with an invalid deposit ID');
+            }), 'Got a refund from a minipool with an invalid deposit ID');
 
             // Incorrect minipool
             await assertThrows(scenarioRefundStalledMinipoolDeposit({
-                withdrawerContract: groupAccessorContract,
+                depositorContract: groupAccessorContract,
                 depositID,
                 minipoolAddress: minipoolAddresses[1],
                 fromAddress: user2,
                 gas: 5000000,
-            }), 'Withdrew from a minipool with an invalid minipool address');
+            }), 'Got a refund from a minipool with an invalid minipool address');
 
             // Incorrect user
             await assertThrows(scenarioRefundStalledMinipoolDeposit({
-                withdrawerContract: groupAccessorContract,
+                depositorContract: groupAccessorContract,
                 depositID,
                 minipoolAddress: minipool.address,
                 fromAddress: user3,
                 gas: 5000000,
-            }), 'Withdrew from a minipool with an invalid user ID');
+            }), 'Got a refund from a minipool with an invalid user ID');
 
         });
 
 
-        // Staker cannot withdraw a deposit via deposit API
-        it(printTitle('staker', 'cannot withdraw a deposit via deposit API'), async () => {
+        // Staker cannot get refund for a deposit via deposit API
+        it(printTitle('staker', 'cannot get refund for a deposit via deposit API'), async () => {
 
             // Invalid user ID
             await assertThrows(scenarioAPIRefundStalledMinipoolDeposit({
@@ -195,7 +195,7 @@ export default function() {
                 minipoolAddress: minipool.address,
                 fromAddress: user2,
                 gas: 5000000,
-            }), 'Withdrew from a minipool with an invalid user ID');
+            }), 'Got a refund from a minipool with an invalid user ID');
 
             // Invalid group ID
             await assertThrows(scenarioAPIRefundStalledMinipoolDeposit({
@@ -205,9 +205,9 @@ export default function() {
                 minipoolAddress: minipool.address,
                 fromAddress: user2,
                 gas: 5000000,
-            }), 'Withdrew from a minipool with an invalid group ID');
+            }), 'Got a refund from a minipool with an invalid group ID');
 
-            // Valid parameters; invalid withdrawer
+            // Valid parameters; invalid depositor
             await assertThrows(scenarioAPIRefundStalledMinipoolDeposit({
                 groupID: groupContract.address,
                 userID: user2,
@@ -215,7 +215,7 @@ export default function() {
                 minipoolAddress: minipool.address,
                 fromAddress: user2,
                 gas: 5000000,
-            }), 'Withdrew from a minipool directly via RocketDepositAPI');
+            }), 'Got a refund from a minipool directly via RocketDepositAPI');
 
         });
 

--- a/test/rocket-deposit/rocket-deposit-api-refund-queue-tests.js
+++ b/test/rocket-deposit/rocket-deposit-api-refund-queue-tests.js
@@ -5,7 +5,7 @@ import { scenarioDeposit, scenarioRefundQueuedDeposit, scenarioAPIRefundQueuedDe
 
 export default function() {
 
-    contract('RocketDepositAPI - Refunds', async (accounts) => {
+    contract('RocketDepositAPI - Queue Refunds', async (accounts) => {
 
 
         // Accounts

--- a/test/rocket-deposit/rocket-deposit-api-refund-tests.js
+++ b/test/rocket-deposit/rocket-deposit-api-refund-tests.js
@@ -1,7 +1,7 @@
 import { printTitle, assertThrows } from '../_lib/utils/general';
 import { RocketDepositAPI, RocketDepositSettings } from '../_lib/artifacts';
 import { createGroupContract, createGroupAccessorContract, addGroupAccessor } from '../_helpers/rocket-group';
-import { scenarioDeposit, scenarioRefundDeposit, scenarioAPIRefundDeposit } from './rocket-deposit-api-scenarios';
+import { scenarioDeposit, scenarioRefundQueuedDeposit, scenarioAPIRefundQueuedDeposit } from './rocket-deposit-api-scenarios';
 
 export default function() {
 
@@ -52,7 +52,7 @@ export default function() {
             depositID = await rocketDepositAPI.getUserQueuedDepositAt.call(groupContract.address, user1, '3m', 0);
 
             // Request refund
-            await scenarioRefundDeposit({
+            await scenarioRefundQueuedDeposit({
                 depositorContract: groupAccessorContract,
                 groupID: groupContract.address,
                 durationID: '3m',
@@ -78,7 +78,7 @@ export default function() {
             depositID = await rocketDepositAPI.getUserQueuedDepositAt.call(groupContract.address, user1, '3m', 0);
 
             // Request refund
-            await assertThrows(scenarioRefundDeposit({
+            await assertThrows(scenarioRefundQueuedDeposit({
                 depositorContract: groupAccessorContract,
                 groupID: groupContract.address,
                 durationID: 'beer',
@@ -91,7 +91,7 @@ export default function() {
 
         // Staker cannot refund a deposit with an invalid ID
         it(printTitle('staker', 'cannot refund a deposit with an invalid ID'), async () => {
-            await assertThrows(scenarioRefundDeposit({
+            await assertThrows(scenarioRefundQueuedDeposit({
                 depositorContract: groupAccessorContract,
                 groupID: groupContract.address,
                 durationID: '3m',
@@ -108,7 +108,7 @@ export default function() {
             await rocketDepositSettings.setRefundDepositAllowed(false, {from: owner});
 
             // Request refund
-            await assertThrows(scenarioRefundDeposit({
+            await assertThrows(scenarioRefundQueuedDeposit({
                 depositorContract: groupAccessorContract,
                 groupID: groupContract.address,
                 durationID: '3m',
@@ -126,7 +126,7 @@ export default function() {
         it(printTitle('staker', 'cannot refund a nonexistant deposit'), async () => {
 
             // Nonexistant deposit ID
-            await assertThrows(scenarioRefundDeposit({
+            await assertThrows(scenarioRefundQueuedDeposit({
                 depositorContract: groupAccessorContract,
                 groupID: groupContract.address,
                 durationID: '3m',
@@ -135,7 +135,7 @@ export default function() {
             }), 'Refunded a nonexistant deposit');
 
             // Nonexistant user
-            await assertThrows(scenarioRefundDeposit({
+            await assertThrows(scenarioRefundQueuedDeposit({
                 depositorContract: groupAccessorContract,
                 groupID: groupContract.address,
                 durationID: '3m',
@@ -150,7 +150,7 @@ export default function() {
         it(printTitle('staker', 'cannot refund a deposit via deposit API'), async () => {
 
             // Invalid user ID
-            await assertThrows(scenarioAPIRefundDeposit({
+            await assertThrows(scenarioAPIRefundQueuedDeposit({
                 groupID: groupContract.address,
                 userID: '0x0000000000000000000000000000000000000000',
                 durationID: '3m',
@@ -159,7 +159,7 @@ export default function() {
             }), 'Refunded a deposit with an invalid user ID');
 
             // Invalid group ID
-            await assertThrows(scenarioAPIRefundDeposit({
+            await assertThrows(scenarioAPIRefundQueuedDeposit({
                 groupID: accounts[9],
                 userID: user1,
                 durationID: '3m',
@@ -168,7 +168,7 @@ export default function() {
             }), 'Refunded a deposit with an invalid group ID');
 
             // Valid parameters; invalid depositor
-            await assertThrows(scenarioAPIRefundDeposit({
+            await assertThrows(scenarioAPIRefundQueuedDeposit({
                 groupID: groupContract.address,
                 userID: user1,
                 durationID: '3m',

--- a/test/rocket-deposit/rocket-deposit-api-scenarios.js
+++ b/test/rocket-deposit/rocket-deposit-api-scenarios.js
@@ -170,7 +170,7 @@ export async function scenarioDeposit({depositorContract, durationID, fromAddres
 }
 
 
-// Request a deposit refund
+// Request a refund from a queued deposit
 export async function scenarioRefundQueuedDeposit({depositorContract, groupID, durationID, depositID, fromAddress, gas}) {
     const rocketDepositAPI = await RocketDepositAPI.deployed();
     const rocketDepositQueue = await RocketDepositQueue.deployed();
@@ -203,8 +203,8 @@ export async function scenarioRefundQueuedDeposit({depositorContract, groupID, d
 }
 
 
-// Withdraw deposit from a minipool
-export async function scenarioRefundStalledMinipoolDeposit({withdrawerContract, depositID, minipoolAddress, fromAddress, gas}) {
+// Request a refund from a stalled minipool
+export async function scenarioRefundStalledMinipoolDeposit({depositorContract, depositID, minipoolAddress, fromAddress, gas}) {
     const minipool = await RocketMinipool.at(minipoolAddress);
 
     // Get initial balances
@@ -216,8 +216,8 @@ export async function scenarioRefundStalledMinipoolDeposit({withdrawerContract, 
     let userExists1 = await minipool.getUserExists.call(fromAddress);
     let userDeposit1 = parseInt(await minipool.getUserDeposit.call(fromAddress));
 
-    // Withdraw
-    let result = await withdrawerContract.refundDepositMinipoolStalled(depositID, minipoolAddress, {from: fromAddress, gas: gas});
+    // Refund
+    let result = await depositorContract.refundDepositMinipoolStalled(depositID, minipoolAddress, {from: fromAddress, gas: gas});
     profileGasUsage('RocketGroupAccessorContract.refundDepositMinipoolStalled', result);
 
     // Get updated balances
@@ -255,7 +255,7 @@ export async function scenarioAPIDeposit({groupID, userID, durationID, fromAddre
 }
 
 
-// Attempt a deposit refund via the deposit API
+// Attempt a queued deposit refund via the deposit API
 export async function scenarioAPIRefundQueuedDeposit({groupID, userID, durationID, depositID, fromAddress, gas}) {
     const rocketDepositAPI = await RocketDepositAPI.deployed();
 
@@ -264,11 +264,11 @@ export async function scenarioAPIRefundQueuedDeposit({groupID, userID, durationI
 
 }
 
-// Attempt a minipool deposit withdrawal via the deposit API
+// Attempt a stalled minipool refund via the deposit API
 export async function scenarioAPIRefundStalledMinipoolDeposit({groupID, userID, depositID, minipoolAddress, fromAddress, gas}) {
     const rocketDepositAPI = await RocketDepositAPI.deployed();
 
-    // Withdraw
+    // Refund
     await rocketDepositAPI.refundDepositMinipoolStalled(groupID, userID, depositID, minipoolAddress, {from: fromAddress, gas: gas});
 
 }

--- a/test/rocket-deposit/rocket-deposit-api-scenarios.js
+++ b/test/rocket-deposit/rocket-deposit-api-scenarios.js
@@ -283,3 +283,12 @@ export async function scenarioAPIRefundStalledMinipoolDeposit({groupID, userID, 
 
 }
 
+// Attempt to withdraw from a staking minipool via the deposit API
+export async function scenarioAPIWithdrawStakingMinipoolDeposit({groupID, userID, depositID, minipoolAddress, amount, fromAddress, gas}) {
+    const rocketDepositAPI = await RocketDepositAPI.deployed();
+
+    // Withdraw
+    await rocketDepositAPI.withdrawDepositMinipoolStaking(groupID, userID, depositID, minipoolAddress, amount, {from: fromAddress, gas: gas});
+
+}
+

--- a/test/rocket-deposit/rocket-deposit-api-scenarios.js
+++ b/test/rocket-deposit/rocket-deposit-api-scenarios.js
@@ -239,6 +239,16 @@ export async function scenarioRefundStalledMinipoolDeposit({depositorContract, d
 }
 
 
+// Withdraw a deposit from a staking minipool
+export async function scenarioWithdrawStakingMinipoolDeposit({withdrawerContract, depositID, minipoolAddress, amount, fromAddress, gas}) {
+
+    // Withdraw
+    let result = await withdrawerContract.withdrawDepositMinipoolStaking(depositID, minipoolAddress, amount, {from: fromAddress, gas: gas});
+    profileGasUsage('RocketGroupAccessorContract.withdrawDepositMinipoolStaking', result);
+
+}
+
+
 // Attempt a deposit via the depositor contract rocketpoolEtherDeposit method
 export async function scenarioRocketpoolEtherDeposit({depositorContract, fromAddress, value, gas}) {
     await depositorContract.rocketpoolEtherDeposit({from: fromAddress, value: value, gas: gas});

--- a/test/rocket-deposit/rocket-deposit-api-withdrawal-staking-tests.js
+++ b/test/rocket-deposit/rocket-deposit-api-withdrawal-staking-tests.js
@@ -104,11 +104,12 @@ export default function() {
             assert.equal(status, 2, 'Pre-check failed: minipool is not at Staking status');
 
             // Withdraw partial minipool deposit
-            scenarioWithdrawStakingMinipoolDeposit({
+            await scenarioWithdrawStakingMinipoolDeposit({
                 withdrawerContract: groupAccessorContract,
                 depositID,
                 minipoolAddress: minipool.address,
                 amount: web3.utils.numberToHex(parseInt(depositAmount) / 2),
+                amountInt: parseInt(depositAmount) / 2,
                 fromAddress: user1,
                 gas: 5000000,
             });
@@ -117,7 +118,7 @@ export default function() {
             depositAmount = await minipool.getUserDeposit.call(user1);
 
             // Withdraw remaining minipool deposit
-            scenarioWithdrawStakingMinipoolDeposit({
+            await scenarioWithdrawStakingMinipoolDeposit({
                 withdrawerContract: groupAccessorContract,
                 depositID,
                 minipoolAddress: minipool.address,

--- a/test/rocket-deposit/rocket-deposit-api-withdrawal-staking-tests.js
+++ b/test/rocket-deposit/rocket-deposit-api-withdrawal-staking-tests.js
@@ -1,0 +1,96 @@
+import { printTitle, assertThrows } from '../_lib/utils/general';
+import { RocketDepositAPI, RocketDepositSettings, RocketMinipoolInterface } from '../_lib/artifacts';
+import { createGroupContract, createGroupAccessorContract, addGroupAccessor } from '../_helpers/rocket-group';
+import { createNodeContract, createNodeMinipools } from '../_helpers/rocket-node';
+import { scenarioDeposit, scenarioWithdrawStakingMinipoolDeposit } from './rocket-deposit-api-scenarios';
+
+export default function() {
+
+    contract('RocketDepositAPI - Staking Withdrawals', async (accounts) => {
+
+
+        // Accounts
+        const owner = accounts[0];
+        const groupOwner = accounts[1];
+        const nodeOperator = accounts[2];
+        const user1 = accounts[3];
+        const user2 = accounts[4];
+
+
+        // Setup
+        let rocketDepositAPI;
+        let rocketDepositSettings;
+        let groupContract;
+        let groupAccessorContract;
+        let nodeContract;
+        let minipoolAddresses;
+        let minipool;
+        let depositID;
+        let depositAmount;
+        before(async () => {
+
+            // Get contracts
+            rocketDepositAPI = await RocketDepositAPI.deployed();
+            rocketDepositSettings = await RocketDepositSettings.deployed();
+
+            // Create group contract
+            groupContract = await createGroupContract({name: 'Group 1', stakingFee: web3.utils.toWei('0.05', 'ether'), groupOwner});
+
+            // Create and add group accessor contract
+            groupAccessorContract = await createGroupAccessorContract({groupContractAddress: groupContract.address, groupOwner});
+            await addGroupAccessor({groupContract, groupAccessorContractAddress: groupAccessorContract.address, groupOwner});
+
+            // Create node contract
+            nodeContract = await createNodeContract({timezone: 'Australia/Brisbane', nodeOperator});
+
+        });
+
+
+        // Staker cannot withdraw from a minipool that isn't staking
+        it(printTitle('staker', 'cannot withdraw from a minipool that isn\'t staking'), async () => {
+
+            // Create single minipool
+            minipoolAddresses = await createNodeMinipools({nodeContract, stakingDurationID: '3m', minipoolCount: 2, nodeOperator, owner});
+            minipool = await RocketMinipoolInterface.at(minipoolAddresses[0]);
+
+            // Get deposit settings
+            let chunkSize = parseInt(await rocketDepositSettings.getDepositChunkSize.call());
+
+            // Deposit to minipool
+            await scenarioDeposit({
+                depositorContract: groupAccessorContract,
+                durationID: '3m',
+                fromAddress: user1,
+                value: chunkSize,
+            });
+            await scenarioDeposit({
+                depositorContract: groupAccessorContract,
+                durationID: '3m',
+                fromAddress: user2,
+                value: chunkSize,
+            });
+
+            // Check minipool status
+            let status = parseInt(await minipool.getStatus.call());
+            assert.equal(status, 1, 'Pre-check failed: minipool is not at PreLaunch status');
+
+            // Get deposit details
+            depositID = await rocketDepositAPI.getUserQueuedDepositAt.call(groupContract.address, user1, '3m', 0);
+            depositAmount = await minipool.getUserDeposit.call(user1);
+
+            // Attempt to withdraw minipool deposit
+            await assertThrows(scenarioWithdrawStakingMinipoolDeposit({
+                withdrawerContract: groupAccessorContract,
+                depositID,
+                minipoolAddress: minipool.address,
+                amount: depositAmount,
+                fromAddress: user1,
+                gas: 5000000,
+            }), 'Withdrew from a minipool that has not timed out');
+
+        });
+
+
+    });
+
+}

--- a/test/rocket-deposit/rocket-deposit-api-withdrawal-staking-tests.js
+++ b/test/rocket-deposit/rocket-deposit-api-withdrawal-staking-tests.js
@@ -2,6 +2,7 @@ import { printTitle, assertThrows } from '../_lib/utils/general';
 import { RocketDepositAPI, RocketDepositSettings, RocketMinipoolInterface } from '../_lib/artifacts';
 import { createGroupContract, createGroupAccessorContract, addGroupAccessor } from '../_helpers/rocket-group';
 import { createNodeContract, createNodeMinipools } from '../_helpers/rocket-node';
+import { stakeSingleMinipool } from '../_helpers/rocket-minipool';
 import { scenarioDeposit, scenarioWithdrawStakingMinipoolDeposit } from './rocket-deposit-api-scenarios';
 
 export default function() {
@@ -15,6 +16,7 @@ export default function() {
         const nodeOperator = accounts[2];
         const user1 = accounts[3];
         const user2 = accounts[4];
+        const user3 = accounts[5];
 
 
         // Setup
@@ -87,6 +89,29 @@ export default function() {
                 fromAddress: user1,
                 gas: 5000000,
             }), 'Withdrew from a minipool that has not timed out');
+
+        });
+
+
+        // Staker can withdraw from a staking minipool
+        it(printTitle('staker', 'can withdraw from a staking minipool'), async () => {
+
+            // Progress minipool to staking
+            await stakeSingleMinipool({groupAccessorContract, staker: user3});
+
+            // Check minipool status
+            let status = parseInt(await minipool.getStatus.call());
+            assert.equal(status, 2, 'Pre-check failed: minipool is not at Staking status');
+
+            // Withdraw minipool deposit
+            scenarioWithdrawStakingMinipoolDeposit({
+                withdrawerContract: groupAccessorContract,
+                depositID,
+                minipoolAddress: minipool.address,
+                amount: depositAmount,
+                fromAddress: user1,
+                gas: 5000000,
+            });
 
         });
 

--- a/test/rocketPool-tests.js
+++ b/test/rocketPool-tests.js
@@ -17,6 +17,7 @@ import rocketNodeTaskCalculateNodeFeeTests from './rocket-node/rocket-node-task-
 import rocketDepositAPIDepositTests from './rocket-deposit/rocket-deposit-api-deposit-tests';
 import rocketDepositAPIRefundQueueTests from './rocket-deposit/rocket-deposit-api-refund-queue-tests';
 import rocketDepositAPIRefundMinipoolTests from './rocket-deposit/rocket-deposit-api-refund-minipool-tests';
+import rocketDepositAPIWithdrawalStakingTests from './rocket-deposit/rocket-deposit-api-withdrawal-staking-tests';
 import rocketRPIPTests from './rocket-rpip/rocket-rpip-tests';
 import rocketUpgradeTests from './rocket-upgrade/rocket-upgrade-tests';
 
@@ -49,6 +50,7 @@ rocketNodeTaskCalculateNodeFeeTests();
 rocketDepositAPIDepositTests();
 rocketDepositAPIRefundQueueTests();
 rocketDepositAPIRefundMinipoolTests();
+rocketDepositAPIWithdrawalStakingTests();
 rocketRPIPTests();
 rocketUpgradeTests();
 

--- a/test/rocketPool-tests.js
+++ b/test/rocketPool-tests.js
@@ -15,8 +15,8 @@ import rocketNodeTaskAdminTests from './rocket-node/rocket-node-task-admin-tests
 import rocketNodeTaskNodeTests from './rocket-node/rocket-node-task-node-tests';
 import rocketNodeTaskCalculateNodeFeeTests from './rocket-node/rocket-node-task-calculate-node-fee-tests';
 import rocketDepositAPIDepositTests from './rocket-deposit/rocket-deposit-api-deposit-tests';
-import rocketDepositAPIRefundTests from './rocket-deposit/rocket-deposit-api-refund-tests';
-import rocketDepositAPIWithdrawalTests from './rocket-deposit/rocket-deposit-api-withdrawal-tests';
+import rocketDepositAPIRefundQueueTests from './rocket-deposit/rocket-deposit-api-refund-queue-tests';
+import rocketDepositAPIRefundMinipoolTests from './rocket-deposit/rocket-deposit-api-refund-minipool-tests';
 import rocketRPIPTests from './rocket-rpip/rocket-rpip-tests';
 import rocketUpgradeTests from './rocket-upgrade/rocket-upgrade-tests';
 
@@ -47,8 +47,8 @@ rocketNodeTaskAdminTests();
 rocketNodeTaskNodeTests();
 rocketNodeTaskCalculateNodeFeeTests();
 rocketDepositAPIDepositTests();
-rocketDepositAPIRefundTests();
-rocketDepositAPIWithdrawalTests();
+rocketDepositAPIRefundQueueTests();
+rocketDepositAPIRefundMinipoolTests();
 rocketRPIPTests();
 rocketUpgradeTests();
 


### PR DESCRIPTION
- Implemented RPB token contract

- Added separate refund and withdrawal methods to RocketDepositAPI and default RocketGroupAccessorContract:
-- refundDepositQueued
-- refundDepositMinipoolStalled
-- withdrawDepositMinipoolStaking
-- withdrawDepositMinipool
- Refund methods refund ETH and are handled by group depositors
- Withdrawal methods withdraw RPB and are handled by group withdrawers

- Moved RocketGroupAccessorContract creation to Factory contract due to gas limit issues

- Added staking withdrawal fee deposit setting

- Various minipool contract deposit / refund / withdrawal updates

- Updated deposit refund & withdrawal unit tests