### PR TITLE
update active minipools to ensure correct status before chunk assignment

### DIFF
--- a/contracts/contract/deposit/RocketDepositQueue.sol
+++ b/contracts/contract/deposit/RocketDepositQueue.sol
@@ -171,6 +171,7 @@ contract RocketDepositQueue is RocketBase {
     function assignChunks(string memory _durationID) public onlyValidDuration(_durationID) {
 
         // Get contracts
+        rocketMinipoolSet = RocketMinipoolSetInterface(getContractAddress("rocketMinipoolSet"));
         rocketNode = RocketNodeInterface(getContractAddress("rocketNode"));
         rocketDepositSettings = RocketDepositSettingsInterface(getContractAddress("rocketDepositSettings"));
 
@@ -180,6 +181,9 @@ contract RocketDepositQueue is RocketBase {
         // Deposit settings
         uint256 chunkSize = rocketDepositSettings.getDepositChunkSize();
         uint256 maxChunkAssignments = rocketDepositSettings.getChunkAssignMax();
+
+        // Update active minipools
+        rocketMinipoolSet.updateActiveMinipools(_durationID);
 
         // Assign chunks while able
         uint256 chunkAssignments = 0;

--- a/contracts/contract/minipool/RocketMinipoolSet.sol
+++ b/contracts/contract/minipool/RocketMinipoolSet.sol
@@ -4,6 +4,7 @@ pragma solidity 0.5.8;
 import "../../RocketBase.sol";
 import "../../interface/RocketNodeInterface.sol";
 import "../../interface/RocketPoolInterface.sol";
+import "../../interface/minipool/RocketMinipoolInterface.sol";
 import "../../interface/settings/RocketMinipoolSettingsInterface.sol";
 import "../../interface/utils/lists/AddressSetStorageInterface.sol";
 
@@ -19,6 +20,7 @@ contract RocketMinipoolSet is RocketBase {
 
     RocketNodeInterface rocketNode = RocketNodeInterface(0);
     RocketPoolInterface rocketPool = RocketPoolInterface(0);
+    RocketMinipoolInterface minipool = RocketMinipoolInterface(0);
     RocketMinipoolSettingsInterface rocketMinipoolSettings = RocketMinipoolSettingsInterface(0);
     AddressSetStorageInterface addressSetStorage = AddressSetStorageInterface(0);
 
@@ -65,6 +67,23 @@ contract RocketMinipoolSet is RocketBase {
 
         // Return active minipool
         return addressSetStorage.getItem(keccak256(abi.encodePacked("minipools.active", _durationID)), offset);
+
+    }
+
+
+    // Update all active minipools to ensure correct status
+    function updateActiveMinipools(string memory _durationID) public onlyLatestContract("rocketDepositQueue", msg.sender) {
+
+        // Get contracts
+        addressSetStorage = AddressSetStorageInterface(getContractAddress("utilAddressSetStorage"));
+
+        // Update active minipools
+        uint256 activeMinipoolCount = addressSetStorage.getCount(keccak256(abi.encodePacked("minipools.active", _durationID)));
+        for (uint256 mi = 0; mi < activeMinipoolCount; ++mi) {
+            address minipoolAddress = addressSetStorage.getItem(keccak256(abi.encodePacked("minipools.active", _durationID)), mi);
+            minipool = RocketMinipoolInterface(minipoolAddress);
+            minipool.updateStatus();
+        }
 
     }
 

--- a/contracts/interface/minipool/RocketMinipoolSetInterface.sol
+++ b/contracts/interface/minipool/RocketMinipoolSetInterface.sol
@@ -2,4 +2,5 @@ pragma solidity 0.5.8;
 
 contract RocketMinipoolSetInterface {
     function getNextActiveMinipool(string memory _durationID, uint256 _seed) public returns (address);
+    function updateActiveMinipools(string memory _durationID) public;
 }


### PR DESCRIPTION
Fixed deposit queue / active minipool set logic to ensure that all active minipools are updated (and stalled if applicable) before chunk assignments to prevent attempted assignments to stalled minipools (and subsequent reverts)