### PR TITLE
Subsidise penalties

### DIFF
--- a/contracts/contract/minipool/RocketMinipoolDelegateDeposit.sol
+++ b/contracts/contract/minipool/RocketMinipoolDelegateDeposit.sol
@@ -171,8 +171,15 @@ contract RocketMinipoolDelegateDeposit is RocketMinipoolBase {
         require(deposits[_depositID].balance > 0, "Deposit does not have remaining balance in minipool.");
         // Get contracts
         publisher = PublisherInterface(getContractAddress("utilPublisher"));
+        // Calculate final balance including penalty incurred by node for losses
+        uint256 balanceEnd = staking.balanceEnd;
+        if (staking.balanceStart > staking.balanceEnd) {
+            uint256 nodePenalty = staking.balanceStart.sub(staking.balanceEnd);
+            if (nodePenalty > node.depositEther) { nodePenalty = node.depositEther; }
+            balanceEnd = balanceEnd.add(nodePenalty);
+        }
         // Calculate rewards earned by deposit
-        int256 rewardsEarned = int256(deposits[_depositID].balance.mul(staking.balanceEnd).div(staking.balanceStart)) - int256(deposits[_depositID].balance);
+        int256 rewardsEarned = int256(deposits[_depositID].balance.mul(balanceEnd).div(staking.balanceStart)) - int256(deposits[_depositID].balance);
         // Withdrawal amount
         uint256 amount = uint256(int256(deposits[_depositID].balance) + rewardsEarned);
         // Pay fees if rewards were earned

--- a/contracts/contract/minipool/RocketMinipoolDelegateDeposit.sol
+++ b/contracts/contract/minipool/RocketMinipoolDelegateDeposit.sol
@@ -171,15 +171,15 @@ contract RocketMinipoolDelegateDeposit is RocketMinipoolBase {
         require(deposits[_depositID].balance > 0, "Deposit does not have remaining balance in minipool.");
         // Get contracts
         publisher = PublisherInterface(getContractAddress("utilPublisher"));
-        // Calculate final balance including penalty incurred by node for losses
-        uint256 balanceEnd = staking.balanceEnd;
+        // Calculate starting balance excluding penalty incurred by node for losses
+        uint256 balanceStart = staking.balanceStart;
         if (staking.balanceStart > staking.balanceEnd) {
             uint256 nodePenalty = staking.balanceStart.sub(staking.balanceEnd);
             if (nodePenalty > node.depositEther) { nodePenalty = node.depositEther; }
-            balanceEnd = balanceEnd.add(nodePenalty);
+            balanceStart = balanceStart.sub(nodePenalty);
         }
         // Calculate rewards earned by deposit
-        int256 rewardsEarned = int256(deposits[_depositID].balance.mul(balanceEnd).div(staking.balanceStart)) - int256(deposits[_depositID].balance);
+        int256 rewardsEarned = int256(deposits[_depositID].balance.mul(staking.balanceEnd).div(balanceStart)) - int256(deposits[_depositID].balance);
         // Withdrawal amount
         uint256 amount = uint256(int256(deposits[_depositID].balance) + rewardsEarned);
         // Pay fees if rewards were earned

--- a/contracts/contract/minipool/RocketMinipoolDelegateNode.sol
+++ b/contracts/contract/minipool/RocketMinipoolDelegateNode.sol
@@ -89,7 +89,15 @@ contract RocketMinipoolDelegateNode is RocketMinipoolBase {
         }
         // Transferring RPB to node contract if withdrawn
         else if (staking.balanceStart > 0 && staking.balanceEnd > 0) {
-            rpbAmount = nodeBalance.mul(staking.balanceEnd).div(staking.balanceStart);
+            // Calculate transfer amount including penalty incurred by node for losses
+            if (staking.balanceStart > staking.balanceEnd) {
+                uint256 nodePenalty = staking.balanceStart.sub(staking.balanceEnd);
+                if (nodeBalance > nodePenalty) { rpbAmount = nodeBalance.sub(nodePenalty); }
+            }
+            else {
+                rpbAmount = nodeBalance.mul(staking.balanceEnd).div(staking.balanceStart);
+            }
+            // Transfer
             if (rpbAmount > 0) { require(rpbContract.transfer(rocketNodeContract.getRewardsAddress(), rpbAmount), "RPB balance transfer error."); }
         }
         // Fire withdrawal event

--- a/test/rocket-deposit/rocket-deposit-api-scenarios.js
+++ b/test/rocket-deposit/rocket-deposit-api-scenarios.js
@@ -415,6 +415,10 @@ export async function scenarioWithdrawMinipoolDeposit({withdrawerContract, depos
     let nodeRpbBalance1 = parseInt(await rocketBETHToken.balanceOf.call(nodeFeeAddress));
     let groupRpbBalance1 = parseInt(await rocketBETHToken.balanceOf.call(groupFeeAddress));
 
+    // Get minipool staking balances
+    let stakingBalanceStart = parseInt(await minipool.getStakingBalanceStart.call());
+    let stakingBalanceEnd = parseInt(await minipool.getStakingBalanceEnd.call());
+
     // Get initial minipool deposit status
     let depositCount1 = parseInt(await minipool.getDepositCount.call());
     let depositExists1 = await minipool.getDepositExists.call(depositID);
@@ -468,9 +472,15 @@ export async function scenarioWithdrawMinipoolDeposit({withdrawerContract, depos
     assert.equal(depositExists2, false, 'Minipool deposit was not removed correctly');
     assert.equal(depositBalance2, 0, 'Minipool deposit balance was not updated correctly');
     assert.isTrue(userRpbBalance2 > userRpbBalance1, 'User RPB balance was not updated correctly');
-    assert.isTrue(rpRpbBalance2 > rpRpbBalance1, 'RP RPB balance was not updated correctly');
-    assert.isTrue(nodeRpbBalance2 > nodeRpbBalance1, 'Node RPB balance was not updated correctly');
-    assert.isTrue(groupRpbBalance2 > groupRpbBalance1, 'Group RPB balance was not updated correctly');
+    if (stakingBalanceEnd > stakingBalanceStart) {
+        assert.isTrue(rpRpbBalance2 > rpRpbBalance1, 'RP RPB balance was not updated correctly');
+        assert.isTrue(nodeRpbBalance2 > nodeRpbBalance1, 'Node RPB balance was not updated correctly');
+        assert.isTrue(groupRpbBalance2 > groupRpbBalance1, 'Group RPB balance was not updated correctly');
+    } else {
+        assert.equal(rpRpbBalance2, rpRpbBalance1, 'RP RPB balance changed and should not have');
+        assert.equal(nodeRpbBalance2, nodeRpbBalance1, 'Node RPB balance changed and should not have');
+        assert.equal(groupRpbBalance2, groupRpbBalance1, 'Group RPB balance changed and should not have');
+    }
     assert.equal(minipoolRpbBalance2, minipoolRpbBalance1 - totalRpbSent, 'Minipool RPB balance was not updated correctly');
     assert.equal(minipoolEthBalance2, minipoolEthBalance1, 'Minipool ether balance changed and should not have');
 

--- a/test/rocket-deposit/rocket-deposit-api-withdrawal-tests.js
+++ b/test/rocket-deposit/rocket-deposit-api-withdrawal-tests.js
@@ -189,7 +189,7 @@ export default function() {
 
             // Withdraw minipool
             await logoutMinipool({minipoolAddress: minipool.address, nodeOperator, owner});
-            await withdrawMinipool({minipoolAddress: minipool.address, balance: web3.utils.toWei('36', 'ether'), nodeOperator, owner});
+            await withdrawMinipool({minipoolAddress: minipool.address, balance: web3.utils.toWei('14', 'ether'), nodeOperator, owner});
 
             // Check minipool status
             let status = parseInt(await minipool.getStatus.call());

--- a/test/rocket-node/rocket-node-contract-withdrawal-tests.js
+++ b/test/rocket-node/rocket-node-contract-withdrawal-tests.js
@@ -301,7 +301,7 @@ export default function() {
 
             // Withdraw minipools
             await withdrawMinipool({minipoolAddress: minipool.address, balance: web3.utils.toWei('36', 'ether'), nodeOperator: operator2, owner});
-            await withdrawMinipool({minipoolAddress: minipool2.address, balance: web3.utils.toWei('36', 'ether'), nodeOperator: operator2, owner});
+            await withdrawMinipool({minipoolAddress: minipool2.address, balance: web3.utils.toWei('14', 'ether'), nodeOperator: operator2, owner});
 
             // Check minipool statuses
             let status = parseInt(await minipool.getStatus.call());


### PR DESCRIPTION
- Penalising nodes for losses incurred during staking
- Paying users proportional shares of node penalties to preserve their original deposit
- Untrusted nodes penalised by `(starting_balance - final_balance)` up to a maximum of their original deposit size
- Added minipool withdrawal unit tests for penalised nodes