### PR TITLE
Watchtower, minipool withdrawal & fees

### DIFF
--- a/contracts/contract/api/RocketGroupAPI.sol
+++ b/contracts/contract/api/RocketGroupAPI.sol
@@ -104,7 +104,7 @@ contract RocketGroupAPI is RocketBase {
         // Check the group name isn't already being used
         require(bytes(rocketStorage.getString(keccak256(abi.encodePacked("group.name", _name)))).length == 0, "Group name is already being used.");
         // Ok create the groups contract now, the address is their main ID and this is where the groups fees and more will reside
-        address newContractAddress = address(new RocketGroupContract(address(rocketStorage), msg.sender, _stakingFee, rocketGroupSettings.getDefaultFee()));
+        address newContractAddress = address(new RocketGroupContract(address(rocketStorage), msg.sender, _stakingFee));
         // If there is a fee required to register a group, check that it is sufficient
         if(rocketGroupSettings.getNewFee() > 0) {
             // Fee correct?

--- a/contracts/contract/deposit/RocketDeposit.sol
+++ b/contracts/contract/deposit/RocketDeposit.sol
@@ -184,10 +184,16 @@ contract RocketDeposit is RocketBase {
         // Check deposit details
         checkDepositDetails(_userID, _groupID, _depositID, _minipool);
 
+        // Get initial withdrawer address balance
+        rocketBETHToken = RocketBETHTokenInterface(getContractAddress("rocketBETHToken"));
+        uint256 initialBalance = rocketBETHToken.balanceOf(_withdrawerAddress);
+
         // Get minipool user balance & withdraw deposit from minipool
         RocketMinipoolInterface minipool = RocketMinipoolInterface(_minipool);
-        uint256 withdrawalAmount = minipool.getUserDeposit(_userID, _groupID);
         minipool.withdraw(_userID, _groupID, _withdrawerAddress);
+
+        // Get amount withdrawn
+        uint256 withdrawalAmount = rocketBETHToken.balanceOf(_withdrawerAddress).sub(initialBalance);
 
         // Update deposit pool details
         addressSetStorage = AddressSetStorageInterface(getContractAddress("utilAddressSetStorage"));

--- a/contracts/contract/deposit/RocketDeposit.sol
+++ b/contracts/contract/deposit/RocketDeposit.sol
@@ -131,7 +131,7 @@ contract RocketDeposit is RocketBase {
 
         // Get minipool user balance & refund deposit from minipool
         RocketMinipoolInterface minipool = RocketMinipoolInterface(_minipool);
-        uint256 refundAmount = minipool.getUserDeposit(_userID);
+        uint256 refundAmount = minipool.getUserDeposit(_userID, _groupID);
         minipool.refund(_userID, _groupID, address(this));
 
         // Update deposit pool details
@@ -168,7 +168,7 @@ contract RocketDeposit is RocketBase {
         minipool.withdrawStaking(_userID, _groupID, _amount, tokenAmount, _withdrawerAddress);
 
         // Update deposit pool details
-        if (!minipool.getUserHasDeposit(_userID)) { addressSetStorage.removeItem(keccak256(abi.encodePacked("deposit.stakingPools", _depositID)), _minipool); }
+        if (!minipool.getUserHasDeposit(_userID, _groupID)) { addressSetStorage.removeItem(keccak256(abi.encodePacked("deposit.stakingPools", _depositID)), _minipool); }
         uint256 stakingPoolAmount = rocketStorage.getUint(keccak256(abi.encodePacked("deposit.stakingPoolAmount", _depositID, _minipool)));
         rocketStorage.setUint(keccak256(abi.encodePacked("deposit.stakingPoolAmount", _depositID, _minipool)), stakingPoolAmount.sub(_amount));
 
@@ -186,7 +186,7 @@ contract RocketDeposit is RocketBase {
 
         // Get minipool user balance & withdraw deposit from minipool
         RocketMinipoolInterface minipool = RocketMinipoolInterface(_minipool);
-        uint256 withdrawalAmount = minipool.getUserDeposit(_userID);
+        uint256 withdrawalAmount = minipool.getUserDeposit(_userID, _groupID);
         minipool.withdraw(_userID, _groupID, _withdrawerAddress);
 
         // Update deposit pool details

--- a/contracts/contract/group/RocketGroupContract.sol
+++ b/contracts/contract/group/RocketGroupContract.sol
@@ -2,7 +2,6 @@ pragma solidity 0.5.0;
 
 // Interfaces
 import "../../interface/RocketStorageInterface.sol";
-import "../../interface/settings/RocketGroupSettingsInterface.sol";
 
 
 /// @title The contract for a group that operates in Rocket Pool, holds the entities fees and more
@@ -15,6 +14,7 @@ contract RocketGroupContract {
     address public owner;                                                       // The group owner that created the contract
     uint8   public version;                                                     // Version of this contract
     uint256 private feePerc = 0;                                                // The fee this groups charges their users given as a % of 1 Ether (eg 0.02 ether = 2%)
+    uint256 private feePercRocketPool = 0;                                      // The fee Rocket Pool charges this group's users given as a % of 1 Ether (eg 0.02 ether = 2%)
 
     mapping(address => bool) private depositors;                                // Valid depositor contracts for the group
     uint256 private depositorCount = 0;
@@ -25,7 +25,6 @@ contract RocketGroupContract {
     /*** Contracts ***************/
 
     RocketStorageInterface rocketStorage = RocketStorageInterface(0);           // The main Rocket Pool storage contract where primary persistant storage is maintained
-    RocketGroupSettingsInterface rocketGroupSettings = RocketGroupSettingsInterface(0);
 
     /*** Events ******************/
 
@@ -54,11 +53,19 @@ contract RocketGroupContract {
     /*** Modifiers ***************/
 
     /**
+    * @dev Throws if not called by RocketGroupAPI.
+    */
+    modifier onlyRocketGroupAPI() {
+        require(msg.sender == rocketStorage.getAddress(keccak256(abi.encodePacked("contract.name", "rocketGroupAPI"))), "Only the RocketGroupAPI contract can perform this function.");
+        _;
+    }
+
+    /**
     * @dev Throws if called by any account other than the owner.
     */
     modifier onlyGroupOwner() {
-      require(msg.sender == owner, "Only the group owner account can perform this function.");
-      _;
+        require(msg.sender == owner, "Only the group owner account can perform this function.");
+        _;
     }
 
     /**
@@ -74,7 +81,7 @@ contract RocketGroupContract {
     /*** Constructor *************/
 
     /// @dev RocketGroupContract constructor
-    constructor(address _rocketStorageAddress, address _owner, uint256 _stakingFeePerc) public onlyValidFeePerc(_stakingFeePerc) {
+    constructor(address _rocketStorageAddress, address _owner, uint256 _stakingFeePerc, uint256 _stakingFeePercRocketPool) public onlyValidFeePerc(_stakingFeePerc) onlyValidFeePerc(_stakingFeePercRocketPool) {
         // Version
         version = 1;
         // Update the storage contract address
@@ -83,22 +90,20 @@ contract RocketGroupContract {
         owner = _owner;
         // Set the staking fee percent
         feePerc = _stakingFeePerc;
+        // Set the RP staking fee percent
+        feePercRocketPool = _stakingFeePercRocketPool;
     }
 
     /*** Getters *************/
 
     /// @dev The fee this groups charges their users given as a % of 1 Ether (eg 0.02 ether = 2%)
-    function getFeePerc() public view returns(uint256) { 
-        // Get the fee for this groups users
+    function getFeePerc() public view returns(uint256) {
         return feePerc;
     }
 
     /// @dev Get the fee that Rocket Pool charges for this group given as a % of 1 Ether (eg 0.02 ether = 2%)
-    function getFeePercRocketPool() public returns(uint256) { 
-        // Get the settings
-        rocketGroupSettings = RocketGroupSettingsInterface(rocketStorage.getAddress(keccak256(abi.encodePacked("contract.name", "rocketGroupSettings"))));
-        // Get the RP fee
-        return rocketGroupSettings.getDefaultFee();
+    function getFeePercRocketPool() public returns(uint256) {
+        return feePercRocketPool;
     }
 
     /// @dev Check that a depositor exists in the group
@@ -119,6 +124,12 @@ contract RocketGroupContract {
         // Ok set it
         feePerc = _stakingFeePerc;
         // Done
+        return true;
+    }
+
+    /// @dev Set the fee Rocket Pool charges this group's users - Given as a % of 1 Ether (eg 0.02 ether = 2%)
+    function setFeePercRocketPool(uint256 _stakingFeePerc) public onlyRocketGroupAPI onlyValidFeePerc(_stakingFeePerc) returns(bool) {
+        feePercRocketPool = _stakingFeePerc;
         return true;
     }
 

--- a/contracts/contract/group/RocketGroupContract.sol
+++ b/contracts/contract/group/RocketGroupContract.sol
@@ -16,6 +16,7 @@ contract RocketGroupContract {
     uint8   public version;                                                     // Version of this contract
     uint256 private feePerc = 0;                                                // The fee this groups charges their users given as a % of 1 Ether (eg 0.02 ether = 2%)
     uint256 private feePercRocketPool = 0;                                      // The fee Rocket Pool charges this group's users given as a % of 1 Ether (eg 0.02 ether = 2%)
+    address private feeAddress;                                                 // The address to send group fees to as RPB
 
     mapping(address => bool) private depositors;                                // Valid depositor contracts for the group
     uint256 private depositorCount = 0;
@@ -99,6 +100,8 @@ contract RocketGroupContract {
         // Set the RP staking fee percent
         rocketGroupSettings = RocketGroupSettingsInterface(rocketStorage.getAddress(keccak256(abi.encodePacked("contract.name", "rocketGroupSettings"))));
         feePercRocketPool = rocketGroupSettings.getDefaultFee();
+        // Default the fee address to the group owner
+        feeAddress = _owner;
     }
 
     /*** Getters *************/
@@ -116,6 +119,11 @@ contract RocketGroupContract {
     /// @dev Get the fee that Rocket Pool charges for this group given as a % of 1 Ether (eg 0.02 ether = 2%)
     function getFeePercRocketPool() public view returns(uint256) {
         return feePercRocketPool;
+    }
+
+    /// @dev Get the address to send group fees to as RPB
+    function getFeeAddress() public view returns(address) {
+        return feeAddress;
     }
 
     /// @dev Check that a depositor exists in the group
@@ -140,6 +148,13 @@ contract RocketGroupContract {
     /// @dev Set the fee Rocket Pool charges this group's users - Given as a % of 1 Ether (eg 0.02 ether = 2%)
     function setFeePercRocketPool(uint256 _stakingFeePercRocketPool) public onlyRocketGroupAPI onlyValidFeePercRocketPool(_stakingFeePercRocketPool) returns(bool) {
         feePercRocketPool = _stakingFeePercRocketPool;
+        return true;
+    }
+
+    /// @dev Set the address to send group fees to as RPB
+    function setFeeAddress(address _feeAddress) public onlyGroupOwner returns(bool) {
+        require(_feeAddress != address(0x0), "Invalid fee address");
+        feeAddress = _feeAddress;
         return true;
     }
 

--- a/contracts/contract/group/RocketGroupContract.sol
+++ b/contracts/contract/group/RocketGroupContract.sol
@@ -103,6 +103,11 @@ contract RocketGroupContract {
 
     /*** Getters *************/
 
+    /// @dev Get the group owner
+    function getOwner() public view returns(address) {
+        return owner;
+    }
+
     /// @dev The fee this groups charges their users given as a % of 1 Ether (eg 0.02 ether = 2%)
     function getFeePerc() public view returns(uint256) {
         return feePerc;

--- a/contracts/contract/group/RocketGroupContract.sol
+++ b/contracts/contract/group/RocketGroupContract.sol
@@ -102,7 +102,7 @@ contract RocketGroupContract {
     }
 
     /// @dev Get the fee that Rocket Pool charges for this group given as a % of 1 Ether (eg 0.02 ether = 2%)
-    function getFeePercRocketPool() public returns(uint256) {
+    function getFeePercRocketPool() public view returns(uint256) {
         return feePercRocketPool;
     }
 

--- a/contracts/contract/group/RocketGroupContract.sol
+++ b/contracts/contract/group/RocketGroupContract.sol
@@ -87,7 +87,7 @@ contract RocketGroupContract {
     /*** Constructor *************/
 
     /// @dev RocketGroupContract constructor
-    constructor(address _rocketStorageAddress, address _owner, uint256 _stakingFeePerc, uint256 _stakingFeePercRocketPool) public onlyValidFeePerc(_stakingFeePerc) onlyValidFeePercRocketPool(_stakingFeePercRocketPool) {
+    constructor(address _rocketStorageAddress, address _owner, uint256 _stakingFeePerc) public onlyValidFeePerc(_stakingFeePerc) {
         // Version
         version = 1;
         // Update the storage contract address
@@ -97,7 +97,8 @@ contract RocketGroupContract {
         // Set the staking fee percent
         feePerc = _stakingFeePerc;
         // Set the RP staking fee percent
-        feePercRocketPool = _stakingFeePercRocketPool;
+        rocketGroupSettings = RocketGroupSettingsInterface(rocketStorage.getAddress(keccak256(abi.encodePacked("contract.name", "rocketGroupSettings"))));
+        feePercRocketPool = rocketGroupSettings.getDefaultFee();
     }
 
     /*** Getters *************/

--- a/contracts/contract/minipool/RocketMinipool.sol
+++ b/contracts/contract/minipool/RocketMinipool.sol
@@ -9,6 +9,7 @@ import "../../interface/settings/RocketNodeSettingsInterface.sol";
 import "../../interface/settings/RocketMinipoolSettingsInterface.sol";
 import "../../interface/casper/DepositInterface.sol";
 import "../../interface/group/RocketGroupContractInterface.sol";
+import "../../interface/node/RocketNodeContractInterface.sol";
 import "../../interface/token/ERC20.sol";
 import "../../interface/utils/pubsub/PublisherInterface.sol";
 // Libraries
@@ -51,7 +52,8 @@ contract RocketMinipool {
     ERC20 rplContract = ERC20(0);                                                                   // The address of our RPL ERC20 token contract
     ERC20 rpbContract = ERC20(0);                                                                   // The address of our RPB ERC20 token contract
     DepositInterface casperDeposit = DepositInterface(0);                                           // Interface of the Casper deposit contract
-    RocketGroupContractInterface rocketGroupContract = RocketGroupContractInterface(0);             // The users group contract that they belong too
+    RocketGroupContractInterface rocketGroupContract = RocketGroupContractInterface(0);             // The users group contract that they belong to
+    RocketNodeContractInterface rocketNodeContract = RocketNodeContractInterface(0);                // The node contract for the node which owns this minipool
     RocketNodeSettingsInterface rocketNodeSettings = RocketNodeSettingsInterface(0);                // The settings for nodes
     RocketPoolInterface rocketPool = RocketPoolInterface(0);                                        // The main pool manager
     RocketMinipoolSettingsInterface rocketMinipoolSettings = RocketMinipoolSettingsInterface(0);    // The main settings contract most global parameters are maintained
@@ -101,7 +103,7 @@ contract RocketMinipool {
     }
 
     struct StakingWithdrawal {
-        address groupOwner;                                     // The owner address of the group the user belonged to
+        address groupFeeAddress;                                // The address to send group fees to
         uint256 amount;                                         // The amount withdrawn by the user
         uint256 feeRP;                                          // The fee charged to the user by Rocket Pool
         uint256 feeGroup;                                       // The fee charged to the user by the group
@@ -183,6 +185,8 @@ contract RocketMinipool {
         node.depositRPL = _depositRPL;
         node.trusted = _trusted;
         node.contractAddress = rocketStorage.getAddress(keccak256(abi.encodePacked("node.contract", _nodeOwner)));
+        // Initialise the node contract
+        rocketNodeContract = RocketNodeContractInterface(node.contractAddress);
         // Set the initial staking properties
         staking.id = _durationID;
         staking.duration = rocketMinipoolSettings.getMinipoolStakingDuration(_durationID);
@@ -324,7 +328,7 @@ contract RocketMinipool {
 
     /// @dev Deposit a users ether to this contract. Will register the user if they don't exist in this contract already.
     /// @param _user New user address
-    /// @param _groupID The 3rd party group the user belongs too
+    /// @param _groupID The 3rd party group the user belongs to
     function deposit(address _user, address _groupID) public payable onlyLatestContract("rocketDepositQueue") returns(bool) {
         // Will throw if conditions are not met in delegate or call fails
         (bool success,) = getContractAddress("rocketMinipoolDelegateUser").delegatecall(abi.encodeWithSignature("deposit(address,address)", _user, _groupID));

--- a/contracts/contract/minipool/RocketMinipool.sol
+++ b/contracts/contract/minipool/RocketMinipool.sol
@@ -33,7 +33,7 @@ contract RocketMinipool {
     Staking private staking;                                    // Staking properties of the minipool to track
     uint256 private userDepositCapacity;                        // Total capacity for user deposits
     uint256 private userDepositTotal;                           // Total value of all assigned user deposits
-    uint256 private stakingTokensWithdrawnTotal;                // Total RPB tokens withdrawn during staking
+    uint256 private stakingUserDepositsWithdrawn;               // Total value of user deposits withdrawn while staking
 
     // Users
     mapping (address => User) private users;                    // Users in this pool
@@ -422,8 +422,8 @@ contract RocketMinipool {
     }
 
     /// @dev Gets the total RPB tokens withdrawn during staking
-    function getStakingTokensWithdrawnTotal() public view returns(uint256) {
-        return stakingTokensWithdrawnTotal;
+    function getStakingUserDepositsWithdrawn() public view returns(uint256) {
+        return stakingUserDepositsWithdrawn;
     }
 
 
@@ -438,11 +438,20 @@ contract RocketMinipool {
         return true;
     }
 
-    /// @dev Sets the status of the pool to a specific value if valid
-    /// @param _status The new status ID to apply
-    function setStatusTo(uint8 _status) public onlyLatestContract("rocketNodeWatchtower") returns (bool) {
+    /// @dev Sets the minipool to logged out
+    function logoutMinipool() public onlyLatestContract("rocketNodeWatchtower") returns (bool) {
         // Will update the status of the pool if conditions are correct
-        (bool success,) = getContractAddress("rocketMinipoolDelegate").delegatecall(abi.encodeWithSignature("setStatusTo(uint8)", _status));
+        (bool success,) = getContractAddress("rocketMinipoolDelegate").delegatecall(abi.encodeWithSignature("logoutMinipool()"));
+        require(success, "Delegate call failed.");
+        // Success
+        return true;
+    }
+
+    /// @dev Sets the minipool to withdrawn and sets its balance at withdrawal
+    /// @param _withdrawalBalance The minipool's balance at withdrawal
+    function withdrawMinipool(uint256 _withdrawalBalance) public onlyLatestContract("rocketNodeWatchtower") returns (bool) {
+        // Will update the status of the pool if conditions are correct
+        (bool success,) = getContractAddress("rocketMinipoolDelegate").delegatecall(abi.encodeWithSignature("withdrawMinipool(uint256)", _withdrawalBalance));
         require(success, "Delegate call failed.");
         // Success
         return true;

--- a/contracts/contract/minipool/RocketMinipool.sol
+++ b/contracts/contract/minipool/RocketMinipool.sol
@@ -29,15 +29,14 @@ contract RocketMinipool {
     uint256 private calcBase = 1 ether;
 
     // General
-    uint8   public version = 1;                                         // Version of this contract
-    Status  private status;                                             // The current status of this pool, statuses are declared via Enum in the minipool settings
-    Node    private node;                                               // Node this minipool is attached to, its creator 
-    Staking private staking;                                            // Staking properties of the minipool to track
-    uint256 private userDepositCapacity;                                // Total capacity for user deposits
-    uint256 private userDepositTotal;                                   // Total value of all assigned user deposits
-    uint256 private stakingUserDepositsWithdrawn;                       // Total value of user deposits withdrawn while staking
-    mapping (address => uint256) private stakingGroupDepositsWithdrawn; // Total value of all deposits withdrawn while staking, by group
-    address[] private stakingGroupDepositsWithdrawnAddresses;
+    uint8   public version = 1;                                     // Version of this contract
+    Status  private status;                                         // The current status of this pool, statuses are declared via Enum in the minipool settings
+    Node    private node;                                           // Node this minipool is attached to, its creator 
+    Staking private staking;                                        // Staking properties of the minipool to track
+    uint256 private userDepositCapacity;                            // Total capacity for user deposits
+    uint256 private userDepositTotal;                               // Total value of all assigned user deposits
+    uint256 private stakingUserDepositsWithdrawn;                   // Total value of user deposits withdrawn while staking
+    StakingWithdrawal[] private stakingUserDepositsWithdrawals;     // Information on deposit withdrawals made by users while staking
 
     // Users
     mapping (address => User) private users;                    // Users in this pool
@@ -101,6 +100,12 @@ contract RocketMinipool {
         uint256 addressIndex;                                   // User's index in the address list
     }
 
+    struct StakingWithdrawal {
+        address groupID;                                        // The address of the group the user belonged to
+        uint256 amount;                                         // The amount withdrawn by the user
+        uint256 groupFee;                                       // The fee charged to the user by the group
+    }
+
 
       
     /*** Events ****************/
@@ -162,8 +167,9 @@ contract RocketMinipool {
         rocketMinipoolSettings = RocketMinipoolSettingsInterface(getContractAddress("rocketMinipoolSettings"));
         // Set the address of the casper deposit contract
         casperDeposit = DepositInterface(getContractAddress("casperDeposit"));
-        // Add the RPL contract address
+        // Add the token contract addresses
         rplContract = ERC20(getContractAddress("rocketPoolToken"));
+        rpbContract = ERC20(getContractAddress("rocketBETHToken"));
         // Set the initial status
         status.current = 0;
         status.time = now;

--- a/contracts/contract/minipool/RocketMinipool.sol
+++ b/contracts/contract/minipool/RocketMinipool.sol
@@ -30,20 +30,20 @@ contract RocketMinipool {
     uint256 private calcBase = 1 ether;
 
     // General
-    uint8   public version = 1;                                     // Version of this contract
-    Status  private status;                                         // The current status of this pool, statuses are declared via Enum in the minipool settings
-    Node    private node;                                           // Node this minipool is attached to, its creator 
-    Staking private staking;                                        // Staking properties of the minipool to track
-    uint256 private userDepositCapacity;                            // Total capacity for user deposits
-    uint256 private userDepositTotal;                               // Total value of all assigned user deposits
-    uint256 private stakingUserDepositsWithdrawn;                   // Total value of user deposits withdrawn while staking
-    StakingWithdrawal[] private stakingUserDepositsWithdrawals;     // Information on deposit withdrawals made by users while staking
+    uint8   public version = 1;                                         // Version of this contract
+    Status  private status;                                             // The current status of this pool, statuses are declared via Enum in the minipool settings
+    Node    private node;                                               // Node this minipool is attached to, its creator 
+    Staking private staking;                                            // Staking properties of the minipool to track
+    uint256 private userDepositCapacity;                                // Total capacity for user deposits
+    uint256 private userDepositTotal;                                   // Total value of all assigned user deposits
+    uint256 private stakingUserDepositsWithdrawn;                       // Total value of user deposits withdrawn while staking
+    mapping (bytes32 => StakingWithdrawal) private stakingWithdrawals;  // Information on deposit withdrawals made by users while staking
+    bytes32[] private stakingWithdrawalIDs;
 
     // Users
     mapping (address => User) private users;                    // Users in this pool
     mapping (address => address) private usersBackupAddress;    // Users backup withdrawal address => users current address in this pool, need these in a mapping so we can do a reverse lookup using the backup address
     address[] private userAddresses;                            // Users in this pool addresses for iteration
-    
 
 
     /*** Contracts **************/
@@ -104,7 +104,9 @@ contract RocketMinipool {
     struct StakingWithdrawal {
         address groupID;                                        // The address of the group the user belonged to
         uint256 amount;                                         // The amount withdrawn by the user
-        uint256 groupFee;                                       // The fee charged to the user by the group
+        uint256 feeRP;                                          // The fee charged to the user by Rocket Pool
+        uint256 feeGroup;                                       // The fee charged to the user by the group
+        bool exists;
     }
 
 

--- a/contracts/contract/minipool/RocketMinipool.sol
+++ b/contracts/contract/minipool/RocketMinipool.sol
@@ -4,6 +4,7 @@ pragma solidity 0.5.0;
 // Interfaces
 import "../../interface/RocketPoolInterface.sol";
 import "../../interface/RocketStorageInterface.sol";
+import "../../interface/minipool/RocketMinipoolInterface.sol";
 import "../../interface/settings/RocketNodeSettingsInterface.sol";
 import "../../interface/settings/RocketMinipoolSettingsInterface.sol";
 import "../../interface/casper/DepositInterface.sol";

--- a/contracts/contract/minipool/RocketMinipool.sol
+++ b/contracts/contract/minipool/RocketMinipool.sol
@@ -41,9 +41,9 @@ contract RocketMinipool {
     bytes32[] private stakingWithdrawalIDs;
 
     // Users
-    mapping (address => User) private users;                    // Users in this pool
+    mapping (bytes32 => User) private users;                    // Users in this pool
     mapping (address => address) private usersBackupAddress;    // Users backup withdrawal address => users current address in this pool, need these in a mapping so we can do a reverse lookup using the backup address
-    address[] private userAddresses;                            // Users in this pool addresses for iteration
+    bytes32[] private userIDs;                                  // Users in this pool IDs for iteration
 
 
     /*** Contracts **************/
@@ -89,16 +89,15 @@ contract RocketMinipool {
 
     struct User {
         address user;                                           // Address of the user
-        address backup;                                         // The backup address of the user
         address groupID;                                        // Address ID of the users group
+        address backup;                                         // The backup address of the user
         uint256 balance;                                        // Chunk balance deposited
-        int256  rewards;                                        // Rewards received after Casper
         uint256 stakingTokensWithdrawn;                         // RPB tokens withdrawn by the user during staking
         uint256 feeRP;                                          // Rocket Pools fee
         uint256 feeGroup;                                       // Group fee
         uint256 created;                                        // Creation timestamp
         bool    exists;                                         // User exists?
-        uint256 addressIndex;                                   // User's index in the address list
+        uint256 idIndex;                                        // User's index in the ID list
     }
 
     struct StakingWithdrawal {
@@ -140,8 +139,9 @@ contract RocketMinipool {
 
     /// @dev Only registered users with this pool
     /// @param _user The users address.
-    modifier isPoolUser(address _user) {
-        require(_user != address(0x0) && users[_user].exists != false);
+    modifier isPoolUser(address _user, address _group) {
+        bytes32 userID = keccak256(abi.encodePacked(_user, _group));
+        require(_user != address(0x0) && _group != address(0x0) && users[userID].exists != false);
         _;
     }
 
@@ -277,12 +277,13 @@ contract RocketMinipool {
 
     /// @dev Returns the user count for this pool
     function getUserCount() public view returns(uint256) {
-        return userAddresses.length;
+        return userIDs.length;
     }
 
     /// @dev Returns the true if the user is in this pool
-    function getUserExists(address _user) public view returns(bool) {
-        return users[_user].exists;
+    function getUserExists(address _user, address _group) public view returns(bool) {
+        bytes32 userID = keccak256(abi.encodePacked(_user, _group));
+        return users[userID].exists;
     }
 
     /// @dev Returns the users original address specified for withdrawals
@@ -296,23 +297,26 @@ contract RocketMinipool {
     }
 
     /// @dev Returns the true if the user has a backup address specified for withdrawals and that maps correctly to their original user address
-    function getUserBackupAddressOK(address _user, address _userBackupAddress) public view isPoolUser(_user) returns(bool) {
+    function getUserBackupAddressOK(address _user, address _group, address _userBackupAddress) public view isPoolUser(_user, _group) returns(bool) {
         return usersBackupAddress[_userBackupAddress] == _user;
     }
 
     /// @dev Returns the true if the user has a deposit in this mini pool
-    function getUserHasDeposit(address _user) public view returns(bool) {
-        return users[_user].exists && users[_user].balance > 0;
+    function getUserHasDeposit(address _user, address _group) public view returns(bool) {
+        bytes32 userID = keccak256(abi.encodePacked(_user, _group));
+        return users[userID].exists && users[userID].balance > 0;
     }
 
     /// @dev Returns the amount of the users deposit
-    function getUserDeposit(address _user) public view isPoolUser(_user) returns(uint256) {
-        return users[_user].balance;
+    function getUserDeposit(address _user, address _group) public view isPoolUser(_user, _group) returns(uint256) {
+        bytes32 userID = keccak256(abi.encodePacked(_user, _group));
+        return users[userID].balance;
     }
 
     /// @dev Returns the amount of the deposit tokens the user has taken out
-    function getUserStakingTokensWithdrawn(address _user) public view isPoolUser(_user) returns(uint256) {
-        return users[_user].stakingTokensWithdrawn;
+    function getUserStakingTokensWithdrawn(address _user, address _group) public view isPoolUser(_user, _group) returns(uint256) {
+        bytes32 userID = keccak256(abi.encodePacked(_user, _group));
+        return users[userID].stakingTokensWithdrawn;
     }
 
 

--- a/contracts/contract/minipool/RocketMinipool.sol
+++ b/contracts/contract/minipool/RocketMinipool.sol
@@ -101,7 +101,7 @@ contract RocketMinipool {
     }
 
     struct StakingWithdrawal {
-        address groupID;                                        // The address of the group the user belonged to
+        address groupOwner;                                     // The owner address of the group the user belonged to
         uint256 amount;                                         // The amount withdrawn by the user
         uint256 feeRP;                                          // The fee charged to the user by Rocket Pool
         uint256 feeGroup;                                       // The fee charged to the user by the group

--- a/contracts/contract/minipool/RocketMinipool.sol
+++ b/contracts/contract/minipool/RocketMinipool.sol
@@ -433,4 +433,15 @@ contract RocketMinipool {
         return true;
     }
 
+    /// @dev Sets the status of the pool to a specific value if valid
+    /// @param _status The new status ID to apply
+    function setStatusTo(uint8 _status) public onlyLatestContract("rocketNodeWatchtower") returns (bool) {
+        // Will update the status of the pool if conditions are correct
+        (bool success,) = getContractAddress("rocketMinipoolDelegate").delegatecall(abi.encodeWithSignature("setStatusTo(uint8)", _status));
+        require(success, "Delegate call failed.");
+        // Success
+        return true;
+    }
+
+
 }

--- a/contracts/contract/minipool/RocketMinipool.sol
+++ b/contracts/contract/minipool/RocketMinipool.sol
@@ -420,8 +420,13 @@ contract RocketMinipool {
     function getUserDepositTotal() public view returns(uint256) {
         return userDepositTotal;
     }
-    
-    
+
+    /// @dev Gets the total RPB tokens withdrawn during staking
+    function getStakingTokensWithdrawnTotal() public view returns(uint256) {
+        return stakingTokensWithdrawnTotal;
+    }
+
+
     // Methods
 
     /// @dev Sets the status of the pool based on its current parameters 

--- a/contracts/contract/minipool/RocketMinipool.sol
+++ b/contracts/contract/minipool/RocketMinipool.sol
@@ -76,6 +76,7 @@ contract RocketMinipool {
         bool    trusted;                                        // Was the node trusted at the time of minipool creation?
         bool    depositExists;                                  // The node operator's deposit exists
         uint256 balance;                                        // The node operator's ether balance
+        uint256 userFee;                                        // The fee charged to users by the node, determined when the minipool begins staking
     }
 
     struct Staking {
@@ -94,7 +95,6 @@ contract RocketMinipool {
         int256  rewards;                                        // Rewards received after Casper
         uint256 stakingTokensWithdrawn;                         // RPB tokens withdrawn by the user during staking
         uint256 feeRP;                                          // Rocket Pools fee
-        uint256 feeNode;                                        // Node operator fee
         uint256 feeGroup;                                       // Group fee
         uint256 created;                                        // Creation timestamp
         bool    exists;                                         // User exists?

--- a/contracts/contract/minipool/RocketMinipool.sol
+++ b/contracts/contract/minipool/RocketMinipool.sol
@@ -4,7 +4,6 @@ pragma solidity 0.5.0;
 // Interfaces
 import "../../interface/RocketPoolInterface.sol";
 import "../../interface/RocketStorageInterface.sol";
-import "../../interface/settings/RocketGroupSettingsInterface.sol";
 import "../../interface/settings/RocketNodeSettingsInterface.sol";
 import "../../interface/settings/RocketMinipoolSettingsInterface.sol";
 import "../../interface/casper/DepositInterface.sol";
@@ -30,13 +29,15 @@ contract RocketMinipool {
     uint256 private calcBase = 1 ether;
 
     // General
-    uint8   public version = 1;                                 // Version of this contract
-    Status  private status;                                     // The current status of this pool, statuses are declared via Enum in the minipool settings
-    Node    private node;                                       // Node this minipool is attached to, its creator 
-    Staking private staking;                                    // Staking properties of the minipool to track
-    uint256 private userDepositCapacity;                        // Total capacity for user deposits
-    uint256 private userDepositTotal;                           // Total value of all assigned user deposits
-    uint256 private stakingUserDepositsWithdrawn;               // Total value of user deposits withdrawn while staking
+    uint8   public version = 1;                                         // Version of this contract
+    Status  private status;                                             // The current status of this pool, statuses are declared via Enum in the minipool settings
+    Node    private node;                                               // Node this minipool is attached to, its creator 
+    Staking private staking;                                            // Staking properties of the minipool to track
+    uint256 private userDepositCapacity;                                // Total capacity for user deposits
+    uint256 private userDepositTotal;                                   // Total value of all assigned user deposits
+    uint256 private stakingUserDepositsWithdrawn;                       // Total value of user deposits withdrawn while staking
+    mapping (address => uint256) private stakingGroupDepositsWithdrawn; // Total value of all deposits withdrawn while staking, by group
+    address[] private stakingGroupDepositsWithdrawnAddresses;
 
     // Users
     mapping (address => User) private users;                    // Users in this pool
@@ -51,7 +52,6 @@ contract RocketMinipool {
     ERC20 rpbContract = ERC20(0);                                                                   // The address of our RPB ERC20 token contract
     DepositInterface casperDeposit = DepositInterface(0);                                           // Interface of the Casper deposit contract
     RocketGroupContractInterface rocketGroupContract = RocketGroupContractInterface(0);             // The users group contract that they belong too
-    RocketGroupSettingsInterface rocketGroupSettings = RocketGroupSettingsInterface(0);             // The settings for groups
     RocketNodeSettingsInterface rocketNodeSettings = RocketNodeSettingsInterface(0);                // The settings for nodes
     RocketPoolInterface rocketPool = RocketPoolInterface(0);                                        // The main pool manager
     RocketMinipoolSettingsInterface rocketMinipoolSettings = RocketMinipoolSettingsInterface(0);    // The main settings contract most global parameters are maintained

--- a/contracts/contract/minipool/RocketMinipool.sol
+++ b/contracts/contract/minipool/RocketMinipool.sol
@@ -27,6 +27,8 @@ contract RocketMinipool {
 
     /**** Properties ***********/
 
+    uint256 private calcBase = 1 ether;
+
     // General
     uint8   public version = 1;                                 // Version of this contract
     Status  private status;                                     // The current status of this pool, statuses are declared via Enum in the minipool settings

--- a/contracts/contract/minipool/RocketMinipool.sol
+++ b/contracts/contract/minipool/RocketMinipool.sol
@@ -5,6 +5,7 @@ pragma solidity 0.5.0;
 import "../../interface/RocketPoolInterface.sol";
 import "../../interface/RocketStorageInterface.sol";
 import "../../interface/settings/RocketGroupSettingsInterface.sol";
+import "../../interface/settings/RocketNodeSettingsInterface.sol";
 import "../../interface/settings/RocketMinipoolSettingsInterface.sol";
 import "../../interface/casper/DepositInterface.sol";
 import "../../interface/group/RocketGroupContractInterface.sol";
@@ -49,6 +50,7 @@ contract RocketMinipool {
     DepositInterface casperDeposit = DepositInterface(0);                                           // Interface of the Casper deposit contract
     RocketGroupContractInterface rocketGroupContract = RocketGroupContractInterface(0);             // The users group contract that they belong too
     RocketGroupSettingsInterface rocketGroupSettings = RocketGroupSettingsInterface(0);             // The settings for groups
+    RocketNodeSettingsInterface rocketNodeSettings = RocketNodeSettingsInterface(0);                // The settings for nodes
     RocketPoolInterface rocketPool = RocketPoolInterface(0);                                        // The main pool manager
     RocketMinipoolSettingsInterface rocketMinipoolSettings = RocketMinipoolSettingsInterface(0);    // The main settings contract most global parameters are maintained
     RocketStorageInterface rocketStorage = RocketStorageInterface(0);                               // The main Rocket Pool storage contract where primary persistant storage is maintained
@@ -90,6 +92,7 @@ contract RocketMinipool {
         int256  rewards;                                        // Rewards received after Casper
         uint256 stakingTokensWithdrawn;                         // RPB tokens withdrawn by the user during staking
         uint256 feeRP;                                          // Rocket Pools fee
+        uint256 feeNode;                                        // Node operator fee
         uint256 feeGroup;                                       // Group fee
         uint256 created;                                        // Creation timestamp
         bool    exists;                                         // User exists?

--- a/contracts/contract/minipool/RocketMinipool.sol
+++ b/contracts/contract/minipool/RocketMinipool.sol
@@ -14,7 +14,7 @@ import "../../interface/utils/pubsub/PublisherInterface.sol";
 import "../../lib/SafeMath.sol";
 
 
-/// @title A minipool under the main RocketPool, all major logic is contained within the RocketMinipoolDelegate contract which is upgradable when minipools are deployed
+/// @title A minipool under the main RocketPool, all major logic is contained within the RocketMinipoolDelegate contracts which are upgradable when minipools are deployed
 /// @author David Rugendyke
 
 contract RocketMinipool {
@@ -207,25 +207,6 @@ contract RocketMinipool {
     }
 
 
-    /*
-    /// @dev Use inline assembly to read the boolean value back from a delegatecall method in the minipooldelegate contract
-    function getDelegateBoolean(string memory _signatureMethod) public returns (bool) {
-        bytes4 signature = getDelegateSignature(_signatureMethod);
-        address minipoolDelegate = getContractAddress("rocketMinipoolDelegate");
-        bool response = false;
-        assembly {
-            let returnSize := 32
-            let mem := mload(0x40)
-            mstore(mem, signature)
-            let err := delegatecall(sub(gas, 10000), minipoolDelegate, mem, 0x04, mem, returnSize)
-            response := mload(mem)
-        }
-        return response; 
-    }
-    */
-   
-    
-
     /*** NODE ***********************************************/
 
     // Getters
@@ -271,7 +252,7 @@ contract RocketMinipool {
     /// @dev Set the ether / rpl deposit and check it
     function nodeDeposit() public payable isNodeContract(msg.sender) returns(bool) {
         // Will throw if conditions are not met in delegate
-        (bool success,) = getContractAddress("rocketMinipoolDelegate").delegatecall(abi.encodeWithSignature("nodeDeposit()"));
+        (bool success,) = getContractAddress("rocketMinipoolDelegateNode").delegatecall(abi.encodeWithSignature("nodeDeposit()"));
         require(success, "Delegate call failed.");
         // Success
         return true;
@@ -280,7 +261,7 @@ contract RocketMinipool {
     /// @dev Withdraw ether / rpl deposit from the minipool if initialised, timed out or withdrawn
     function nodeWithdraw() public isNodeContract(msg.sender) returns(bool) {
         // Will throw if conditions are not met in delegate
-        (bool success,) = getContractAddress("rocketMinipoolDelegate").delegatecall(abi.encodeWithSignature("nodeWithdraw()"));
+        (bool success,) = getContractAddress("rocketMinipoolDelegateNode").delegatecall(abi.encodeWithSignature("nodeWithdraw()"));
         require(success, "Delegate call failed.");
         // Success
         return true;
@@ -339,7 +320,7 @@ contract RocketMinipool {
     /// @param _groupID The 3rd party group the user belongs too
     function deposit(address _user, address _groupID) public payable onlyLatestContract("rocketDepositQueue") returns(bool) {
         // Will throw if conditions are not met in delegate or call fails
-        (bool success,) = getContractAddress("rocketMinipoolDelegate").delegatecall(abi.encodeWithSignature("deposit(address,address)", _user, _groupID));
+        (bool success,) = getContractAddress("rocketMinipoolDelegateUser").delegatecall(abi.encodeWithSignature("deposit(address,address)", _user, _groupID));
         require(success, "Delegate call failed.");
         // Success
         return true;
@@ -352,7 +333,7 @@ contract RocketMinipool {
     /// @param _refundAddress The address to refund the user's deposit to
     function refund(address _user, address _groupID, address _refundAddress) public onlyLatestContract("rocketDeposit") returns(bool) {
         // Will throw if conditions are not met in delegate or call fails
-        (bool success,) = getContractAddress("rocketMinipoolDelegate").delegatecall(abi.encodeWithSignature("refund(address,address,address)", _user, _groupID, _refundAddress));
+        (bool success,) = getContractAddress("rocketMinipoolDelegateUser").delegatecall(abi.encodeWithSignature("refund(address,address,address)", _user, _groupID, _refundAddress));
         require(success, "Delegate call failed.");
         // Success
         return true;
@@ -367,7 +348,7 @@ contract RocketMinipool {
     /// @param _withdrawnAddress The address the user's deposit was withdrawn to
     function withdrawStaking(address _user, address _groupID, uint256 _withdrawnAmount, uint256 _tokenAmount, address _withdrawnAddress) public onlyLatestContract("rocketDeposit") returns(bool) {
         // Will throw if conditions are not met in delegate or call fails
-        (bool success,) = getContractAddress("rocketMinipoolDelegate").delegatecall(abi.encodeWithSignature("withdrawStaking(address,address,uint256,uint256,address)", _user, _groupID, _withdrawnAmount, _tokenAmount, _withdrawnAddress));
+        (bool success,) = getContractAddress("rocketMinipoolDelegateUser").delegatecall(abi.encodeWithSignature("withdrawStaking(address,address,uint256,uint256,address)", _user, _groupID, _withdrawnAmount, _tokenAmount, _withdrawnAddress));
         require(success, "Delegate call failed.");
         // Success
         return true;
@@ -380,7 +361,7 @@ contract RocketMinipool {
     /// @param _withdrawalAddress The address to withdraw the user's deposit to
     function withdraw(address _user, address _groupID, address _withdrawalAddress) public onlyLatestContract("rocketDeposit") returns(bool) {
         // Will throw if conditions are not met in delegate or call fails
-        (bool success,) = getContractAddress("rocketMinipoolDelegate").delegatecall(abi.encodeWithSignature("withdraw(address,address,address)", _user, _groupID, _withdrawalAddress));
+        (bool success,) = getContractAddress("rocketMinipoolDelegateUser").delegatecall(abi.encodeWithSignature("withdraw(address,address,address)", _user, _groupID, _withdrawalAddress));
         require(success, "Delegate call failed.");
         // Success
         return true;
@@ -443,7 +424,7 @@ contract RocketMinipool {
     /// @dev Sets the status of the pool based on its current parameters 
     function updateStatus() public returns(bool) {
         // Will update the status of the pool if conditions are correct
-        (bool success,) = getContractAddress("rocketMinipoolDelegate").delegatecall(abi.encodeWithSignature("updateStatus()"));
+        (bool success,) = getContractAddress("rocketMinipoolDelegateStatus").delegatecall(abi.encodeWithSignature("updateStatus()"));
         require(success, "Delegate call failed.");
         // Success
         return true;
@@ -452,7 +433,7 @@ contract RocketMinipool {
     /// @dev Sets the minipool to logged out
     function logoutMinipool() public onlyLatestContract("rocketNodeWatchtower") returns (bool) {
         // Will update the status of the pool if conditions are correct
-        (bool success,) = getContractAddress("rocketMinipoolDelegate").delegatecall(abi.encodeWithSignature("logoutMinipool()"));
+        (bool success,) = getContractAddress("rocketMinipoolDelegateStatus").delegatecall(abi.encodeWithSignature("logoutMinipool()"));
         require(success, "Delegate call failed.");
         // Success
         return true;
@@ -462,7 +443,7 @@ contract RocketMinipool {
     /// @param _withdrawalBalance The minipool's balance at withdrawal
     function withdrawMinipool(uint256 _withdrawalBalance) public onlyLatestContract("rocketNodeWatchtower") returns (bool) {
         // Will update the status of the pool if conditions are correct
-        (bool success,) = getContractAddress("rocketMinipoolDelegate").delegatecall(abi.encodeWithSignature("withdrawMinipool(uint256)", _withdrawalBalance));
+        (bool success,) = getContractAddress("rocketMinipoolDelegateStatus").delegatecall(abi.encodeWithSignature("withdrawMinipool(uint256)", _withdrawalBalance));
         require(success, "Delegate call failed.");
         // Success
         return true;

--- a/contracts/contract/minipool/RocketMinipoolDelegate.sol
+++ b/contracts/contract/minipool/RocketMinipoolDelegate.sol
@@ -5,6 +5,7 @@ pragma solidity 0.5.0;
 import "../../interface/RocketPoolInterface.sol";
 import "../../interface/RocketStorageInterface.sol";
 import "../../interface/settings/RocketGroupSettingsInterface.sol";
+import "../../interface/settings/RocketNodeSettingsInterface.sol";
 import "../../interface/settings/RocketMinipoolSettingsInterface.sol";
 import "../../interface/casper/DepositInterface.sol";
 import "../../interface/group/RocketGroupContractInterface.sol";
@@ -49,6 +50,7 @@ contract RocketMinipoolDelegate {
     DepositInterface casperDeposit = DepositInterface(0);                                           // Interface of the Casper deposit contract
     RocketGroupContractInterface rocketGroupContract = RocketGroupContractInterface(0);             // The users group contract that they belong too
     RocketGroupSettingsInterface rocketGroupSettings = RocketGroupSettingsInterface(0);             // The settings for groups
+    RocketNodeSettingsInterface rocketNodeSettings = RocketNodeSettingsInterface(0);                // The settings for nodes
     RocketPoolInterface rocketPool = RocketPoolInterface(0);                                        // The main pool manager
     RocketMinipoolSettingsInterface rocketMinipoolSettings = RocketMinipoolSettingsInterface(0);    // The main settings contract most global parameters are maintained
     RocketStorageInterface rocketStorage = RocketStorageInterface(0);                               // The main Rocket Pool storage contract where primary persistant storage is maintained
@@ -90,6 +92,7 @@ contract RocketMinipoolDelegate {
         int256  rewards;                                        // Rewards received after Casper
         uint256 stakingTokensWithdrawn;                         // RPB tokens withdrawn by the user during staking
         uint256 feeRP;                                          // Rocket Pools fee
+        uint256 feeNode;                                        // Node operator fee
         uint256 feeGroup;                                       // Group fee
         uint256 created;                                        // Creation timestamp
         bool    exists;                                         // User exists?
@@ -406,8 +409,9 @@ contract RocketMinipoolDelegate {
         require(_user != address(0x0), "User address invalid.");
         // Get the users group contract 
         rocketGroupContract = RocketGroupContractInterface(_groupID);
-        // Get the group settings
+        // Get the settings
         rocketGroupSettings = RocketGroupSettingsInterface(getContractAddress("rocketGroupSettings"));
+        rocketNodeSettings = RocketNodeSettingsInterface(getContractAddress("rocketNodeSettings"));
         // Check the user isn't already registered
         if (users[_user].exists == false) {
             // Add the new user to the mapping of User structs
@@ -419,6 +423,7 @@ contract RocketMinipoolDelegate {
                 rewards: 0,
                 stakingTokensWithdrawn: 0,
                 feeRP: rocketGroupSettings.getDefaultFee(),
+                feeNode: rocketNodeSettings.getFeePerc(),
                 feeGroup: rocketGroupContract.getFeePerc(),
                 exists: true,
                 created: now,

--- a/contracts/contract/minipool/RocketMinipoolDelegate.sol
+++ b/contracts/contract/minipool/RocketMinipoolDelegate.sol
@@ -365,7 +365,7 @@ contract RocketMinipoolDelegate {
         stakingUserDepositsWithdrawals.push(StakingWithdrawal({
             groupID: _groupID,
             amount: _withdrawnAmount,
-            groupFee: users[_user].feeGroup,
+            groupFee: users[_user].feeGroup
         }));
         // Decrement user's balance
         users[_user].balance = users[_user].balance.sub(_withdrawnAmount);
@@ -602,7 +602,7 @@ contract RocketMinipoolDelegate {
             // Transfer fees from forfeited rewards to group contracts
             for (uint256 i = 0; i < stakingUserDepositsWithdrawals.length; ++i) {
                 StakingWithdrawal memory withdrawal = stakingUserDepositsWithdrawals[i];
-                uint256 userRewardsForfeited = int256(withdrawal.amount.mul(staking.balanceEnd).div(staking.balanceStart)) - int256(withdrawal.amount);
+                int256 userRewardsForfeited = int256(withdrawal.amount.mul(staking.balanceEnd).div(staking.balanceStart)) - int256(withdrawal.amount);
                 if (userRewardsForfeited > 0) {
                     uint256 groupFeeAmount = uint256(userRewardsForfeited).mul(withdrawal.groupFee).div(calcBase);
                     require(rpbContract.transfer(withdrawal.groupID, groupFeeAmount), "Group fee could not be transferred to group contract address");

--- a/contracts/contract/minipool/RocketMinipoolDelegate.sol
+++ b/contracts/contract/minipool/RocketMinipoolDelegate.sol
@@ -526,9 +526,12 @@ contract RocketMinipoolDelegate {
     /// @dev Sets the status of the pool to a specific value if valid
     /// @param _status The new status ID to apply
     function setStatusTo(uint8 _status) public onlyLatestContract("rocketNodeWatchtower") returns (bool) {
-        // Check status
-        require(_status == 3 || _status == 4, "Minipool status may only be set to LoggedOut or Withdrawn");
-        require(_status != status.current, "Minipool is already set to status");
+        // Check current and new status
+        require(
+            (status.current == 2 && _status == 3) ||
+            (status.current == 3 && _status == 4),
+            "Minipool status may only be updated from Staking to LoggedOut or LoggedOut to Withdrawn"
+        );
         // Set status
         setStatus(_status);
         // Success

--- a/contracts/contract/minipool/RocketMinipoolDelegate.sol
+++ b/contracts/contract/minipool/RocketMinipoolDelegate.sol
@@ -437,8 +437,6 @@ contract RocketMinipoolDelegate {
         require(_user != address(0x0), "User address invalid.");
         // Get the users group contract 
         rocketGroupContract = RocketGroupContractInterface(_groupID);
-        // Get the settings
-        rocketMinipoolSettings = RocketMinipoolSettingsInterface(getContractAddress("rocketMinipoolSettings"));
         // Check the user isn't already registered
         if (users[_user].exists == false) {
             // Add the new user to the mapping of User structs
@@ -449,7 +447,7 @@ contract RocketMinipoolDelegate {
                 balance: 0,
                 rewards: 0,
                 stakingTokensWithdrawn: 0,
-                feeRP: rocketMinipoolSettings.getMinipoolWithdrawalFeePerc(),
+                feeRP: rocketGroupContract.getFeePercRocketPool(),
                 feeGroup: rocketGroupContract.getFeePerc(),
                 exists: true,
                 created: now,

--- a/contracts/contract/minipool/RocketMinipoolDelegate.sol
+++ b/contracts/contract/minipool/RocketMinipoolDelegate.sol
@@ -523,6 +523,19 @@ contract RocketMinipoolDelegate {
     }
 
 
+    /// @dev Sets the status of the pool to a specific value if valid
+    /// @param _status The new status ID to apply
+    function setStatusTo(uint8 _status) public onlyLatestContract("rocketNodeWatchtower") returns (bool) {
+        // Check status
+        require(_status == 3 || _status == 4, "Minipool status may only be set to LoggedOut or Withdrawn");
+        require(_status != status.current, "Minipool is already set to status");
+        // Set status
+        setStatus(_status);
+        // Success
+        return true;
+    }
+
+
     /// @dev All kids outta the pool - will close and self destruct this pool if the conditions are correct
     function closePool() private {
         // Get the RP interface

--- a/contracts/contract/minipool/RocketMinipoolDelegateNode.sol
+++ b/contracts/contract/minipool/RocketMinipoolDelegateNode.sol
@@ -41,9 +41,9 @@ contract RocketMinipoolDelegateNode {
     bytes32[] private stakingWithdrawalIDs;
 
     // Users
-    mapping (address => User) private users;                    // Users in this pool
+    mapping (bytes32 => User) private users;                    // Users in this pool
     mapping (address => address) private usersBackupAddress;    // Users backup withdrawal address => users current address in this pool, need these in a mapping so we can do a reverse lookup using the backup address
-    address[] private userAddresses;                            // Users in this pool addresses for iteration
+    bytes32[] private userIDs;                                  // Users in this pool IDs for iteration
 
 
     /*** Contracts **************/
@@ -89,16 +89,15 @@ contract RocketMinipoolDelegateNode {
 
     struct User {
         address user;                                           // Address of the user
-        address backup;                                         // The backup address of the user
         address groupID;                                        // Address ID of the users group
+        address backup;                                         // The backup address of the user
         uint256 balance;                                        // Chunk balance deposited
-        int256  rewards;                                        // Rewards received after Casper
         uint256 stakingTokensWithdrawn;                         // RPB tokens withdrawn by the user during staking
         uint256 feeRP;                                          // Rocket Pools fee
         uint256 feeGroup;                                       // Group fee
         uint256 created;                                        // Creation timestamp
         bool    exists;                                         // User exists?
-        uint256 addressIndex;                                   // User's index in the address list
+        uint256 idIndex;                                        // User's index in the ID list
     }
 
     struct StakingWithdrawal {

--- a/contracts/contract/minipool/RocketMinipoolDelegateNode.sol
+++ b/contracts/contract/minipool/RocketMinipoolDelegateNode.sol
@@ -4,6 +4,7 @@ pragma solidity 0.5.0;
 // Interfaces
 import "../../interface/RocketPoolInterface.sol";
 import "../../interface/RocketStorageInterface.sol";
+import "../../interface/minipool/RocketMinipoolInterface.sol";
 import "../../interface/settings/RocketNodeSettingsInterface.sol";
 import "../../interface/settings/RocketMinipoolSettingsInterface.sol";
 import "../../interface/casper/DepositInterface.sol";
@@ -175,13 +176,6 @@ contract RocketMinipoolDelegateNode {
     }
 
 
-    /// @dev Update minipool status
-    function updateStatus() private {
-        (bool success,) = getContractAddress("rocketMinipoolDelegateStatus").delegatecall(abi.encodeWithSignature("updateStatus()"));
-        require(success, "Delegate call failed.");
-    }
-
-
     /*** Node methods ********/
 
 
@@ -234,7 +228,8 @@ contract RocketMinipoolDelegateNode {
         // Fire withdrawal event
         emit NodeWithdrawal(msg.sender, etherAmount, rpbAmount, rplAmount, now);
         // Update the status
-        updateStatus();
+        RocketMinipoolInterface minipool = RocketMinipoolInterface(address(this));
+        minipool.updateStatus();
         // Success
         return true;
     }

--- a/contracts/contract/minipool/RocketMinipoolDelegateNode.sol
+++ b/contracts/contract/minipool/RocketMinipoolDelegateNode.sol
@@ -221,7 +221,7 @@ contract RocketMinipoolDelegateNode {
             if (etherAmount > 0) { address(uint160(node.contractAddress)).transfer(etherAmount); }
         }
         // Transferring RPB to node contract if withdrawn
-        else {
+        else if (staking.balanceStart > 0 && staking.balanceEnd > 0) {
             rpbAmount = nodeBalance.mul(staking.balanceEnd).div(staking.balanceStart);
             if (rpbAmount > 0) { require(rpbContract.transfer(node.contractAddress, rpbAmount), "RPB balance transfer error."); }
         }

--- a/contracts/contract/minipool/RocketMinipoolDelegateNode.sol
+++ b/contracts/contract/minipool/RocketMinipoolDelegateNode.sol
@@ -30,20 +30,20 @@ contract RocketMinipoolDelegateNode {
     uint256 private calcBase = 1 ether;
 
     // General
-    uint8   public version = 1;                                     // Version of this contract
-    Status  private status;                                         // The current status of this pool, statuses are declared via Enum in the minipool settings
-    Node    private node;                                           // Node this minipool is attached to, its creator 
-    Staking private staking;                                        // Staking properties of the minipool to track
-    uint256 private userDepositCapacity;                            // Total capacity for user deposits
-    uint256 private userDepositTotal;                               // Total value of all assigned user deposits
-    uint256 private stakingUserDepositsWithdrawn;                   // Total value of user deposits withdrawn while staking
-    StakingWithdrawal[] private stakingUserDepositsWithdrawals;     // Information on deposit withdrawals made by users while staking
+    uint8   public version = 1;                                         // Version of this contract
+    Status  private status;                                             // The current status of this pool, statuses are declared via Enum in the minipool settings
+    Node    private node;                                               // Node this minipool is attached to, its creator 
+    Staking private staking;                                            // Staking properties of the minipool to track
+    uint256 private userDepositCapacity;                                // Total capacity for user deposits
+    uint256 private userDepositTotal;                                   // Total value of all assigned user deposits
+    uint256 private stakingUserDepositsWithdrawn;                       // Total value of user deposits withdrawn while staking
+    mapping (bytes32 => StakingWithdrawal) private stakingWithdrawals;  // Information on deposit withdrawals made by users while staking
+    bytes32[] private stakingWithdrawalIDs;
 
     // Users
     mapping (address => User) private users;                    // Users in this pool
     mapping (address => address) private usersBackupAddress;    // Users backup withdrawal address => users current address in this pool, need these in a mapping so we can do a reverse lookup using the backup address
     address[] private userAddresses;                            // Users in this pool addresses for iteration
-    
 
 
     /*** Contracts **************/
@@ -104,7 +104,9 @@ contract RocketMinipoolDelegateNode {
     struct StakingWithdrawal {
         address groupID;                                        // The address of the group the user belonged to
         uint256 amount;                                         // The amount withdrawn by the user
-        uint256 groupFee;                                       // The fee charged to the user by the group
+        uint256 feeRP;                                          // The fee charged to the user by Rocket Pool
+        uint256 feeGroup;                                       // The fee charged to the user by the group
+        bool exists;
     }
 
 

--- a/contracts/contract/minipool/RocketMinipoolDelegateNode.sol
+++ b/contracts/contract/minipool/RocketMinipoolDelegateNode.sol
@@ -1,0 +1,243 @@
+pragma solidity 0.5.0;
+
+
+// Interfaces
+import "../../interface/RocketPoolInterface.sol";
+import "../../interface/RocketStorageInterface.sol";
+import "../../interface/settings/RocketNodeSettingsInterface.sol";
+import "../../interface/settings/RocketMinipoolSettingsInterface.sol";
+import "../../interface/casper/DepositInterface.sol";
+import "../../interface/group/RocketGroupContractInterface.sol";
+import "../../interface/token/ERC20.sol";
+import "../../interface/utils/pubsub/PublisherInterface.sol";
+// Libraries
+import "../../lib/SafeMath.sol";
+
+
+/// @title The minipool delegate for node methods, should contain all primary logic for methods that minipools use, is entirely upgradable so that currently deployed pools can get any bug fixes or additions - storage here MUST match the minipool contract
+/// @author David Rugendyke
+
+contract RocketMinipoolDelegateNode {
+
+    /*** Libs  *****************/
+
+    using SafeMath for uint;
+
+
+    /**** Properties ***********/
+
+    uint256 private calcBase = 1 ether;
+
+    // General
+    uint8   public version = 1;                                     // Version of this contract
+    Status  private status;                                         // The current status of this pool, statuses are declared via Enum in the minipool settings
+    Node    private node;                                           // Node this minipool is attached to, its creator 
+    Staking private staking;                                        // Staking properties of the minipool to track
+    uint256 private userDepositCapacity;                            // Total capacity for user deposits
+    uint256 private userDepositTotal;                               // Total value of all assigned user deposits
+    uint256 private stakingUserDepositsWithdrawn;                   // Total value of user deposits withdrawn while staking
+    StakingWithdrawal[] private stakingUserDepositsWithdrawals;     // Information on deposit withdrawals made by users while staking
+
+    // Users
+    mapping (address => User) private users;                    // Users in this pool
+    mapping (address => address) private usersBackupAddress;    // Users backup withdrawal address => users current address in this pool, need these in a mapping so we can do a reverse lookup using the backup address
+    address[] private userAddresses;                            // Users in this pool addresses for iteration
+    
+
+
+    /*** Contracts **************/
+
+    ERC20 rplContract = ERC20(0);                                                                   // The address of our RPL ERC20 token contract
+    ERC20 rpbContract = ERC20(0);                                                                   // The address of our RPB ERC20 token contract
+    DepositInterface casperDeposit = DepositInterface(0);                                           // Interface of the Casper deposit contract
+    RocketGroupContractInterface rocketGroupContract = RocketGroupContractInterface(0);             // The users group contract that they belong too
+    RocketNodeSettingsInterface rocketNodeSettings = RocketNodeSettingsInterface(0);                // The settings for nodes
+    RocketPoolInterface rocketPool = RocketPoolInterface(0);                                        // The main pool manager
+    RocketMinipoolSettingsInterface rocketMinipoolSettings = RocketMinipoolSettingsInterface(0);    // The main settings contract most global parameters are maintained
+    RocketStorageInterface rocketStorage = RocketStorageInterface(0);                               // The main Rocket Pool storage contract where primary persistant storage is maintained
+    PublisherInterface publisher = PublisherInterface(0);                                           // Main pubsub system event publisher
+
+
+    /*** Structs ***************/
+
+    struct Status {
+        uint8   current;                                        // The current status code, see RocketMinipoolSettings for more information
+        uint8   previous;                                       // The previous status code
+        uint256 time;                                           // The time the status last changed
+        uint256 block;                                          // The block number the status last changed
+    }
+
+    struct Node {
+        address owner;                                          // Etherbase address of the node which owns this minipool
+        address contractAddress;                                // The nodes Rocket Pool contract
+        uint256 depositEther;                                   // The nodes required ether contribution
+        uint256 depositRPL;                                     // The nodes required RPL contribution
+        bool    trusted;                                        // Was the node trusted at the time of minipool creation?
+        bool    depositExists;                                  // The node operator's deposit exists
+        uint256 balance;                                        // The node operator's ether balance
+        uint256 userFee;                                        // The fee charged to users by the node, determined when the minipool begins staking
+    }
+
+    struct Staking {
+        string  id;                                             // Duration ID
+        uint256 duration;                                       // Duration in blocks
+        uint256 balanceStart;                                   // Ether balance of this minipool when it begins staking
+        uint256 balanceEnd;                                     // Ether balance of this minipool when it completes staking
+        bytes   depositInput;                                   // DepositInput data to be submitted to the casper deposit contract
+    }
+
+    struct User {
+        address user;                                           // Address of the user
+        address backup;                                         // The backup address of the user
+        address groupID;                                        // Address ID of the users group
+        uint256 balance;                                        // Chunk balance deposited
+        int256  rewards;                                        // Rewards received after Casper
+        uint256 stakingTokensWithdrawn;                         // RPB tokens withdrawn by the user during staking
+        uint256 feeRP;                                          // Rocket Pools fee
+        uint256 feeGroup;                                       // Group fee
+        uint256 created;                                        // Creation timestamp
+        bool    exists;                                         // User exists?
+        uint256 addressIndex;                                   // User's index in the address list
+    }
+
+    struct StakingWithdrawal {
+        address groupID;                                        // The address of the group the user belonged to
+        uint256 amount;                                         // The amount withdrawn by the user
+        uint256 groupFee;                                       // The fee charged to the user by the group
+    }
+
+
+    /*** Events ****************/
+
+
+    event NodeDeposit (
+        address indexed _from,                                  // Transferred from
+        uint256 etherAmount,                                    // Amount of ETH
+        uint256 rplAmount,                                      // Amount of RPL
+        uint256 created                                         // Creation timestamp
+    );
+
+    event NodeWithdrawal (
+        address indexed _to,                                    // Transferred to
+        uint256 etherAmount,                                    // Amount of ETH
+        uint256 rpbAmount,                                      // Amount of RPB
+        uint256 rplAmount,                                      // Amount of RPL
+        uint256 created                                         // Creation timestamp
+    );
+
+
+    /*** Modifiers *************/
+
+
+    /// @dev Only the node owner which this minipool belongs to
+    /// @param _nodeOwner The node owner address.
+    modifier isNodeOwner(address _nodeOwner) {
+        require(_nodeOwner != address(0x0) && _nodeOwner == node.owner, "Incorrect node owner address passed.");
+        _;
+    }
+
+    /// @dev Only the node contract which this minipool belongs to
+    /// @param _nodeContract The node contract address
+    modifier isNodeContract(address _nodeContract) {
+        require(_nodeContract != address(0x0) && _nodeContract == node.contractAddress, "Incorrect node contract address passed.");
+        _;
+    }
+
+    /// @dev Only allow access from the latest version of the specified Rocket Pool contract
+    modifier onlyLatestContract(string memory _contract) {
+        require(msg.sender == getContractAddress(_contract), "Only the latest specified Rocket Pool contract can access this method.");
+        _;
+    }
+
+
+    /*** Methods *************/
+
+
+    /// @dev minipool constructor
+    /// @param _rocketStorageAddress Address of Rocket Pools storage.
+    constructor(address _rocketStorageAddress) public {
+        // Update the storage contract address
+        rocketStorage = RocketStorageInterface(_rocketStorageAddress);
+        // Get minipool settings
+        rocketMinipoolSettings = RocketMinipoolSettingsInterface(getContractAddress("rocketMinipoolSettings"));
+        // Set the address of the casper deposit contract
+        casperDeposit = DepositInterface(getContractAddress("casperDeposit"));
+        // Add the token contract addresses
+        rplContract = ERC20(getContractAddress("rocketPoolToken"));
+        rpbContract = ERC20(getContractAddress("rocketBETHToken"));
+    }
+
+
+    /// @dev Get the the contracts address - This method should be called before interacting with any RP contracts to ensure the latest address is used
+    function getContractAddress(string memory _contractName) private view returns(address) { 
+        // Get the current API contract address 
+        return rocketStorage.getAddress(keccak256(abi.encodePacked("contract.name", _contractName)));
+    }
+
+
+    /// @dev Update minipool status
+    function updateStatus() private {
+        (bool success,) = getContractAddress("rocketMinipoolDelegateStatus").delegatecall(abi.encodeWithSignature("updateStatus()"));
+        require(success, "Delegate call failed.");
+    }
+
+
+    /*** Node methods ********/
+
+
+    /// @dev Set the ether / rpl deposit and check it
+    function nodeDeposit() public payable isNodeContract(msg.sender) returns(bool) {
+        // Get minipool settings
+        rocketMinipoolSettings = RocketMinipoolSettingsInterface(getContractAddress("rocketMinipoolSettings"));
+        // Check the RPL exists in the minipool now, should have been sent before the ether
+        require(rplContract.balanceOf(address(this)) >= node.depositRPL, "RPL deposit size does not match the minipool amount set when it was created.");
+        // Check it is the correct amount passed when the minipool was created
+        require(msg.value == node.depositEther, "Ether deposit size does not match the minipool amount set when it was created.");
+        // Check that the node operator has not already deposited
+        require(node.depositExists == false, "Node owner has already made deposit for this minipool.");
+        // Set node operator deposit flag & balance
+        node.depositExists = true;
+        node.balance = msg.value;
+        // Fire deposit event
+        emit NodeDeposit(msg.sender, msg.value, rplContract.balanceOf(address(this)), now);
+        // All good
+        return true;
+    }
+
+
+    /// @dev Withdraw ether / rpl deposit from the minipool if initialised, timed out or withdrawn
+    function nodeWithdraw() public isNodeContract(msg.sender) returns(bool) {
+        // Check current status
+        require(status.current == 0 || status.current == 4 || status.current == 6, "Minipool is not currently allowing node withdrawals.");
+        // Check node operator's deposit exists
+        require(node.depositExists == true, "Node operator does not have a deposit in minipool.");
+        // Get withdrawal amounts
+        uint256 nodeBalance = node.balance;
+        uint256 etherAmount = 0;
+        uint256 rpbAmount = 0;
+        uint256 rplAmount = rplContract.balanceOf(address(this));
+        // Update node operator deposit flag & balance
+        node.depositExists = false;
+        node.balance = 0;
+        // Transfer RPL balance to node contract
+        if (rplAmount > 0) { require(rplContract.transfer(node.contractAddress, rplAmount), "RPL balance transfer error."); }
+        // Refunding ether to node contract if initialised or timed out
+        if (status.current == 0 || status.current == 6) {
+            etherAmount = nodeBalance;
+            if (etherAmount > 0) { address(uint160(node.contractAddress)).transfer(etherAmount); }
+        }
+        // Transferring RPB to node contract if withdrawn
+        else {
+            rpbAmount = nodeBalance.mul(staking.balanceEnd).div(staking.balanceStart);
+            if (rpbAmount > 0) { require(rpbContract.transfer(node.contractAddress, rpbAmount), "RPB balance transfer error."); }
+        }
+        // Fire withdrawal event
+        emit NodeWithdrawal(msg.sender, etherAmount, rpbAmount, rplAmount, now);
+        // Update the status
+        updateStatus();
+        // Success
+        return true;
+    }
+
+
+}

--- a/contracts/contract/minipool/RocketMinipoolDelegateNode.sol
+++ b/contracts/contract/minipool/RocketMinipoolDelegateNode.sol
@@ -9,6 +9,7 @@ import "../../interface/settings/RocketNodeSettingsInterface.sol";
 import "../../interface/settings/RocketMinipoolSettingsInterface.sol";
 import "../../interface/casper/DepositInterface.sol";
 import "../../interface/group/RocketGroupContractInterface.sol";
+import "../../interface/node/RocketNodeContractInterface.sol";
 import "../../interface/token/ERC20.sol";
 import "../../interface/utils/pubsub/PublisherInterface.sol";
 // Libraries
@@ -51,7 +52,8 @@ contract RocketMinipoolDelegateNode {
     ERC20 rplContract = ERC20(0);                                                                   // The address of our RPL ERC20 token contract
     ERC20 rpbContract = ERC20(0);                                                                   // The address of our RPB ERC20 token contract
     DepositInterface casperDeposit = DepositInterface(0);                                           // Interface of the Casper deposit contract
-    RocketGroupContractInterface rocketGroupContract = RocketGroupContractInterface(0);             // The users group contract that they belong too
+    RocketGroupContractInterface rocketGroupContract = RocketGroupContractInterface(0);             // The users group contract that they belong to
+    RocketNodeContractInterface rocketNodeContract = RocketNodeContractInterface(0);                // The node contract for the node which owns this minipool
     RocketNodeSettingsInterface rocketNodeSettings = RocketNodeSettingsInterface(0);                // The settings for nodes
     RocketPoolInterface rocketPool = RocketPoolInterface(0);                                        // The main pool manager
     RocketMinipoolSettingsInterface rocketMinipoolSettings = RocketMinipoolSettingsInterface(0);    // The main settings contract most global parameters are maintained
@@ -101,7 +103,7 @@ contract RocketMinipoolDelegateNode {
     }
 
     struct StakingWithdrawal {
-        address groupOwner;                                     // The owner address of the group the user belonged to
+        address groupFeeAddress;                                // The address to send group fees to
         uint256 amount;                                         // The amount withdrawn by the user
         uint256 feeRP;                                          // The fee charged to the user by Rocket Pool
         uint256 feeGroup;                                       // The fee charged to the user by the group
@@ -224,7 +226,7 @@ contract RocketMinipoolDelegateNode {
         // Transferring RPB to node contract if withdrawn
         else if (staking.balanceStart > 0 && staking.balanceEnd > 0) {
             rpbAmount = nodeBalance.mul(staking.balanceEnd).div(staking.balanceStart);
-            if (rpbAmount > 0) { require(rpbContract.transfer(node.owner, rpbAmount), "RPB balance transfer error."); }
+            if (rpbAmount > 0) { require(rpbContract.transfer(rocketNodeContract.getRewardsAddress(), rpbAmount), "RPB balance transfer error."); }
         }
         // Fire withdrawal event
         emit NodeWithdrawal(msg.sender, etherAmount, rpbAmount, rplAmount, now);

--- a/contracts/contract/minipool/RocketMinipoolDelegateNode.sol
+++ b/contracts/contract/minipool/RocketMinipoolDelegateNode.sol
@@ -101,7 +101,7 @@ contract RocketMinipoolDelegateNode {
     }
 
     struct StakingWithdrawal {
-        address groupID;                                        // The address of the group the user belonged to
+        address groupOwner;                                     // The owner address of the group the user belonged to
         uint256 amount;                                         // The amount withdrawn by the user
         uint256 feeRP;                                          // The fee charged to the user by Rocket Pool
         uint256 feeGroup;                                       // The fee charged to the user by the group
@@ -224,7 +224,7 @@ contract RocketMinipoolDelegateNode {
         // Transferring RPB to node contract if withdrawn
         else if (staking.balanceStart > 0 && staking.balanceEnd > 0) {
             rpbAmount = nodeBalance.mul(staking.balanceEnd).div(staking.balanceStart);
-            if (rpbAmount > 0) { require(rpbContract.transfer(node.contractAddress, rpbAmount), "RPB balance transfer error."); }
+            if (rpbAmount > 0) { require(rpbContract.transfer(node.owner, rpbAmount), "RPB balance transfer error."); }
         }
         // Fire withdrawal event
         emit NodeWithdrawal(msg.sender, etherAmount, rpbAmount, rplAmount, now);

--- a/contracts/contract/minipool/RocketMinipoolDelegateStatus.sol
+++ b/contracts/contract/minipool/RocketMinipoolDelegateStatus.sol
@@ -41,9 +41,9 @@ contract RocketMinipoolDelegateStatus {
     bytes32[] private stakingWithdrawalIDs;
 
     // Users
-    mapping (address => User) private users;                    // Users in this pool
+    mapping (bytes32 => User) private users;                    // Users in this pool
     mapping (address => address) private usersBackupAddress;    // Users backup withdrawal address => users current address in this pool, need these in a mapping so we can do a reverse lookup using the backup address
-    address[] private userAddresses;                            // Users in this pool addresses for iteration
+    bytes32[] private userIDs;                                  // Users in this pool IDs for iteration
 
 
     /*** Contracts **************/
@@ -89,16 +89,15 @@ contract RocketMinipoolDelegateStatus {
 
     struct User {
         address user;                                           // Address of the user
-        address backup;                                         // The backup address of the user
         address groupID;                                        // Address ID of the users group
+        address backup;                                         // The backup address of the user
         uint256 balance;                                        // Chunk balance deposited
-        int256  rewards;                                        // Rewards received after Casper
         uint256 stakingTokensWithdrawn;                         // RPB tokens withdrawn by the user during staking
         uint256 feeRP;                                          // Rocket Pools fee
         uint256 feeGroup;                                       // Group fee
         uint256 created;                                        // Creation timestamp
         bool    exists;                                         // User exists?
-        uint256 addressIndex;                                   // User's index in the address list
+        uint256 idIndex;                                        // User's index in the ID list
     }
 
     struct StakingWithdrawal {
@@ -164,7 +163,7 @@ contract RocketMinipoolDelegateStatus {
 
     /// @dev Returns the user count for this pool
     function getUserCount() public view returns(uint256) {
-        return userAddresses.length;
+        return userIDs.length;
     }
 
 

--- a/contracts/contract/minipool/RocketMinipoolDelegateStatus.sol
+++ b/contracts/contract/minipool/RocketMinipoolDelegateStatus.sol
@@ -1,0 +1,292 @@
+pragma solidity 0.5.0;
+
+
+// Interfaces
+import "../../interface/RocketPoolInterface.sol";
+import "../../interface/RocketStorageInterface.sol";
+import "../../interface/settings/RocketNodeSettingsInterface.sol";
+import "../../interface/settings/RocketMinipoolSettingsInterface.sol";
+import "../../interface/casper/DepositInterface.sol";
+import "../../interface/group/RocketGroupContractInterface.sol";
+import "../../interface/token/ERC20.sol";
+import "../../interface/utils/pubsub/PublisherInterface.sol";
+// Libraries
+import "../../lib/SafeMath.sol";
+
+
+/// @title The minipool delegate for status methods, should contain all primary logic for methods that minipools use, is entirely upgradable so that currently deployed pools can get any bug fixes or additions - storage here MUST match the minipool contract
+/// @author David Rugendyke
+
+contract RocketMinipoolDelegateStatus {
+
+    /*** Libs  *****************/
+
+    using SafeMath for uint;
+
+
+    /**** Properties ***********/
+
+    uint256 private calcBase = 1 ether;
+
+    // General
+    uint8   public version = 1;                                     // Version of this contract
+    Status  private status;                                         // The current status of this pool, statuses are declared via Enum in the minipool settings
+    Node    private node;                                           // Node this minipool is attached to, its creator 
+    Staking private staking;                                        // Staking properties of the minipool to track
+    uint256 private userDepositCapacity;                            // Total capacity for user deposits
+    uint256 private userDepositTotal;                               // Total value of all assigned user deposits
+    uint256 private stakingUserDepositsWithdrawn;                   // Total value of user deposits withdrawn while staking
+    StakingWithdrawal[] private stakingUserDepositsWithdrawals;     // Information on deposit withdrawals made by users while staking
+
+    // Users
+    mapping (address => User) private users;                    // Users in this pool
+    mapping (address => address) private usersBackupAddress;    // Users backup withdrawal address => users current address in this pool, need these in a mapping so we can do a reverse lookup using the backup address
+    address[] private userAddresses;                            // Users in this pool addresses for iteration
+    
+
+
+    /*** Contracts **************/
+
+    ERC20 rplContract = ERC20(0);                                                                   // The address of our RPL ERC20 token contract
+    ERC20 rpbContract = ERC20(0);                                                                   // The address of our RPB ERC20 token contract
+    DepositInterface casperDeposit = DepositInterface(0);                                           // Interface of the Casper deposit contract
+    RocketGroupContractInterface rocketGroupContract = RocketGroupContractInterface(0);             // The users group contract that they belong too
+    RocketNodeSettingsInterface rocketNodeSettings = RocketNodeSettingsInterface(0);                // The settings for nodes
+    RocketPoolInterface rocketPool = RocketPoolInterface(0);                                        // The main pool manager
+    RocketMinipoolSettingsInterface rocketMinipoolSettings = RocketMinipoolSettingsInterface(0);    // The main settings contract most global parameters are maintained
+    RocketStorageInterface rocketStorage = RocketStorageInterface(0);                               // The main Rocket Pool storage contract where primary persistant storage is maintained
+    PublisherInterface publisher = PublisherInterface(0);                                           // Main pubsub system event publisher
+
+    
+    /*** Structs ***************/
+
+    struct Status {
+        uint8   current;                                        // The current status code, see RocketMinipoolSettings for more information
+        uint8   previous;                                       // The previous status code
+        uint256 time;                                           // The time the status last changed
+        uint256 block;                                          // The block number the status last changed
+    }
+
+    struct Node {
+        address owner;                                          // Etherbase address of the node which owns this minipool
+        address contractAddress;                                // The nodes Rocket Pool contract
+        uint256 depositEther;                                   // The nodes required ether contribution
+        uint256 depositRPL;                                     // The nodes required RPL contribution
+        bool    trusted;                                        // Was the node trusted at the time of minipool creation?
+        bool    depositExists;                                  // The node operator's deposit exists
+        uint256 balance;                                        // The node operator's ether balance
+        uint256 userFee;                                        // The fee charged to users by the node, determined when the minipool begins staking
+    }
+
+    struct Staking {
+        string  id;                                             // Duration ID
+        uint256 duration;                                       // Duration in blocks
+        uint256 balanceStart;                                   // Ether balance of this minipool when it begins staking
+        uint256 balanceEnd;                                     // Ether balance of this minipool when it completes staking
+        bytes   depositInput;                                   // DepositInput data to be submitted to the casper deposit contract
+    }
+
+    struct User {
+        address user;                                           // Address of the user
+        address backup;                                         // The backup address of the user
+        address groupID;                                        // Address ID of the users group
+        uint256 balance;                                        // Chunk balance deposited
+        int256  rewards;                                        // Rewards received after Casper
+        uint256 stakingTokensWithdrawn;                         // RPB tokens withdrawn by the user during staking
+        uint256 feeRP;                                          // Rocket Pools fee
+        uint256 feeGroup;                                       // Group fee
+        uint256 created;                                        // Creation timestamp
+        bool    exists;                                         // User exists?
+        uint256 addressIndex;                                   // User's index in the address list
+    }
+
+    struct StakingWithdrawal {
+        address groupID;                                        // The address of the group the user belonged to
+        uint256 amount;                                         // The amount withdrawn by the user
+        uint256 groupFee;                                       // The fee charged to the user by the group
+    }
+
+
+    /*** Events ****************/
+
+
+    event PoolDestroyed (
+        address indexed _user,                                  // User that triggered the close
+        address indexed _address,                               // Address of the pool
+        uint256 created                                         // Creation timestamp
+    );
+
+    event StatusChange (
+        uint256 indexed _statusCodeNew,                         // Pools status code - new
+        uint256 indexed _statusCodeOld,                         // Pools status code - old
+        uint256 time,                                           // The last time the status changed
+        uint256 block                                           // The last block number the status changed
+    );
+
+
+    /*** Modifiers *************/
+
+
+    /// @dev Only allow access from the latest version of the specified Rocket Pool contract
+    modifier onlyLatestContract(string memory _contract) {
+        require(msg.sender == getContractAddress(_contract), "Only the latest specified Rocket Pool contract can access this method.");
+        _;
+    }
+
+
+    /*** Methods *************/
+
+
+    /// @dev minipool constructor
+    /// @param _rocketStorageAddress Address of Rocket Pools storage.
+    constructor(address _rocketStorageAddress) public {
+        // Update the storage contract address
+        rocketStorage = RocketStorageInterface(_rocketStorageAddress);
+        // Get minipool settings
+        rocketMinipoolSettings = RocketMinipoolSettingsInterface(getContractAddress("rocketMinipoolSettings"));
+        // Set the address of the casper deposit contract
+        casperDeposit = DepositInterface(getContractAddress("casperDeposit"));
+        // Add the token contract addresses
+        rplContract = ERC20(getContractAddress("rocketPoolToken"));
+        rpbContract = ERC20(getContractAddress("rocketBETHToken"));
+    }
+
+
+    /// @dev Get the the contracts address - This method should be called before interacting with any RP contracts to ensure the latest address is used
+    function getContractAddress(string memory _contractName) private view returns(address) { 
+        // Get the current API contract address 
+        return rocketStorage.getAddress(keccak256(abi.encodePacked("contract.name", _contractName)));
+    }
+
+
+    /// @dev Returns the user count for this pool
+    function getUserCount() public view returns(uint256) {
+        return userAddresses.length;
+    }
+
+
+    /// @dev Change the status
+    /// @param _newStatus status id to apply to the minipool
+    function setStatus(uint8 _newStatus) private {
+        // Fire the event if the status has changed
+        if (_newStatus != status.current) {
+            status.previous = status.current;
+            status.current = _newStatus;
+            status.time = now;
+            status.block = block.number;
+            emit StatusChange(status.current, status.previous, status.time, status.block);
+            // Publish status change event
+            publisher = PublisherInterface(getContractAddress("utilPublisher"));
+            publisher.publish(keccak256("minipool.status.change"), abi.encodeWithSignature("onMinipoolStatusChange(address,uint8)", address(this), _newStatus));
+        }
+    }
+
+
+    /// @dev Sets the status of the pool based on its current parameters 
+    function updateStatus() public returns(bool) {
+        // Set our status now - see RocketMinipoolSettings.sol for pool statuses and keys
+        rocketMinipoolSettings = RocketMinipoolSettingsInterface(getContractAddress("rocketMinipoolSettings"));
+        // Get minipool settings
+        uint256 launchAmount = rocketMinipoolSettings.getMinipoolLaunchAmount();
+        // Check to see if we can close the pool - stops execution if closed
+        closePool();
+        // Set to Prelaunch - Minipool has been assigned user(s) ether but not enough to begin staking yet. Node owners cannot withdraw their ether/rpl.
+        if (getUserCount() == 1 && status.current == 0) {
+            // Prelaunch
+            setStatus(1);
+            // Done
+            return true;
+        }
+        // Set to Staking - Minipool has received enough ether to begin staking, it's users and node owners ether is combined and sent to stake with Casper for the desired duration. Do not enforce the required ether, just send the right amount.
+        if (getUserCount() > 0 && status.current == 1 && address(this).balance >= launchAmount) {
+            // If the node is not trusted, double check to make sure it has the correct RPL balance
+            if(!node.trusted) {
+                require(rplContract.balanceOf(address(this)) >= node.depositRPL, "Nodes RPL balance does not match its intended staking balance.");
+            }
+            // Send deposit to casper deposit contract
+            casperDeposit.deposit.value(launchAmount)(staking.depositInput);
+            // Set staking start balance
+            staking.balanceStart = launchAmount;
+            // Set node user fee
+            rocketNodeSettings = RocketNodeSettingsInterface(getContractAddress("rocketNodeSettings"));
+            node.userFee = rocketNodeSettings.getFeePerc();
+            // Staking
+            setStatus(2);
+            // Done
+            return true;
+        }
+        // Set to TimedOut - If a minipool is widowed or stuck for a long time, it is classed as timed out (it has users, not enough to begin staking, but the node owner cannot close it)
+        if (status.current == 1 && status.time <= (now - rocketMinipoolSettings.getMinipoolTimeout())) {
+            // TimedOut
+            setStatus(6);
+            // Done
+            return true;
+        }
+        // Done
+        return true; 
+    }
+
+
+    /// @dev Sets the minipool to logged out
+    function logoutMinipool() public onlyLatestContract("rocketNodeWatchtower") returns (bool) {
+        // Check current status
+        require(status.current == 2, "Minipool may only be logged out while staking");
+        // Set LoggedOut status
+        setStatus(3);
+        // Success
+        return true;
+    }
+
+
+    /// @dev Sets the minipool to withdrawn and sets its balance at withdrawal
+    /// @param _withdrawalBalance The minipool's balance at withdrawal
+    function withdrawMinipool(uint256 _withdrawalBalance) public onlyLatestContract("rocketNodeWatchtower") returns (bool) {
+        // Check current status
+        require(status.current == 3, "Minipool may only be withdrawn while logged out");
+        // Set Withdrawn status
+        setStatus(4);
+        // Set staking end balance
+        staking.balanceEnd = _withdrawalBalance;
+        // Success
+        return true;
+    }
+
+
+    /// @dev All kids outta the pool - will close and self destruct this pool if the conditions are correct
+    function closePool() private {
+        // Get the RP interface
+        rocketPool = RocketPoolInterface(getContractAddress("rocketPool"));
+        // Remove the minipool if possible
+        if(rocketPool.minipoolRemove()) {
+            // Send any unclaimed RPL back to the node contract
+            uint256 rplBalance = rplContract.balanceOf(address(this));
+            if (rplBalance > 0) { require(rplContract.transfer(node.contractAddress, rplBalance), "RPL balance transfer error."); }
+            // Transfer fees from forfeited rewards to node contract
+            int256 rewardsForfeited = int256(stakingUserDepositsWithdrawn.mul(staking.balanceEnd).div(staking.balanceStart)) - int256(stakingUserDepositsWithdrawn);
+            if (rewardsForfeited > 0) {
+                uint256 nodeFeeAmount = uint256(rewardsForfeited).mul(node.userFee).div(calcBase);
+                require(rpbContract.transfer(node.contractAddress, nodeFeeAmount), "Node operator fee could not be transferred to node contract address");
+            }
+            // Transfer fees from forfeited rewards to group contracts
+            for (uint256 i = 0; i < stakingUserDepositsWithdrawals.length; ++i) {
+                StakingWithdrawal memory withdrawal = stakingUserDepositsWithdrawals[i];
+                int256 userRewardsForfeited = int256(withdrawal.amount.mul(staking.balanceEnd).div(staking.balanceStart)) - int256(withdrawal.amount);
+                if (userRewardsForfeited > 0) {
+                    uint256 groupFeeAmount = uint256(userRewardsForfeited).mul(withdrawal.groupFee).div(calcBase);
+                    require(rpbContract.transfer(withdrawal.groupID, groupFeeAmount), "Group fee could not be transferred to group contract address");
+                }
+            }
+            // Get minipool settings
+            rocketMinipoolSettings = RocketMinipoolSettingsInterface(getContractAddress("rocketMinipoolSettings"));
+            // Transfer remaining RPB balance to rocket pool
+            uint256 rpbBalance = rpbContract.balanceOf(address(this));
+            if (rpbBalance > 0) { require(rpbContract.transfer(rocketMinipoolSettings.getMinipoolWithdrawalFeeDepositAddress(), rpbBalance), "RPB balance transfer error."); }
+            // Log it
+            emit PoolDestroyed(msg.sender, address(this), now);
+            // Close now and send any unclaimed ether back to the node contract
+            selfdestruct(address(uint160(node.contractAddress)));
+        }
+    }
+
+
+}

--- a/contracts/contract/minipool/RocketMinipoolDelegateStatus.sol
+++ b/contracts/contract/minipool/RocketMinipoolDelegateStatus.sol
@@ -101,7 +101,7 @@ contract RocketMinipoolDelegateStatus {
     }
 
     struct StakingWithdrawal {
-        address groupID;                                        // The address of the group the user belonged to
+        address groupOwner;                                     // The owner address of the group the user belonged to
         uint256 amount;                                         // The amount withdrawn by the user
         uint256 feeRP;                                          // The fee charged to the user by Rocket Pool
         uint256 feeGroup;                                       // The fee charged to the user by the group
@@ -280,11 +280,11 @@ contract RocketMinipoolDelegateStatus {
                         rewardsForfeited -= int256(rpFeeAmount + nodeFeeAmount);
                         // Calculate group fee from remaining rewards and transfer
                         uint256 groupFeeAmount = uint256(rewardsForfeited).mul(withdrawal.feeGroup).div(calcBase);
-                        if (groupFeeAmount > 0) { require(rpbContract.transfer(withdrawal.groupID, groupFeeAmount), "Group fee could not be transferred to group contract address"); }
+                        if (groupFeeAmount > 0) { require(rpbContract.transfer(withdrawal.groupOwner, groupFeeAmount), "Group fee could not be transferred to group contract address"); }
                     }
                 }
                 // Transfer total node fees
-                if (nodeFeeTotal > 0) { require(rpbContract.transfer(node.contractAddress, nodeFeeTotal), "Node operator fee could not be transferred to node contract address"); }
+                if (nodeFeeTotal > 0) { require(rpbContract.transfer(node.owner, nodeFeeTotal), "Node operator fee could not be transferred to node contract address"); }
             }
             // Transfer remaining RPB balance to rocket pool
             uint256 rpbBalance = rpbContract.balanceOf(address(this));

--- a/contracts/contract/minipool/RocketMinipoolDelegateStatus.sol
+++ b/contracts/contract/minipool/RocketMinipoolDelegateStatus.sol
@@ -278,7 +278,7 @@ contract RocketMinipoolDelegateStatus {
                         uint256 rpFeeAmount = uint256(rewardsForfeited).mul(withdrawal.feeRP).div(calcBase);
                         uint256 nodeFeeAmount = uint256(rewardsForfeited).mul(node.userFee).div(calcBase);
                         nodeFeeTotal = nodeFeeTotal.add(nodeFeeAmount);
-                        rewardsForfeited -= (rpFeeAmount + nodeFeeAmount);
+                        rewardsForfeited -= int256(rpFeeAmount + nodeFeeAmount);
                         // Calculate group fee from remaining rewards and transfer
                         uint256 groupFeeAmount = uint256(rewardsForfeited).mul(withdrawal.feeGroup).div(calcBase);
                         if (groupFeeAmount > 0) { require(rpbContract.transfer(withdrawal.groupID, groupFeeAmount), "Group fee could not be transferred to group contract address"); }

--- a/contracts/contract/minipool/RocketMinipoolDelegateUser.sol
+++ b/contracts/contract/minipool/RocketMinipoolDelegateUser.sol
@@ -312,8 +312,8 @@ contract RocketMinipoolDelegateUser {
             // Update withdrawal amount
             amount = amount.sub(rpFeeAmount).sub(nodeFeeAmount).sub(groupFeeAmount);
             // Transfer fees
-            require(rpbContract.transfer(rocketMinipoolSettings.getMinipoolWithdrawalFeeDepositAddress(), rpFeeAmount), "Rocket Pool fee could not be transferred to RP fee address");
-            require(rpbContract.transfer(node.contractAddress, nodeFeeAmount), "Node operator fee could not be transferred to node contract address");
+            if (rpFeeAmount > 0) { require(rpbContract.transfer(rocketMinipoolSettings.getMinipoolWithdrawalFeeDepositAddress(), rpFeeAmount), "Rocket Pool fee could not be transferred to RP fee address"); }
+            if (nodeFeeAmount > 0) { require(rpbContract.transfer(node.contractAddress, nodeFeeAmount), "Node operator fee could not be transferred to node contract address"); }
             if (groupFeeAmount > 0) { require(rpbContract.transfer(_groupID, groupFeeAmount), "Group fee could not be transferred to group contract address"); }
         }
         // Transfer withdrawal amount to withdrawal address as RPB tokens

--- a/contracts/contract/minipool/RocketMinipoolDelegateUser.sol
+++ b/contracts/contract/minipool/RocketMinipoolDelegateUser.sol
@@ -321,7 +321,7 @@ contract RocketMinipoolDelegateUser {
             }
         }
         // Transfer withdrawal amount to withdrawal address as RPB tokens
-        require(rpbContract.transfer(_withdrawalAddress, amount), "Withdrawal amount could not be transferred to withdrawal address");
+        if (amount > 0) { require(rpbContract.transfer(_withdrawalAddress, amount), "Withdrawal amount could not be transferred to withdrawal address"); }
         // Remove user
         removeUser(_user, _groupID);
         // Publish withdrawal event

--- a/contracts/contract/minipool/RocketMinipoolDelegateUser.sol
+++ b/contracts/contract/minipool/RocketMinipoolDelegateUser.sol
@@ -346,9 +346,6 @@ contract RocketMinipoolDelegateUser {
             userAddresses.push(_user);
             // Fire the event
             emit UserAdded(_user, now);
-            // Update the status of the pool
-            RocketMinipoolInterface minipool = RocketMinipoolInterface(address(this));
-            minipool.updateStatus();
             // Success
             return true;
         }
@@ -370,9 +367,6 @@ contract RocketMinipoolDelegateUser {
         delete users[_user];
         // Fire the event
         emit UserRemoved(_user, now);
-        // Update the status of the pool
-        RocketMinipoolInterface minipool = RocketMinipoolInterface(address(this));
-        minipool.updateStatus();
         // Success
         return true;
     }

--- a/contracts/contract/minipool/RocketMinipoolDelegateUser.sol
+++ b/contracts/contract/minipool/RocketMinipoolDelegateUser.sol
@@ -289,10 +289,13 @@ contract RocketMinipoolDelegateUser {
             if (rewardsEarned > 0) {
                 // Get the settings
                 rocketMinipoolSettings = RocketMinipoolSettingsInterface(getContractAddress("rocketMinipoolSettings"));
-                // Get fee amounts
+                // Calculate and subtract RP and node fees from rewards
                 uint256 rpFeeAmount = uint256(rewardsEarned).mul(users[_user].feeRP).div(calcBase);
                 uint256 nodeFeeAmount = uint256(rewardsEarned).mul(node.userFee).div(calcBase);
+                rewardsEarned -= (rpFeeAmount + nodeFeeAmount);
+                // Calculate group fee from remaining rewards
                 uint256 groupFeeAmount = uint256(rewardsEarned).mul(users[_user].feeGroup).div(calcBase);
+                // Update withdrawal amount
                 amount = amount.sub(rpFeeAmount).sub(nodeFeeAmount).sub(groupFeeAmount);
                 // Transfer fees
                 require(rpbContract.transfer(rocketMinipoolSettings.getMinipoolWithdrawalFeeDepositAddress(), rpFeeAmount), "Rocket Pool fee could not be transferred to RP fee address");

--- a/contracts/contract/minipool/RocketMinipoolDelegateUser.sol
+++ b/contracts/contract/minipool/RocketMinipoolDelegateUser.sol
@@ -4,6 +4,7 @@ pragma solidity 0.5.0;
 // Interfaces
 import "../../interface/RocketPoolInterface.sol";
 import "../../interface/RocketStorageInterface.sol";
+import "../../interface/minipool/RocketMinipoolInterface.sol";
 import "../../interface/settings/RocketNodeSettingsInterface.sol";
 import "../../interface/settings/RocketMinipoolSettingsInterface.sol";
 import "../../interface/casper/DepositInterface.sol";
@@ -165,13 +166,6 @@ contract RocketMinipoolDelegateUser {
     }
 
 
-    /// @dev Update minipool status
-    function updateStatus() private {
-        (bool success,) = getContractAddress("rocketMinipoolDelegateStatus").delegatecall(abi.encodeWithSignature("updateStatus()"));
-        require(success, "Delegate call failed.");
-    }
-
-
     /*** User methods ********/
 
 
@@ -193,7 +187,8 @@ contract RocketMinipoolDelegateUser {
         // All good? Fire the event for the new deposit
         emit PoolTransfer(msg.sender, address(this), keccak256("deposit"), msg.value, users[_user].balance, now);
         // Update the status
-        updateStatus();
+        RocketMinipoolInterface minipool = RocketMinipoolInterface(address(this));
+        minipool.updateStatus();
         // Success
         return true;
     }
@@ -224,7 +219,8 @@ contract RocketMinipoolDelegateUser {
         // All good? Fire the event for the refund
         emit PoolTransfer(address(this), _refundAddress, keccak256("refund"), amount, 0, now);
         // Update the status
-        updateStatus();
+        RocketMinipoolInterface minipool = RocketMinipoolInterface(address(this));
+        minipool.updateStatus();
         // Success
         return true;
     }
@@ -262,7 +258,8 @@ contract RocketMinipoolDelegateUser {
         // All good? Fire the event for the withdrawal
         emit PoolTransfer(address(this), _withdrawnAddress, keccak256("withdrawal"), _withdrawnAmount, 0, now);
         // Update the status
-        updateStatus();
+        RocketMinipoolInterface minipool = RocketMinipoolInterface(address(this));
+        minipool.updateStatus();
         // Success
         return true;
     }
@@ -307,7 +304,8 @@ contract RocketMinipoolDelegateUser {
         // All good? Fire the event for the withdrawal
         emit PoolTransfer(address(this), _withdrawalAddress, keccak256("withdrawal"), amount, 0, now);
         // Update the status
-        updateStatus();
+        RocketMinipoolInterface minipool = RocketMinipoolInterface(address(this));
+        minipool.updateStatus();
         // Success
         return true;
     }
@@ -341,7 +339,8 @@ contract RocketMinipoolDelegateUser {
             // Fire the event
             emit UserAdded(_user, now);
             // Update the status of the pool
-            updateStatus();
+            RocketMinipoolInterface minipool = RocketMinipoolInterface(address(this));
+            minipool.updateStatus();
             // Success
             return true;
         }
@@ -364,7 +363,8 @@ contract RocketMinipoolDelegateUser {
         // Fire the event
         emit UserRemoved(_user, now);
         // Update the status of the pool
-        updateStatus();
+        RocketMinipoolInterface minipool = RocketMinipoolInterface(address(this));
+        minipool.updateStatus();
         // Success
         return true;
     }

--- a/contracts/contract/minipool/RocketMinipoolDelegateUser.sol
+++ b/contracts/contract/minipool/RocketMinipoolDelegateUser.sol
@@ -254,7 +254,7 @@ contract RocketMinipoolDelegateUser {
         // Update staking deposit withdrawal info
         if (!stakingWithdrawals[userID].exists) {
             stakingWithdrawals[userID] = StakingWithdrawal({
-                groupOwner: rocketGroupContract.owner,
+                groupOwner: rocketGroupContract.getOwner(),
                 amount: 0,
                 feeRP: users[userID].feeRP,
                 feeGroup: users[userID].feeGroup,
@@ -317,7 +317,7 @@ contract RocketMinipoolDelegateUser {
             // Transfer fees
             if (rpFeeAmount > 0) { require(rpbContract.transfer(rocketMinipoolSettings.getMinipoolWithdrawalFeeDepositAddress(), rpFeeAmount), "Rocket Pool fee could not be transferred to RP fee address"); }
             if (nodeFeeAmount > 0) { require(rpbContract.transfer(node.owner, nodeFeeAmount), "Node operator fee could not be transferred to node contract address"); }
-            if (groupFeeAmount > 0) { require(rpbContract.transfer(rocketGroupContract.owner, groupFeeAmount), "Group fee could not be transferred to group contract address"); }
+            if (groupFeeAmount > 0) { require(rpbContract.transfer(rocketGroupContract.getOwner(), groupFeeAmount), "Group fee could not be transferred to group contract address"); }
         }
         // Transfer withdrawal amount to withdrawal address as RPB tokens
         if (amount > 0) { require(rpbContract.transfer(_withdrawalAddress, amount), "Withdrawal amount could not be transferred to withdrawal address"); }

--- a/contracts/contract/minipool/RocketMinipoolDelegateUser.sol
+++ b/contracts/contract/minipool/RocketMinipoolDelegateUser.sol
@@ -302,7 +302,7 @@ contract RocketMinipoolDelegateUser {
                 // Calculate and subtract RP and node fees from rewards
                 uint256 rpFeeAmount = uint256(rewardsEarned).mul(users[_user].feeRP).div(calcBase);
                 uint256 nodeFeeAmount = uint256(rewardsEarned).mul(node.userFee).div(calcBase);
-                rewardsEarned -= (rpFeeAmount + nodeFeeAmount);
+                rewardsEarned -= int256(rpFeeAmount + nodeFeeAmount);
                 // Calculate group fee from remaining rewards
                 uint256 groupFeeAmount = uint256(rewardsEarned).mul(users[_user].feeGroup).div(calcBase);
                 // Update withdrawal amount

--- a/contracts/contract/minipool/RocketMinipoolDelegateUser.sol
+++ b/contracts/contract/minipool/RocketMinipoolDelegateUser.sol
@@ -297,7 +297,7 @@ contract RocketMinipoolDelegateUser {
         // Withdrawal amount
         uint256 amount = users[userID].balance;
         // Check staking balances
-        if (staking.balanceStart > 0 && staking.balanceEnd > 0) {
+        if (staking.balanceStart > 0) {
             // Calculate rewards earned by user
             int256 rewardsEarned = int256(users[userID].balance.mul(staking.balanceEnd).div(staking.balanceStart)) - int256(users[userID].balance);
             // Set withdrawal amount

--- a/contracts/contract/node/RocketNodeContract.sol
+++ b/contracts/contract/node/RocketNodeContract.sol
@@ -26,6 +26,7 @@ contract RocketNodeContract {
 
     address private owner;                                                          // The node that created the contract
     uint8   public version;                                                         // Version of this contract
+    address private rewardsAddress;                                                  // The address to send node operator rewards and fees to as RPB
 
     DepositReservation private depositReservation;                                  // Node operator's deposit reservation
 
@@ -124,6 +125,8 @@ contract RocketNodeContract {
         rplContract = ERC20(rocketStorage.getAddress(keccak256(abi.encodePacked("contract.name", "rocketPoolToken"))));
         // Set the node owner
         owner = _owner;
+        // Default the reward address to the node owner
+        rewardsAddress = _owner;
     }
 
 
@@ -132,6 +135,11 @@ contract RocketNodeContract {
     /// @dev Returns the nodes owner - its coinbase account
     function getOwner() public view returns(address) { 
         return owner;
+    }
+
+    /// @dev Returns the address to send node operator rewards and fees to as RPB
+    function getRewardsAddress() public view returns(address) {
+        return rewardsAddress;
     }
 
     /// @dev Returns the current ETH balance on the contract
@@ -180,7 +188,15 @@ contract RocketNodeContract {
     
     /*** Setters *************/
 
-    
+
+    /// @dev Set the address to send node operator rewards and fees to as RPB
+    function setRewardsAddress(address _rewardsAddress) public onlyNodeOwner returns(bool) {
+        require(_rewardsAddress != address(0x0), "Invalid reward address");
+        rewardsAddress = _rewardsAddress;
+        return true;
+    }
+
+
     /*** Methods *************/
 
 

--- a/contracts/contract/node/RocketNodeWatchtower.sol
+++ b/contracts/contract/node/RocketNodeWatchtower.sol
@@ -50,9 +50,9 @@ contract RocketNodeWatchtower is RocketBase {
     /// @dev Set a minipool to LoggedOut status
     /// @param _minipool The address of the minipool to log out
     function logoutMinipool(address _minipool) public onlyTrustedNode returns (bool) {
-        // Set minipool status to LoggedOut, reverts if already at status
+        // Log minipool out, reverts if not allowed
         RocketMinipoolInterface minipool = RocketMinipoolInterface(_minipool);
-        minipool.setStatusTo(3);
+        minipool.logoutMinipool();
         // Success
         return true;
     }
@@ -64,15 +64,15 @@ contract RocketNodeWatchtower is RocketBase {
     function withdrawMinipool(address _minipool, uint256 _balance) public onlyTrustedNode returns (bool) {
         // Get minipool contract
         RocketMinipoolInterface minipool = RocketMinipoolInterface(_minipool);
-        // Set minipool status to Withdrawn, reverts if already at status
-        minipool.setStatusTo(4);
-        // Get token amount to mint - subtract tokens withdrawn while staking
-        uint256 stakingTokensWithdrawn = minipool.getStakingTokensWithdrawnTotal();
-        uint256 amount = (stakingTokensWithdrawn > _balance) ? 0 : _balance.sub(stakingTokensWithdrawn);
+        // Withdraw minipool, reverts if not allowed
+        minipool.withdrawMinipool(_balance);
+        // Get token amount to mint - subtract deposits withdrawn while staking
+        uint256 stakingUserDepositsWithdrawn = minipool.getStakingUserDepositsWithdrawn();
+        uint256 tokenAmount = (stakingUserDepositsWithdrawn > _balance) ? 0 : _balance.sub(stakingUserDepositsWithdrawn);
         // Mint RPB tokens to minipool
-        if (amount > 0) {
+        if (tokenAmount > 0) {
             rocketBETHToken = RocketBETHTokenInterface(getContractAddress("rocketBETHToken"));
-            rocketBETHToken.mint(_minipool, amount);
+            rocketBETHToken.mint(_minipool, tokenAmount);
         }
         // Success
         return true;

--- a/contracts/contract/node/RocketNodeWatchtower.sol
+++ b/contracts/contract/node/RocketNodeWatchtower.sol
@@ -47,8 +47,10 @@ contract RocketNodeWatchtower is RocketBase {
     /// @param _balance The balance of the minipool to mint as RPB tokens
     function withdrawMinipool(address _minipool, uint256 _balance) public onlyTrustedNode returns (bool) {
         // Mint RPB tokens to minipool
-        rocketBETHToken = RocketBETHTokenInterface(getContractAddress("rocketBETHToken"));
-        rocketBETHToken.mint(_minipool, _balance);
+        if (_balance > 0) {
+            rocketBETHToken = RocketBETHTokenInterface(getContractAddress("rocketBETHToken"));
+            rocketBETHToken.mint(_minipool, _balance);
+        }
         // Set minipool status to Withdrawn, reverts if already at status
         RocketMinipoolInterface minipool = RocketMinipoolInterface(_minipool);
         minipool.setStatusTo(4);

--- a/contracts/contract/node/RocketNodeWatchtower.sol
+++ b/contracts/contract/node/RocketNodeWatchtower.sol
@@ -28,6 +28,15 @@ contract RocketNodeWatchtower is RocketBase {
     }
 
 
+    /*** Constructor *************/
+
+
+    /// @dev RocketNodeWatchtower constructor
+    constructor(address _rocketStorageAddress) RocketBase(_rocketStorageAddress) public {
+        version = 1;
+    }
+
+
     /*** Methods ****************/
 
 

--- a/contracts/contract/node/RocketNodeWatchtower.sol
+++ b/contracts/contract/node/RocketNodeWatchtower.sol
@@ -1,0 +1,60 @@
+pragma solidity 0.5.0;
+
+
+import "../../RocketBase.sol";
+import "../../interface/minipool/RocketMinipoolInterface.sol";
+import "../../interface/token/RocketBETHTokenInterface.sol";
+
+
+/// @title RocketNodeWatchtower - Handles watchtower (trusted) node functions
+/// @author Jake Pospischil
+
+contract RocketNodeWatchtower is RocketBase {
+
+
+    /*** Contracts **************/
+
+
+    RocketBETHTokenInterface rocketBETHToken = RocketBETHTokenInterface(0);
+
+
+    /*** Modifiers **************/
+
+
+    /// @dev Only passes if the sender is a trusted node account
+    modifier onlyTrustedNode() {
+        require(rocketStorage.getBool(keccak256(abi.encodePacked("node.trusted", msg.sender))), "Caller is not a trusted node account.");
+        _;
+    }
+
+
+    /*** Methods ****************/
+
+
+    /// @dev Set a minipool to LoggedOut status
+    /// @param _minipool The address of the minipool to log out
+    function logoutMinipool(address _minipool) public onlyTrustedNode returns (bool) {
+        // Set minipool status to LoggedOut, reverts if already at status
+        RocketMinipoolInterface minipool = RocketMinipoolInterface(_minipool);
+        minipool.setStatusTo(3);
+        // Success
+        return true;
+    }
+
+
+    /// @dev Set a minipool to Withdrawn status and mint RPB tokens to it
+    /// @param _minipool The address of the minipool to withdraw
+    /// @param _balance The balance of the minipool to mint as RPB tokens
+    function withdrawMinipool(address _minipool, uint256 _balance) public onlyTrustedNode returns (bool) {
+        // Mint RPB tokens to minipool
+        rocketBETHToken = RocketBETHTokenInterface(getContractAddress("rocketBETHToken"));
+        rocketBETHToken.mint(_minipool, _balance);
+        // Set minipool status to Withdrawn, reverts if already at status
+        RocketMinipoolInterface minipool = RocketMinipoolInterface(_minipool);
+        minipool.setStatusTo(4);
+        // Success
+        return true;
+    }
+
+
+}

--- a/contracts/contract/node/tasks/CalculateNodeFee.sol
+++ b/contracts/contract/node/tasks/CalculateNodeFee.sol
@@ -53,7 +53,7 @@ contract CalculateNodeFee is RocketBase {
             uint256 feePerc = rocketNodeSettings.getFeePerc();
             uint256 feeVoteCyclePercChange = rocketNodeSettings.getFeeVoteCyclePercChange();
             uint256 minFeePerc = 0 ether; // 0%
-            uint256 maxFeePerc = 1 ether; // 100%
+            uint256 maxFeePerc = rocketNodeSettings.getMaxFeePerc();
             if (increaseVotes > decreaseVotes && increaseVotes > noChangeVotes && feePerc <= maxFeePerc.sub(feeVoteCyclePercChange)) {
                 rocketStorage.setUint(keccak256(abi.encodePacked("settings.node.fee.perc")), feePerc.add(feeVoteCyclePercChange));
             }

--- a/contracts/contract/settings/RocketGroupSettings.sol
+++ b/contracts/contract/settings/RocketGroupSettings.sol
@@ -17,6 +17,7 @@ contract RocketGroupSettings is RocketBase {
         if (!rocketStorage.getBool(keccak256(abi.encodePacked("settings.group.init")))) {
             // Group Settings
             setDefaultFee(0.02 ether);                                                          // The default fee Rocket Pool charges given as a % of 1 Ether (eg 0.02 ether = 2%)
+            setMaxFee(0.5 ether);                                                               // The maximum fee Rocket Pool charges given as a % of 1 Ether (eg 0.02 ether = 2%)
             setNewAllowed(true);                                                                // Are new groups allowed to be added
             setNewFee(0.05 ether);                                                              // The amount of ether required to register a new group 
             setNewFeeAddress(msg.sender);                                                       // The address to send the new group fee to
@@ -30,9 +31,14 @@ contract RocketGroupSettings is RocketBase {
     /*** Getters **********************/
 
 
-    /// @dev The default fee Rocket Pool charges given as a % of 1 Ether (eg 0.02 ether = 2%)                                              
+    /// @dev The default fee Rocket Pool charges given as a % of 1 Ether (eg 0.02 ether = 2%)
     function getDefaultFee() public view returns (uint256) {
-        return rocketStorage.getUint(keccak256(abi.encodePacked("settings.group.fee.default"))); 
+        return rocketStorage.getUint(keccak256(abi.encodePacked("settings.group.fee.default")));
+    }
+
+    /// @dev The maximum fee Rocket Pool charges given as a % of 1 Ether (eg 0.02 ether = 2%)
+    function getMaxFee() public view returns (uint256) {
+        return rocketStorage.getUint(keccak256(abi.encodePacked("settings.group.fee.max")));
     }
 
     /// @dev Are new groups allowed to be added                             
@@ -53,11 +59,18 @@ contract RocketGroupSettings is RocketBase {
 
     /*** Setters **********************/
 
-    /// @dev The default fee Rocket Pool charges given as a % of 1 Ether (eg 0.02 ether = 2%)                                              
+    /// @dev The default fee Rocket Pool charges given as a % of 1 Ether (eg 0.02 ether = 2%)
     function setDefaultFee(uint256 _weiAmount) public onlySuperUser {
         require(_weiAmount >= 0, "Default fee cannot be less than 0.");
         require(_weiAmount <= 1 ether, "Default fee cannot be greater than 100%.");
-        rocketStorage.setUint(keccak256(abi.encodePacked("settings.group.fee.default")), _weiAmount); 
+        rocketStorage.setUint(keccak256(abi.encodePacked("settings.group.fee.default")), _weiAmount);
+    }
+
+    /// @dev The maximum fee Rocket Pool charges given as a % of 1 Ether (eg 0.02 ether = 2%)
+    function setMaxFee(uint256 _weiAmount) public onlySuperUser {
+        require(_weiAmount >= 0, "Maximum fee cannot be less than 0.");
+        require(_weiAmount <= 1 ether, "Maximum fee cannot be greater than 100%.");
+        rocketStorage.setUint(keccak256(abi.encodePacked("settings.group.fee.max")), _weiAmount);
     }
 
     /// @dev Are new groups allowed to be added                                                   

--- a/contracts/contract/settings/RocketGroupSettings.sol
+++ b/contracts/contract/settings/RocketGroupSettings.sol
@@ -19,7 +19,7 @@ contract RocketGroupSettings is RocketBase {
             setDefaultFee(0.02 ether);                                                          // The default fee Rocket Pool charges given as a % of 1 Ether (eg 0.02 ether = 2%)
             setNewAllowed(true);                                                                // Are new groups allowed to be added
             setNewFee(0.05 ether);                                                              // The amount of ether required to register a new group 
-            setNewFeeAddress(msg.sender);                                                       // The address to send the new group fee too
+            setNewFeeAddress(msg.sender);                                                       // The address to send the new group fee to
             // Initialise settings
             rocketStorage.setBool(keccak256(abi.encodePacked("settings.group.init")), true);
         }

--- a/contracts/contract/settings/RocketMinipoolSettings.sol
+++ b/contracts/contract/settings/RocketMinipoolSettings.sol
@@ -38,7 +38,6 @@ contract RocketMinipoolSettings is RocketBase {
             setMinipoolStakingDuration("3m", 526000);                                           // Set the possible staking times for minipools in blocks given avg 15sec blocktime, 3 months (the withdrawal time from Casper is added onto this, it is not included) 
             setMinipoolStakingDuration("6m",  1052000);                                         // 6 Months
             setMinipoolStakingDuration("12m", 2104000);                                         // 12 Months
-            setMinipoolWithdrawalFeePerc(0.05 ether);                                           // The default fee given as a % of 1 Ether (eg 5%)    
             setMinipoolWithdrawalFeeDepositAddress(msg.sender);                                 // The account to send Rocket Pool Fees too, must be an account, not a contract address
             setMinipoolBackupCollectEnabled(true);                                              // Are user backup addresses allowed to collect on behalf of the user after a certain time limit
             setMinipoolBackupCollectDuration(526000);                                           // The block count limit of which after a deposit is received back from Casper, that the user backup address can get access to the deposit - 3months default
@@ -123,11 +122,6 @@ contract RocketMinipoolSettings is RocketBase {
         return getMinipoolStakingDuration("3m");
     }
 
-    /// @dev The default fee given as a % of 1 Ether (eg 5%)    
-    function getMinipoolWithdrawalFeePerc() public view returns (uint256) {
-        return rocketStorage.getUint(keccak256(abi.encodePacked("settings.minipool.fee.withdrawal.perc")));
-    }
-
     /// @dev The account to send Rocket Pool Fees too, must be an account, not a contract address
     function getMinipoolWithdrawalFeeDepositAddress() public view returns (address) {
         return rocketStorage.getAddress(keccak256(abi.encodePacked("settings.minipool.fee.withdrawal.address")));
@@ -178,11 +172,6 @@ contract RocketMinipoolSettings is RocketBase {
     function setMinipoolStakingDuration(string memory _option, uint256 _blocks) public onlySuperUser {
         require(_blocks > 0, "Amount of blocks for staking duration not specified.");
         rocketStorage.setUint(keccak256(abi.encodePacked("settings.minipool.staking.option", _option)), _blocks);  
-    }
-
-    /// @dev Set the Rocket Pool post Casper withdrawal fee given as a % of 1 Ether (eg 5% = 0.05 Ether = 50000000000000000 Wei)
-    function setMinipoolWithdrawalFeePerc(uint256 _withdrawalFeePerc) public onlySuperUser {
-        rocketStorage.setUint(keccak256(abi.encodePacked("settings.minipool.fee.withdrawal.perc")), _withdrawalFeePerc); 
     }
 
     /// @dev The account to send Rocket Pool Fees too, must be an account, not a contract address

--- a/contracts/contract/settings/RocketNodeSettings.sol
+++ b/contracts/contract/settings/RocketNodeSettings.sol
@@ -25,6 +25,7 @@ contract RocketNodeSettings is RocketBase {
             setInactiveDuration(48 hours);                                              // The duration needed by a node not checking in to disable it, needs to be manually reanabled when fixed
             setMaxInactiveNodeChecks(3);                                                // The maximum number of other nodes to check for inactivity on checkin
             setFeePerc(0.05 ether);                                                     // The node operator fee percentage, as a fraction of 1 ether (5%)
+            setMaxFeePerc(0.5 ether);                                                   // The maximum node operator fee percentage, as a fraction of 1 ether (50%)
             setFeeVoteCycleDuration(24 hours);                                          // The duration of a node fee voting cycle
             setFeeVoteCyclePercChange(0.005 ether);                                     // Node fee percentage change per voting cycle, as a fraction of 1 ether (0.5%)
             setDepositAllowed(true);                                                    // Are deposits allowed by nodes?
@@ -82,6 +83,11 @@ contract RocketNodeSettings is RocketBase {
     /// @dev The node operator fee percentage, as a fraction of 1 ether
     function getFeePerc() public view returns (uint256) {
         return rocketStorage.getUint(keccak256(abi.encodePacked("settings.node.fee.perc")));
+    }
+
+    /// @dev The node operator fee percentage, as a fraction of 1 ether
+    function getMaxFeePerc() public view returns (uint256) {
+        return rocketStorage.getUint(keccak256(abi.encodePacked("settings.node.max.fee.perc")));
     }
 
     /// @dev The duration of a node fee voting cycle
@@ -157,6 +163,11 @@ contract RocketNodeSettings is RocketBase {
     function setFeePerc(uint256 _amount) public onlySuperUser {
         require(!rocketStorage.getBool(keccak256(abi.encodePacked("settings.node.init"))), "Node operator fee percentage cannot be set after initialisation");
         rocketStorage.setUint(keccak256(abi.encodePacked("settings.node.fee.perc")), _amount);
+    }
+
+    /// @dev The maximum node operator fee percentage, as a fraction of 1 ether
+    function setMaxFeePerc(uint256 _amount) public onlySuperUser {
+        rocketStorage.setUint(keccak256(abi.encodePacked("settings.node.max.fee.perc")), _amount);
     }
 
     /// @dev The duration of a node fee voting cycle

--- a/contracts/contract/token/RocketBETHToken.sol
+++ b/contracts/contract/token/RocketBETHToken.sol
@@ -43,10 +43,10 @@ contract RocketBETHToken is StandardToken, RocketBase {
     /*** Modifiers **************/
 
 
-    // Sender must be a super user or RocketDeposit
-    modifier onlySuperUserOrDeposit() {
+    // Sender must be RocketNodeWatchtower or RocketDeposit contract
+    modifier onlyNodeWatchtowerOrDeposit() {
         require(
-            (roleHas("owner", msg.sender) || roleHas("admin", msg.sender)) ||
+            msg.sender == rocketStorage.getAddress(keccak256(abi.encodePacked("contract.name", "rocketNodeWatchtower"))) ||
             msg.sender == rocketStorage.getAddress(keccak256(abi.encodePacked("contract.name", "rocketDeposit"))),
             "Sender is not a super user or RocketDeposit"
         );
@@ -73,7 +73,7 @@ contract RocketBETHToken is StandardToken, RocketBase {
      * @param _amount The amount of tokens to mint
      * @return A boolean that indicates if the operation was successful
      */
-    function mint(address _to, uint256 _amount) public onlySuperUserOrDeposit returns (bool) {
+    function mint(address _to, uint256 _amount) public onlyNodeWatchtowerOrDeposit returns (bool) {
         // Check burn amount
         require(_amount > 0, "Invalid token mint amount");
         // Mint tokens

--- a/contracts/interface/group/RocketGroupContractInterface.sol
+++ b/contracts/interface/group/RocketGroupContractInterface.sol
@@ -4,6 +4,7 @@ pragma solidity 0.5.0;
 // Our group contract interface
 contract RocketGroupContractInterface {
     // Getters
+    function getOwner() public view returns(address);
     function getFeePerc() public view returns(uint256);
     function getFeePercRocketPool() public view returns(uint256);
     function hasDepositor(address _depositorAddress) public view returns (bool);

--- a/contracts/interface/group/RocketGroupContractInterface.sol
+++ b/contracts/interface/group/RocketGroupContractInterface.sol
@@ -7,4 +7,5 @@ contract RocketGroupContractInterface {
     function getFeePerc() public view returns(uint256);
     function hasDepositor(address _depositorAddress) public view returns (bool);
     function hasWithdrawer(address _withdrawerAddress) public view returns (bool);
+    function setFeePercRocketPool(uint256 _stakingFeePerc) public returns(bool);
 }

--- a/contracts/interface/group/RocketGroupContractInterface.sol
+++ b/contracts/interface/group/RocketGroupContractInterface.sol
@@ -5,6 +5,7 @@ pragma solidity 0.5.0;
 contract RocketGroupContractInterface {
     // Getters
     function getFeePerc() public view returns(uint256);
+    function getFeePercRocketPool() public view returns(uint256);
     function hasDepositor(address _depositorAddress) public view returns (bool);
     function hasWithdrawer(address _withdrawerAddress) public view returns (bool);
     function setFeePercRocketPool(uint256 _stakingFeePerc) public returns(bool);

--- a/contracts/interface/group/RocketGroupContractInterface.sol
+++ b/contracts/interface/group/RocketGroupContractInterface.sol
@@ -7,6 +7,7 @@ contract RocketGroupContractInterface {
     function getOwner() public view returns(address);
     function getFeePerc() public view returns(uint256);
     function getFeePercRocketPool() public view returns(uint256);
+    function getFeeAddress() public view returns(address);
     function hasDepositor(address _depositorAddress) public view returns (bool);
     function hasWithdrawer(address _withdrawerAddress) public view returns (bool);
     function setFeePercRocketPool(uint256 _stakingFeePerc) public returns(bool);

--- a/contracts/interface/minipool/RocketMinipoolInterface.sol
+++ b/contracts/interface/minipool/RocketMinipoolInterface.sol
@@ -22,6 +22,7 @@ contract RocketMinipoolInterface {
     function getDepositInput() public view returns (bytes memory);
     function getUserDepositCapacity() public view returns(uint256);
     function getUserDepositTotal() public view returns(uint256);
+    function getStakingTokensWithdrawnTotal() public view returns(uint256);
     // Methods
     function nodeDeposit() public payable returns(bool);
     function nodeWithdraw() public returns(bool);

--- a/contracts/interface/minipool/RocketMinipoolInterface.sol
+++ b/contracts/interface/minipool/RocketMinipoolInterface.sol
@@ -11,9 +11,9 @@ contract RocketMinipoolInterface {
     function getNodeDepositExists() public view returns(bool);
     function getNodeBalance() public view returns(uint256);
     function getUserCount() public view returns(uint256);
-    function getUserExists(address _user) public view returns(bool);
-    function getUserHasDeposit(address _user) public view returns(bool);
-    function getUserDeposit(address _user) public view returns(uint256);
+    function getUserExists(address _user, address _group) public view returns(bool);
+    function getUserHasDeposit(address _user, address _group) public view returns(bool);
+    function getUserDeposit(address _user, address _group) public view returns(uint256);
     function getStatus() public view returns(uint8);
     function getStatusChangedTime() public view returns(uint256);
     function getStatusChangedBlock() public view returns(uint256);

--- a/contracts/interface/minipool/RocketMinipoolInterface.sol
+++ b/contracts/interface/minipool/RocketMinipoolInterface.sol
@@ -22,7 +22,7 @@ contract RocketMinipoolInterface {
     function getDepositInput() public view returns (bytes memory);
     function getUserDepositCapacity() public view returns(uint256);
     function getUserDepositTotal() public view returns(uint256);
-    function getStakingTokensWithdrawnTotal() public view returns(uint256);
+    function getStakingUserDepositsWithdrawn() public view returns(uint256);
     // Methods
     function nodeDeposit() public payable returns(bool);
     function nodeWithdraw() public returns(bool);
@@ -31,5 +31,6 @@ contract RocketMinipoolInterface {
     function withdrawStaking(address _user, address _groupID, uint256 _withdrawnAmount, uint256 _tokenAmount, address _withdrawnAddress) public returns(bool);
     function withdraw(address _user, address _groupID, address _withdrawalAddress) public returns(bool);
     function updateStatus() public returns(bool);
-    function setStatusTo(uint8 _status) public returns (bool);
+    function logoutMinipool() public returns (bool);
+    function withdrawMinipool(uint256 _withdrawalBalance) public returns (bool);
 }

--- a/contracts/interface/minipool/RocketMinipoolInterface.sol
+++ b/contracts/interface/minipool/RocketMinipoolInterface.sol
@@ -30,4 +30,5 @@ contract RocketMinipoolInterface {
     function withdrawStaking(address _user, address _groupID, uint256 _withdrawnAmount, uint256 _tokenAmount, address _withdrawnAddress) public returns(bool);
     function withdraw(address _user, address _groupID, address _withdrawalAddress) public returns(bool);
     function updateStatus() public returns(bool);
+    function setStatusTo(uint8 _status) public returns (bool);
 }

--- a/contracts/interface/node/RocketNodeContractInterface.sol
+++ b/contracts/interface/node/RocketNodeContractInterface.sol
@@ -3,6 +3,7 @@ pragma solidity 0.5.0;
 
 contract RocketNodeContractInterface {
     function getOwner() public view returns(address);
+    function getRewardsAddress() public view returns(address);
     function getHasDepositReservation() public view returns(bool);
     function getDepositReservedTime() public view returns(uint256);
     function getDepositReserveEtherRequired() public returns(uint256);

--- a/contracts/interface/settings/RocketGroupSettingsInterface.sol
+++ b/contracts/interface/settings/RocketGroupSettingsInterface.sol
@@ -5,6 +5,7 @@ pragma solidity 0.5.0;
 contract RocketGroupSettingsInterface {
     // Getters
     function getDefaultFee() public view returns (uint256);
+    function getMaxFee() public view returns (uint256);
     function getNewAllowed() public view returns (bool);
     function getNewFee() public view returns (uint256);
     function getNewFeeAddress() public view returns (address payable);

--- a/contracts/interface/settings/RocketMinipoolSettingsInterface.sol
+++ b/contracts/interface/settings/RocketMinipoolSettingsInterface.sol
@@ -15,7 +15,6 @@ contract RocketMinipoolSettingsInterface {
     function getMinipoolDepositGas() public view returns (uint256);
     function getMinipoolStakingDuration(string memory _durationID) public view returns (uint256);
     function getMinipoolMinimumStakingTime() public view returns (uint256);
-    function getMinipoolWithdrawalFeePerc() public view returns (uint256);
     function getMinipoolWithdrawalFeeDepositAddress() public view returns (address);
     function getMinipoolBackupCollectEnabled() public view returns (bool);
     function getMinipoolBackupCollectDuration() public view returns (uint256);

--- a/contracts/interface/settings/RocketNodeSettingsInterface.sol
+++ b/contracts/interface/settings/RocketNodeSettingsInterface.sol
@@ -13,6 +13,7 @@ contract RocketNodeSettingsInterface {
     function getInactiveDuration() public view returns (uint256);
     function getMaxInactiveNodeChecks() public view returns (uint256);
     function getFeePerc() public view returns (uint256);
+    function getMaxFeePerc() public view returns (uint256);
     function getFeeVoteCycleDuration() public view returns (uint256);
     function getFeeVoteCyclePercChange() public view returns (uint256);
     function getDepositAllowed() public view returns (bool);

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -39,6 +39,7 @@ contracts.rocketGroupAccessorFactory = artifacts.require('./group/RocketGroupAcc
 contracts.rocketNodeFactory = artifacts.require('./node/RocketNodeFactory.sol');
 contracts.rocketNodeKeys = artifacts.require('./node/RocketNodeKeys.sol');
 contracts.rocketNodeTasks = artifacts.require('./node/RocketNodeTasks.sol');
+contracts.rocketNodeWatchtower = artifacts.require('./node/RocketNodeWatchtower.sol');
 // Minipool
 contracts.rocketMinipoolDelegate = artifacts.require('./minipool/RocketMinipoolDelegate.sol');
 contracts.rocketMinipoolFactory = artifacts.require('./minipool/RocketMinipoolFactory.sol');

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -41,7 +41,9 @@ contracts.rocketNodeKeys = artifacts.require('./node/RocketNodeKeys.sol');
 contracts.rocketNodeTasks = artifacts.require('./node/RocketNodeTasks.sol');
 contracts.rocketNodeWatchtower = artifacts.require('./node/RocketNodeWatchtower.sol');
 // Minipool
-contracts.rocketMinipoolDelegate = artifacts.require('./minipool/RocketMinipoolDelegate.sol');
+contracts.rocketMinipoolDelegateNode = artifacts.require('./minipool/RocketMinipoolDelegateNode.sol');
+contracts.rocketMinipoolDelegateStatus = artifacts.require('./minipool/RocketMinipoolDelegateStatus.sol');
+contracts.rocketMinipoolDelegateUser = artifacts.require('./minipool/RocketMinipoolDelegateUser.sol');
 contracts.rocketMinipoolFactory = artifacts.require('./minipool/RocketMinipoolFactory.sol');
 contracts.rocketMinipoolSet = artifacts.require('./minipool/RocketMinipoolSet.sol');
 // Settings

--- a/package-lock.json
+++ b/package-lock.json
@@ -1501,7 +1501,7 @@
         "@chainsafesystems/ssz": "1.6.0",
         "commander": "2.19.0",
         "lowdb": "1.0.0",
-        "truffle": "5.0.4",
+        "truffle": "5.0.6",
         "web3": "1.0.0-beta.37",
         "ws": "6.1.3"
       },
@@ -1512,9 +1512,9 @@
           "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
         },
         "truffle": {
-          "version": "5.0.4",
-          "resolved": "https://registry.npmjs.org/truffle/-/truffle-5.0.4.tgz",
-          "integrity": "sha512-pZYFbU10Hb6PiTalJm+dB6s1qIZjE5qc0ux5fIgQ7Nj24zDrlYmOYruP3yhuqywwzr3PUHGPxr6hXuje0BFYoA==",
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/truffle/-/truffle-5.0.6.tgz",
+          "integrity": "sha512-SBk42qft5ElzdAoolHzy3TIzIrh/GmbEiI+kKoj2nj4GYZtHdXePWA+cp7AwzhNuXiMaR4UwYqVVhn8yxOiAXg==",
           "requires": {
             "app-module-path": "2.2.0",
             "mocha": "4.1.0",
@@ -4265,9 +4265,9 @@
       }
     },
     "ganache-cli": {
-      "version": "6.2.5",
-      "resolved": "https://registry.npmjs.org/ganache-cli/-/ganache-cli-6.2.5.tgz",
-      "integrity": "sha512-E4SP8QNeuc2N/ojFoCK+08OYHX8yrtGeFtipZmJPPTQ6U8Hmq3JcbXZDxQfChPQUY5mtbRSwptJa4EtiQyJjAQ==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/ganache-cli/-/ganache-cli-6.4.1.tgz",
+      "integrity": "sha512-MUZ1DNnmlTrXnH6EuINuew75AI9d/wbIC0WpZCJo5Endsf6ZwEvfnfxGMpEnVizRri1mon2WWxLGAmALDxVcRQ==",
       "dev": true,
       "requires": {
         "bn.js": "4.11.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1496,12 +1496,12 @@
       }
     },
     "beacon-chain-simulator": {
-      "version": "github:rocket-pool/beacon-chain-simulator#491db867365e4034d9ea6b275d594140f792e023",
+      "version": "github:rocket-pool/beacon-chain-simulator#c64eba8ef009e89947877bf1be6d4fbafc07e8dc",
       "requires": {
         "@chainsafesystems/ssz": "1.6.0",
         "commander": "2.19.0",
         "lowdb": "1.0.0",
-        "truffle": "5.0.6",
+        "truffle": "5.0.7",
         "web3": "1.0.0-beta.37",
         "ws": "6.1.3"
       },
@@ -1512,9 +1512,9 @@
           "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
         },
         "truffle": {
-          "version": "5.0.6",
-          "resolved": "https://registry.npmjs.org/truffle/-/truffle-5.0.6.tgz",
-          "integrity": "sha512-SBk42qft5ElzdAoolHzy3TIzIrh/GmbEiI+kKoj2nj4GYZtHdXePWA+cp7AwzhNuXiMaR4UwYqVVhn8yxOiAXg==",
+          "version": "5.0.7",
+          "resolved": "https://registry.npmjs.org/truffle/-/truffle-5.0.7.tgz",
+          "integrity": "sha512-RofK+kS9l4x6jdhtjLTMDIAF+P34I0/0gzCZeSjixqS5Sp+7gq2WI8ALAW0VgyahuwQl4TIyrGT0lsKjNscvFw==",
           "requires": {
             "app-module-path": "2.2.0",
             "mocha": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "babel-preset-stage-2": "^6.24.1",
     "babel-preset-stage-3": "^6.24.1",
     "babel-register": "^6.26.0",
-    "ganache-cli": "^6.1.8",
+    "ganache-cli": "^6.4.1",
     "prettier": "^1.10.2",
     "solidity-coverage": "^0.5.11",
     "truffle": "^5.0.1",

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -26,7 +26,7 @@ fi
 # Beacon chain simulator config
 beacon_port=9545
 deposit_contract_address=0xb50eA9565646e5Ed39688694b283cb185A3CC130
-withdrawal_contract_address=0xE73E4F83471fFA4e5b7A626f4cf0906Eb4cA7265
+withdrawal_contract_address=0xbFCc171226E3B5f98db59B625ED02d084D9bebF3
 withdrawal_from_address=0xe6ed92d26573c67af5eca7fb2a49a807fb8f88db
 
 ganache_running() {

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -26,7 +26,7 @@ fi
 # Beacon chain simulator config
 beacon_port=9545
 deposit_contract_address=0xb50eA9565646e5Ed39688694b283cb185A3CC130
-withdrawal_contract_address=0xF2493ACAE21783dc004b17B633331AeCe69Aa6d3
+withdrawal_contract_address=0xE73E4F83471fFA4e5b7A626f4cf0906Eb4cA7265
 withdrawal_from_address=0xe6ed92d26573c67af5eca7fb2a49a807fb8f88db
 
 ganache_running() {

--- a/test/_helpers/rocket-minipool.js
+++ b/test/_helpers/rocket-minipool.js
@@ -1,6 +1,6 @@
 // Dependencies
 import { TimeController } from '../_lib/utils/general'
-import { RocketDepositSettings, RocketMinipoolInterface, RocketMinipoolSettings } from '../_lib/artifacts';
+import { RocketAdmin, RocketDepositSettings, RocketMinipoolInterface, RocketMinipoolSettings, RocketNodeWatchtower } from '../_lib/artifacts';
 import { userDeposit } from './rocket-deposit';
 
 
@@ -62,6 +62,24 @@ export async function stakeSingleMinipool({groupAccessorContract, staker}) {
             value: selfAssignableDepositSize,
         });
     }
+
+}
+
+
+// Make minipool withdraw with balance
+export async function withdrawMinipool({minipoolAddress, balance, nodeOperator, owner}) {
+
+    // Get contracts
+    let rocketNodeWatchtower = await RocketNodeWatchtower.deployed();
+    let rocketAdmin = await RocketAdmin.deployed();
+
+    // Set node status
+    let nodeTrusted = await rocketAdmin.getNodeTrusted.call(nodeOperator);
+    if (!nodeTrusted) await rocketAdmin.setNodeTrusted(nodeOperator, true, {from: owner});
+
+    // Logout & withdraw minipool
+    await rocketNodeWatchtower.logoutMinipool(minipoolAddress, {from: nodeOperator});
+    await rocketNodeWatchtower.withdrawMinipool(minipoolAddress, balance, {from: nodeOperator});
 
 }
 

--- a/test/_lib/artifacts.js
+++ b/test/_lib/artifacts.js
@@ -18,6 +18,7 @@ export const RocketNodeAPI = artifacts.require('./contract/RocketNodeAPI');
 export const RocketNodeContract = artifacts.require('./contract/RocketNodeContract');
 export const RocketNodeSettings = artifacts.require('./contract/RocketNodeSettings');
 export const RocketNodeTasks = artifacts.require('./contract/RocketNodeTasks');
+export const RocketNodeWatchtower = artifacts.require('./contract/RocketNodeWatchtower');
 export const RocketPIP = artifacts.require('./contract/RocketPIP');
 export const RocketPool = artifacts.require('./contract/RocketPool');
 export const RocketPoolToken = artifacts.require('./contract/DummyRocketPoolToken.sol');

--- a/test/_lib/artifacts.js
+++ b/test/_lib/artifacts.js
@@ -2,6 +2,7 @@ const $Web3 = require('web3');
 const $web3 = new $Web3('http://localhost:8545');
 
 export const RocketAdmin = artifacts.require('./contract/RocketAdmin');
+export const RocketBETHToken = artifacts.require('./contract/RocketBETHToken.sol');
 export const RocketDepositAPI = artifacts.require('./contract/RocketDepositAPI');
 export const RocketDepositSettings = artifacts.require('./contract/RocketDepositSettings');
 export const RocketDepositQueue = artifacts.require('./contract/RocketDepositQueue');

--- a/test/rocket-deposit/rocket-deposit-api-refund-minipool-tests.js
+++ b/test/rocket-deposit/rocket-deposit-api-refund-minipool-tests.js
@@ -118,7 +118,7 @@ export default function() {
             // Get deposit ID
             depositID = await rocketDepositAPI.getUserQueuedDepositAt.call(groupContract.address, user2, '3m', 0);
 
-            // Attempt to Refund minipool deposit
+            // Attempt to refund minipool deposit
             await assertThrows(scenarioRefundStalledMinipoolDeposit({
                 depositorContract: groupAccessorContract,
                 depositID: '0x0000000000000000000000000000000000000000000000000000000000000000',

--- a/test/rocket-deposit/rocket-deposit-api-scenarios.js
+++ b/test/rocket-deposit/rocket-deposit-api-scenarios.js
@@ -293,6 +293,17 @@ export async function scenarioWithdrawStakingMinipoolDeposit({withdrawerContract
 }
 
 
+// Withdraw a deposit from a withdrawn minipool
+export async function scenarioWithdrawMinipoolDeposit({withdrawerContract, depositID, minipoolAddress, fromAddress, gas}) {
+    const minipool = await RocketMinipool.at(minipoolAddress);
+
+    // Withdraw
+    let result = await withdrawerContract.withdrawDepositMinipool(depositID, minipoolAddress, {from: fromAddress, gas: gas});
+    profileGasUsage('RocketGroupAccessorContract.withdrawDepositMinipool', result);
+
+}
+
+
 // Attempt a deposit via the depositor contract rocketpoolEtherDeposit method
 export async function scenarioRocketpoolEtherDeposit({depositorContract, fromAddress, value, gas}) {
     await depositorContract.rocketpoolEtherDeposit({from: fromAddress, value: value, gas: gas});

--- a/test/rocket-deposit/rocket-deposit-api-scenarios.js
+++ b/test/rocket-deposit/rocket-deposit-api-scenarios.js
@@ -2,7 +2,7 @@
 import { getTransactionContractEvents } from '../_lib/utils/general';
 import { deserialiseDepositInput, getValidatorStatus } from '../_lib/utils/beacon';
 import { profileGasUsage } from '../_lib/utils/profiling';
-import { RocketBETHToken, RocketDepositAPI, RocketDepositQueue, RocketDepositSettings, RocketGroupContract, RocketMinipool, RocketMinipoolSettings, RocketPool } from '../_lib/artifacts';
+import { RocketBETHToken, RocketDepositAPI, RocketDepositQueue, RocketDepositSettings, RocketGroupContract, RocketMinipool, RocketMinipoolSettings, RocketNodeContract, RocketPool } from '../_lib/artifacts';
 
 
 // Get all available minipools
@@ -304,18 +304,22 @@ export async function scenarioWithdrawMinipoolDeposit({withdrawerContract, depos
     let groupID = await withdrawerContract.groupID.call();
     let groupContract = await RocketGroupContract.at(groupID);
 
-    // Get RP, node and group fee/reward addresses
-    let rpFeeAccount = await rocketMinipoolSettings.getMinipoolWithdrawalFeeDepositAddress.call();
-    let nodeOwner = await minipool.getNodeOwner.call();
-    let groupOwner = await groupContract.owner.call();
+    // Get node contract
+    let nodeContractAddress = await minipool.getNodeContract.call();
+    let nodeContract = await RocketNodeContract.at(nodeContractAddress);
+
+    // Get RP, node and group fee addresses
+    let rpFeeAddress = await rocketMinipoolSettings.getMinipoolWithdrawalFeeDepositAddress.call();
+    let nodeFeeAddress = await nodeContract.getRewardsAddress.call();
+    let groupFeeAddress = await groupContract.getFeeAddress.call();
 
     // Get initial balances
     let minipoolEthBalance1 = parseInt(await web3.eth.getBalance(minipoolAddress));
     let minipoolRpbBalance1 = parseInt(await rocketBETHToken.balanceOf.call(minipoolAddress));
     let userRpbBalance1 = parseInt(await rocketBETHToken.balanceOf.call(fromAddress));
-    let rpRpbBalance1 = parseInt(await rocketBETHToken.balanceOf.call(rpFeeAccount));
-    let nodeRpbBalance1 = parseInt(await rocketBETHToken.balanceOf.call(nodeOwner));
-    let groupRpbBalance1 = parseInt(await rocketBETHToken.balanceOf.call(groupOwner));
+    let rpRpbBalance1 = parseInt(await rocketBETHToken.balanceOf.call(rpFeeAddress));
+    let nodeRpbBalance1 = parseInt(await rocketBETHToken.balanceOf.call(nodeFeeAddress));
+    let groupRpbBalance1 = parseInt(await rocketBETHToken.balanceOf.call(groupFeeAddress));
 
     // Get initial minipool user status
     let userCount1 = parseInt(await minipool.getUserCount.call());
@@ -330,9 +334,9 @@ export async function scenarioWithdrawMinipoolDeposit({withdrawerContract, depos
     let minipoolEthBalance2 = parseInt(await web3.eth.getBalance(minipoolAddress));
     let minipoolRpbBalance2 = parseInt(await rocketBETHToken.balanceOf.call(minipoolAddress));
     let userRpbBalance2 = parseInt(await rocketBETHToken.balanceOf.call(fromAddress));
-    let rpRpbBalance2 = parseInt(await rocketBETHToken.balanceOf.call(rpFeeAccount));
-    let nodeRpbBalance2 = parseInt(await rocketBETHToken.balanceOf.call(nodeOwner));
-    let groupRpbBalance2 = parseInt(await rocketBETHToken.balanceOf.call(groupOwner));
+    let rpRpbBalance2 = parseInt(await rocketBETHToken.balanceOf.call(rpFeeAddress));
+    let nodeRpbBalance2 = parseInt(await rocketBETHToken.balanceOf.call(nodeFeeAddress));
+    let groupRpbBalance2 = parseInt(await rocketBETHToken.balanceOf.call(groupFeeAddress));
 
     // Get updated minipool user status
     let userCount2 = parseInt(await minipool.getUserCount.call());

--- a/test/rocket-deposit/rocket-deposit-api-scenarios.js
+++ b/test/rocket-deposit/rocket-deposit-api-scenarios.js
@@ -283,3 +283,12 @@ export async function scenarioAPIRefundStalledMinipoolDeposit({groupID, userID, 
 
 }
 
+// Attempt to withdraw from a staking minipool via the deposit API
+export async function scenarioAPIWithdrawStakingMinipoolDeposit({groupID, userID, depositID, minipoolAddress, amount, fromAddress, gas}) {
+    const rocketDepositAPI = await RocketDepositAPI.deployed();
+
+    // Withdraw
+    await rocketDepositAPI.withdrawDepositMinipoolStaking(groupID, userID, depositID, minipoolAddress, amount, {from: fromAddress, gas: gas});
+
+}
+

--- a/test/rocket-deposit/rocket-deposit-api-scenarios.js
+++ b/test/rocket-deposit/rocket-deposit-api-scenarios.js
@@ -347,3 +347,13 @@ export async function scenarioAPIWithdrawStakingMinipoolDeposit({groupID, userID
 
 }
 
+
+// Attempt to withdraw from a withdrawn minipool via the deposit API
+export async function scenarioAPIWithdrawMinipoolDeposit({groupID, userID, depositID, minipoolAddress, fromAddress, gas}) {
+    const rocketDepositAPI = await RocketDepositAPI.deployed();
+
+    // Withdraw
+    await rocketDepositAPI.withdrawDepositMinipool(groupID, userID, depositID, minipoolAddress, {from: fromAddress, gas: gas});
+
+}
+

--- a/test/rocket-deposit/rocket-deposit-api-withdrawal-staking-tests.js
+++ b/test/rocket-deposit/rocket-deposit-api-withdrawal-staking-tests.js
@@ -249,7 +249,7 @@ export default function() {
                 gas: 5000000,
             }), 'Withdrew from a minipool with an invalid group ID');
 
-            // Valid parameters; invalid depositor
+            // Valid parameters; invalid withdrawer
             await assertThrows(scenarioAPIWithdrawStakingMinipoolDeposit({
                 groupID: groupContract.address,
                 userID: user2,

--- a/test/rocket-deposit/rocket-deposit-api-withdrawal-staking-tests.js
+++ b/test/rocket-deposit/rocket-deposit-api-withdrawal-staking-tests.js
@@ -78,7 +78,7 @@ export default function() {
 
             // Get deposit details
             depositID = await rocketDepositAPI.getUserQueuedDepositAt.call(groupContract.address, user1, '3m', 0);
-            depositAmount = await minipool.getUserDeposit.call(user1);
+            depositAmount = await minipool.getUserDeposit.call(user1, groupContract.address);
 
             // Attempt to withdraw minipool deposit
             await assertThrows(scenarioWithdrawStakingMinipoolDeposit({
@@ -115,7 +115,7 @@ export default function() {
             });
 
             // Get deposit amount
-            depositAmount = await minipool.getUserDeposit.call(user1);
+            depositAmount = await minipool.getUserDeposit.call(user1, groupContract.address);
 
             // Withdraw remaining minipool deposit
             await scenarioWithdrawStakingMinipoolDeposit({
@@ -135,7 +135,7 @@ export default function() {
 
             // Get deposit details
             depositID = await rocketDepositAPI.getUserQueuedDepositAt.call(groupContract.address, user2, '3m', 0);
-            depositAmount = await minipool.getUserDeposit.call(user2);
+            depositAmount = await minipool.getUserDeposit.call(user2, groupContract.address);
 
             // Attempt to withdraw minipool deposit
             await assertThrows(scenarioWithdrawStakingMinipoolDeposit({

--- a/test/rocket-deposit/rocket-deposit-api-withdrawal-staking-tests.js
+++ b/test/rocket-deposit/rocket-deposit-api-withdrawal-staking-tests.js
@@ -104,11 +104,12 @@ export default function() {
             assert.equal(status, 2, 'Pre-check failed: minipool is not at Staking status');
 
             // Withdraw partial minipool deposit
-            scenarioWithdrawStakingMinipoolDeposit({
+            await scenarioWithdrawStakingMinipoolDeposit({
                 withdrawerContract: groupAccessorContract,
                 depositID,
                 minipoolAddress: minipool.address,
                 amount: web3.utils.numberToHex(parseInt(depositAmount) / 2),
+                amountInt: parseInt(depositAmount) / 2,
                 fromAddress: user1,
                 gas: 5000000,
             });
@@ -117,7 +118,7 @@ export default function() {
             depositAmount = await minipool.getUserDeposit.call(user1);
 
             // Withdraw remaining minipool deposit
-            scenarioWithdrawStakingMinipoolDeposit({
+            await scenarioWithdrawStakingMinipoolDeposit({
                 withdrawerContract: groupAccessorContract,
                 depositID,
                 minipoolAddress: minipool.address,

--- a/test/rocket-deposit/rocket-deposit-api-withdrawal-tests.js
+++ b/test/rocket-deposit/rocket-deposit-api-withdrawal-tests.js
@@ -1,0 +1,144 @@
+import { printTitle, assertThrows } from '../_lib/utils/general';
+import { RocketDepositAPI, RocketDepositSettings, RocketMinipoolInterface } from '../_lib/artifacts';
+import { createGroupContract, createGroupAccessorContract, addGroupAccessor } from '../_helpers/rocket-group';
+import { createNodeContract, createNodeMinipools } from '../_helpers/rocket-node';
+import { stakeSingleMinipool, withdrawMinipool } from '../_helpers/rocket-minipool';
+import { scenarioDeposit, scenarioWithdrawMinipoolDeposit, scenarioAPIWithdrawMinipoolDeposit } from './rocket-deposit-api-scenarios';
+
+export default function() {
+
+    contract('RocketDepositAPI - Withdrawals', async (accounts) => {
+
+
+        // Accounts
+        const owner = accounts[0];
+        const groupOwner = accounts[1];
+        const nodeOperator = accounts[2];
+        const user1 = accounts[3];
+        const user2 = accounts[4];
+        const user3 = accounts[5];
+
+
+        // Setup
+        let rocketDepositAPI;
+        let rocketDepositSettings;
+        let groupContract;
+        let groupAccessorContract;
+        let nodeContract;
+        let minipoolAddresses;
+        let minipool;
+        let depositID;
+        before(async () => {
+
+            // Get contracts
+            rocketDepositAPI = await RocketDepositAPI.deployed();
+            rocketDepositSettings = await RocketDepositSettings.deployed();
+
+            // Create group contract
+            groupContract = await createGroupContract({name: 'Group 1', stakingFee: web3.utils.toWei('0.05', 'ether'), groupOwner});
+
+            // Create and add group accessor contract
+            groupAccessorContract = await createGroupAccessorContract({groupContractAddress: groupContract.address, groupOwner});
+            await addGroupAccessor({groupContract, groupAccessorContractAddress: groupAccessorContract.address, groupOwner});
+
+            // Create node contract
+            nodeContract = await createNodeContract({timezone: 'Australia/Brisbane', nodeOperator});
+
+        });
+
+
+        // Staker cannot withdraw from a minipool that hasn't withdrawn
+        it(printTitle('staker', 'cannot withdraw from a minipool that hasn\'t withdrawn'), async () => {
+
+            // Create single minipool
+            minipoolAddresses = await createNodeMinipools({nodeContract, stakingDurationID: '3m', minipoolCount: 2, nodeOperator, owner});
+            minipool = await RocketMinipoolInterface.at(minipoolAddresses[0]);
+
+            // Get deposit settings
+            let chunkSize = parseInt(await rocketDepositSettings.getDepositChunkSize.call());
+
+            // Deposit to minipool
+            await scenarioDeposit({
+                depositorContract: groupAccessorContract,
+                durationID: '3m',
+                fromAddress: user1,
+                value: chunkSize,
+            });
+            await scenarioDeposit({
+                depositorContract: groupAccessorContract,
+                durationID: '3m',
+                fromAddress: user2,
+                value: chunkSize,
+            });
+
+            // Progress minipool to staking
+            await stakeSingleMinipool({groupAccessorContract, staker: user3});
+
+            // Check minipool status
+            let status = parseInt(await minipool.getStatus.call());
+            assert.equal(status, 2, 'Pre-check failed: minipool is not at Staking status');
+
+            // Get deposit ID
+            depositID = await rocketDepositAPI.getUserQueuedDepositAt.call(groupContract.address, user1, '3m', 0);
+
+            // Attempt to withdraw minipool deposit
+            await assertThrows(scenarioWithdrawMinipoolDeposit({
+                withdrawerContract: groupAccessorContract,
+                depositID,
+                minipoolAddress: minipool.address,
+                fromAddress: user1,
+                gas: 5000000,
+            }), 'Withdrew from a minipool that has not withdrawn');
+
+        });
+
+
+        // Staker can withdraw from a withdrawn minipool
+        it(printTitle('staker', 'can withdraw from a withdrawn minipool'), async () => {
+
+            // Withdraw minipool
+            await withdrawMinipool({minipoolAddress: minipool.address, balance: web3.utils.toWei('36', 'ether'), nodeOperator, owner});
+
+            // Check minipool status
+            let status = parseInt(await minipool.getStatus.call());
+            assert.equal(status, 4, 'Pre-check failed: minipool is not at Withdrawn status');
+
+            // Withdraw minipool deposit
+            await scenarioWithdrawMinipoolDeposit({
+                withdrawerContract: groupAccessorContract,
+                depositID,
+                minipoolAddress: minipool.address,
+                fromAddress: user1,
+                gas: 5000000,
+            });
+
+        });
+
+
+        // Staker cannot withdraw a deposit with an invalid ID
+        it(printTitle('staker', 'cannot withdraw a deposit with an invalid ID'), async () => {});
+
+
+        // Staker cannot withdraw a deposit while withdrawals are disabled
+        it(printTitle('staker', 'cannot withdraw a deposit while withdrawals are disabled'), async () => {
+
+            // Disable withdrawals
+            await rocketDepositSettings.setWithdrawalAllowed(false, {from: owner, gas: 500000});
+
+            // Re-enable withdrawals
+            await rocketDepositSettings.setWithdrawalAllowed(true, {from: owner, gas: 500000});
+
+        });
+
+
+        // Staker cannot withdraw a nonexistant deposit
+        it(printTitle('staker', 'cannot withdraw a nonexistant deposit'), async () => {});
+
+
+        // Staker cannot withdraw a deposit via deposit API
+        it(printTitle('staker', 'cannot withdraw a deposit via deposit API'), async () => {});
+
+
+    });
+
+}

--- a/test/rocket-node/rocket-node-watchtower-scenarios.js
+++ b/test/rocket-node/rocket-node-watchtower-scenarios.js
@@ -1,0 +1,23 @@
+// Dependencies
+import { RocketNodeWatchtower } from '../_lib/artifacts';
+
+
+// Logout minipool
+export async function scenarioLogoutMinipool({minipoolAddress, fromAddress, gas}) {
+    const rocketNodeWatchtower = await RocketNodeWatchtower.deployed();
+
+    // Logout
+    await rocketNodeWatchtower.logoutMinipool(minipoolAddress, {from: fromAddress, gas: gas});
+
+}
+
+
+// Withdraw minipool
+export async function scenarioWithdrawMinipool({minipoolAddress, balance, fromAddress, gas}) {
+    const rocketNodeWatchtower = await RocketNodeWatchtower.deployed();
+
+    // Withdraw
+    await rocketNodeWatchtower.withdrawMinipool(minipoolAddress, balance, {from: fromAddress, gas: gas});
+
+}
+

--- a/test/rocket-node/rocket-node-watchtower-scenarios.js
+++ b/test/rocket-node/rocket-node-watchtower-scenarios.js
@@ -30,7 +30,7 @@ export async function scenarioWithdrawMinipool({minipool, balance, fromAddress, 
     // Get initial minipool status
     let status1 = parseInt(await minipool.getStatus.call());
     let rpbBalance1 = parseInt(await rocketBETHToken.balanceOf.call(minipool.address));
-    let stakingTokensWithdrawn = parseInt(await minipool.getStakingTokensWithdrawnTotal.call());
+    let stakingUserDepositsWithdrawn = parseInt(await minipool.getStakingUserDepositsWithdrawn.call());
 
     // Withdraw
     await rocketNodeWatchtower.withdrawMinipool(minipool.address, balance, {from: fromAddress, gas: gas});
@@ -40,7 +40,7 @@ export async function scenarioWithdrawMinipool({minipool, balance, fromAddress, 
     let rpbBalance2 = parseInt(await rocketBETHToken.balanceOf.call(minipool.address));
 
     // Get expected RPB increase
-    let expectedRpbIncrease = (stakingTokensWithdrawn > parseInt(balance)) ? 0 : parseInt(balance) - stakingTokensWithdrawn;
+    let expectedRpbIncrease = (stakingUserDepositsWithdrawn > parseInt(balance)) ? 0 : parseInt(balance) - stakingUserDepositsWithdrawn;
 
     // Asserts
     assert.equal(status1, 3, 'Minipool was not at LoggedOut status before withdrawal');

--- a/test/rocket-node/rocket-node-watchtower-scenarios.js
+++ b/test/rocket-node/rocket-node-watchtower-scenarios.js
@@ -1,23 +1,51 @@
 // Dependencies
-import { RocketNodeWatchtower } from '../_lib/artifacts';
+import { RocketBETHToken, RocketNodeWatchtower } from '../_lib/artifacts';
 
 
 // Logout minipool
-export async function scenarioLogoutMinipool({minipoolAddress, fromAddress, gas}) {
+export async function scenarioLogoutMinipool({minipool, fromAddress, gas}) {
     const rocketNodeWatchtower = await RocketNodeWatchtower.deployed();
 
+    // Get initial minipool status
+    let status1 = parseInt(await minipool.getStatus.call());
+
     // Logout
-    await rocketNodeWatchtower.logoutMinipool(minipoolAddress, {from: fromAddress, gas: gas});
+    await rocketNodeWatchtower.logoutMinipool(minipool.address, {from: fromAddress, gas: gas});
+
+    // Get updated minipool status
+    let status2 = parseInt(await minipool.getStatus.call());
+
+    // Asserts
+    assert.equal(status1, 2, 'Minipool was not at Staking status before logout');
+    assert.equal(status2, 3, 'Minipool was not set to LoggedOut status successfully');
 
 }
 
 
 // Withdraw minipool
-export async function scenarioWithdrawMinipool({minipoolAddress, balance, fromAddress, gas}) {
+export async function scenarioWithdrawMinipool({minipool, balance, fromAddress, gas}) {
     const rocketNodeWatchtower = await RocketNodeWatchtower.deployed();
+    const rocketBETHToken = await RocketBETHToken.deployed();
+
+    // Get initial minipool status
+    let status1 = parseInt(await minipool.getStatus.call());
+    let rpbBalance1 = parseInt(await rocketBETHToken.balanceOf.call(minipool.address));
+    let stakingTokensWithdrawn = parseInt(await minipool.getStakingTokensWithdrawnTotal.call());
 
     // Withdraw
-    await rocketNodeWatchtower.withdrawMinipool(minipoolAddress, balance, {from: fromAddress, gas: gas});
+    await rocketNodeWatchtower.withdrawMinipool(minipool.address, balance, {from: fromAddress, gas: gas});
+
+    // Get updated minipool status
+    let status2 = parseInt(await minipool.getStatus.call());
+    let rpbBalance2 = parseInt(await rocketBETHToken.balanceOf.call(minipool.address));
+
+    // Get expected RPB increase
+    let expectedRpbIncrease = (stakingTokensWithdrawn > parseInt(balance)) ? 0 : parseInt(balance) - stakingTokensWithdrawn;
+
+    // Asserts
+    assert.equal(status1, 3, 'Minipool was not at LoggedOut status before withdrawal');
+    assert.equal(status2, 4, 'Minipool was not set to Withdrawn status successfully');
+    assert.equal(rpbBalance2, rpbBalance1 + expectedRpbIncrease, 'Minipool RPB balance was not increased correctly');
 
 }
 

--- a/test/rocket-node/rocket-node-watchtower-tests.js
+++ b/test/rocket-node/rocket-node-watchtower-tests.js
@@ -1,0 +1,160 @@
+import { printTitle, assertThrows } from '../_lib/utils/general';
+import { RocketAdmin, RocketMinipoolInterface } from '../_lib/artifacts';
+import { createGroupContract, createGroupAccessorContract, addGroupAccessor } from '../_helpers/rocket-group';
+import { createNodeContract, createNodeMinipools } from '../_helpers/rocket-node';
+import { stakeSingleMinipool } from '../_helpers/rocket-minipool';
+import { scenarioLogoutMinipool, scenarioWithdrawMinipool } from './rocket-node-watchtower-scenarios';
+
+export default function() {
+
+    contract('RocketNodeWatchtower', async (accounts) => {
+
+
+        // Accounts
+        const owner = accounts[0];
+        const groupOwner = accounts[1];
+        const untrustedNodeOperator = accounts[2];
+        const trustedNodeOperator = accounts[3];
+        const staker = accounts[4];
+
+
+        // Setup
+        let untrustedNodeContract;
+        let trustedNodeContract;
+        let minipool;
+        let groupAccessorContract;
+        before(async () => {
+
+            // Create node contracts
+            untrustedNodeContract = await createNodeContract({timezone: 'Australia/Brisbane', nodeOperator: untrustedNodeOperator});
+            trustedNodeContract = await createNodeContract({timezone: 'Australia/Brisbane', nodeOperator: trustedNodeOperator});
+
+            // Set node contract status
+            let rocketAdmin = await RocketAdmin.deployed();
+            await rocketAdmin.setNodeTrusted(trustedNodeOperator, true, {from: owner, gas: 500000});
+
+            // Create minipool
+            let minipoolAddresses = await createNodeMinipools({nodeContract: untrustedNodeContract, stakingDurationID: '3m', minipoolCount: 1, nodeOperator: untrustedNodeOperator, owner});
+            minipool = await RocketMinipoolInterface.at(minipoolAddresses[0]);
+
+            // Create group contract
+            let groupContract = await createGroupContract({name: 'Group 1', stakingFee: web3.utils.toWei('0.05', 'ether'), groupOwner});
+
+            // Create and add group accessor contract
+            groupAccessorContract = await createGroupAccessorContract({groupContractAddress: groupContract.address, groupOwner});
+            await addGroupAccessor({groupContract, groupAccessorContractAddress: groupAccessorContract.address, groupOwner});
+
+        });
+
+
+        // Trusted node cannot logout a minipool that is not staking
+        it(printTitle('trusted node', 'cannot logout a minipool that is not staking'), async () => {
+
+            // Check minipool status
+            let status = parseInt(await minipool.getStatus.call());
+            assert.notEqual(status, 2, 'Pre-check failed: minipool is at Staking status');
+
+            // Attempt logout
+            await assertThrows(scenarioLogoutMinipool({
+                minipoolAddress: minipool.address,
+                fromAddress: trustedNodeOperator,
+                gas: 500000,
+            }), 'Logged out a minipool that was not staking');
+
+        });
+
+
+        // Trusted node cannot withdraw a minipool that is not logged out
+        it(printTitle('trusted node', 'cannot withdraw a minipool that is not logged out'), async () => {
+
+            // Check minipool status
+            let status = parseInt(await minipool.getStatus.call());
+            assert.notEqual(status, 3, 'Pre-check failed: minipool is at LoggedOut status');
+
+            // Attempt withdrawal
+            await assertThrows(scenarioWithdrawMinipool({
+                minipoolAddress: minipool.address,
+                balance: web3.utils.toWei('32', 'ether'),
+                fromAddress: trustedNodeOperator,
+                gas: 500000,
+            }), 'Withdrew a minipool that was not logged out');
+
+        });
+
+
+        // Untrusted node cannot logout a staking minipool
+        it(printTitle('untrusted node', 'cannot logout a staking minipool'), async () => {
+
+            // Progress minipool to staking
+            await stakeSingleMinipool({groupAccessorContract, staker});
+
+            // Check minipool status
+            let status = parseInt(await minipool.getStatus.call());
+            assert.equal(status, 2, 'Pre-check failed: minipool is not at Staking status');
+
+            // Attempt logout
+            await assertThrows(scenarioLogoutMinipool({
+                minipoolAddress: minipool.address,
+                fromAddress: untrustedNodeOperator,
+                gas: 500000,
+            }), 'Untrusted node logged out a staking minipool');
+
+        });
+
+
+        // Trusted node can logout a staking minipool
+        it(printTitle('trusted node', 'can logout a staking minipool'), async () => {
+
+            // Check minipool status
+            let status = parseInt(await minipool.getStatus.call());
+            assert.equal(status, 2, 'Pre-check failed: minipool is not at Staking status');
+
+            // Logout
+            await scenarioLogoutMinipool({
+                minipoolAddress: minipool.address,
+                fromAddress: trustedNodeOperator,
+                gas: 500000,
+            });
+
+        });
+
+
+        // Untrusted node cannot withdraw a logged out minipool
+        it(printTitle('untrusted node', 'cannot withdraw a logged out minipool'), async () => {
+
+            // Check minipool status
+            let status = parseInt(await minipool.getStatus.call());
+            assert.equal(status, 3, 'Pre-check failed: minipool is not at LoggedOut status');
+
+            // Attempt withdrawal
+            await assertThrows(scenarioWithdrawMinipool({
+                minipoolAddress: minipool.address,
+                balance: web3.utils.toWei('32', 'ether'),
+                fromAddress: untrustedNodeOperator,
+                gas: 500000,
+            }), 'Untrusted node withdrew a logged out minipool');
+
+        });
+
+
+        // Trusted node can withdraw a logged out minipool
+        it(printTitle('trusted node', 'can withdraw a logged out minipool'), async () => {
+
+            // Check minipool status
+            let status = parseInt(await minipool.getStatus.call());
+            assert.equal(status, 3, 'Pre-check failed: minipool is not at LoggedOut status');
+
+            // Withdraw
+            await scenarioWithdrawMinipool({
+                minipoolAddress: minipool.address,
+                balance: web3.utils.toWei('32', 'ether'),
+                fromAddress: trustedNodeOperator,
+                gas: 500000,
+            });
+
+        });
+
+
+    });
+
+}

--- a/test/rocket-node/rocket-node-watchtower-tests.js
+++ b/test/rocket-node/rocket-node-watchtower-tests.js
@@ -56,7 +56,7 @@ export default function() {
 
             // Attempt logout
             await assertThrows(scenarioLogoutMinipool({
-                minipoolAddress: minipool.address,
+                minipool,
                 fromAddress: trustedNodeOperator,
                 gas: 500000,
             }), 'Logged out a minipool that was not staking');
@@ -73,7 +73,7 @@ export default function() {
 
             // Attempt withdrawal
             await assertThrows(scenarioWithdrawMinipool({
-                minipoolAddress: minipool.address,
+                minipool,
                 balance: web3.utils.toWei('32', 'ether'),
                 fromAddress: trustedNodeOperator,
                 gas: 500000,
@@ -94,7 +94,7 @@ export default function() {
 
             // Attempt logout
             await assertThrows(scenarioLogoutMinipool({
-                minipoolAddress: minipool.address,
+                minipool,
                 fromAddress: untrustedNodeOperator,
                 gas: 500000,
             }), 'Untrusted node logged out a staking minipool');
@@ -111,7 +111,7 @@ export default function() {
 
             // Logout
             await scenarioLogoutMinipool({
-                minipoolAddress: minipool.address,
+                minipool,
                 fromAddress: trustedNodeOperator,
                 gas: 500000,
             });
@@ -128,7 +128,7 @@ export default function() {
 
             // Attempt withdrawal
             await assertThrows(scenarioWithdrawMinipool({
-                minipoolAddress: minipool.address,
+                minipool,
                 balance: web3.utils.toWei('32', 'ether'),
                 fromAddress: untrustedNodeOperator,
                 gas: 500000,
@@ -146,7 +146,7 @@ export default function() {
 
             // Withdraw
             await scenarioWithdrawMinipool({
-                minipoolAddress: minipool.address,
+                minipool,
                 balance: web3.utils.toWei('32', 'ether'),
                 fromAddress: trustedNodeOperator,
                 gas: 500000,

--- a/test/rocketPool-tests.js
+++ b/test/rocketPool-tests.js
@@ -20,6 +20,7 @@ import rocketDepositAPIDepositTests from './rocket-deposit/rocket-deposit-api-de
 import rocketDepositAPIRefundQueueTests from './rocket-deposit/rocket-deposit-api-refund-queue-tests';
 import rocketDepositAPIRefundMinipoolTests from './rocket-deposit/rocket-deposit-api-refund-minipool-tests';
 import rocketDepositAPIWithdrawalStakingTests from './rocket-deposit/rocket-deposit-api-withdrawal-staking-tests';
+import rocketDepositAPIWithdrawalTests from './rocket-deposit/rocket-deposit-api-withdrawal-tests';
 import rocketRPIPTests from './rocket-rpip/rocket-rpip-tests';
 import rocketUpgradeTests from './rocket-upgrade/rocket-upgrade-tests';
 
@@ -55,6 +56,7 @@ rocketDepositAPIDepositTests();
 rocketDepositAPIRefundQueueTests();
 rocketDepositAPIRefundMinipoolTests();
 rocketDepositAPIWithdrawalStakingTests();
+rocketDepositAPIWithdrawalTests();
 rocketRPIPTests();
 rocketUpgradeTests();
 

--- a/test/rocketPool-tests.js
+++ b/test/rocketPool-tests.js
@@ -15,6 +15,7 @@ import rocketNodeContractWithdrawalTests from './rocket-node/rocket-node-contrac
 import rocketNodeTaskAdminTests from './rocket-node/rocket-node-task-admin-tests';
 import rocketNodeTaskNodeTests from './rocket-node/rocket-node-task-node-tests';
 import rocketNodeTaskCalculateNodeFeeTests from './rocket-node/rocket-node-task-calculate-node-fee-tests';
+import rocketNodeWatchtowerTests from './rocket-node/rocket-node-watchtower-tests';
 import rocketDepositAPIDepositTests from './rocket-deposit/rocket-deposit-api-deposit-tests';
 import rocketDepositAPIRefundQueueTests from './rocket-deposit/rocket-deposit-api-refund-queue-tests';
 import rocketDepositAPIRefundMinipoolTests from './rocket-deposit/rocket-deposit-api-refund-minipool-tests';
@@ -49,6 +50,7 @@ rocketNodeContractWithdrawalTests();
 rocketNodeTaskAdminTests();
 rocketNodeTaskNodeTests();
 rocketNodeTaskCalculateNodeFeeTests();
+rocketNodeWatchtowerTests();
 rocketDepositAPIDepositTests();
 rocketDepositAPIRefundQueueTests();
 rocketDepositAPIRefundMinipoolTests();


### PR DESCRIPTION
- Implemented fee payment and reward transfer on minipool user withdrawal, node withdrawal and minipool closure
- Implemented minipool withdrawal unit tests

- Refactored minipool delegate contract into separate contracts for user, node, and status functionality
- Fixed minipool user map to be keyed by user and group address

- Removed deprecated minipool fee settings
- Updated node and group fee settings, including maximum fee % (50%)
- Made Rocket Pool fee configurable per group via RocketGroupAPI
