### PR TITLE
Change .gitattribute to .gitattributes

### DIFF
--- a/.gitattribute
+++ b/.gitattribute
@@ -1,1 +1,0 @@
-*.sol linguist-language=Solidity

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sol linguist-language=Solidity

--- a/contracts/.gitattribute
+++ b/contracts/.gitattribute
@@ -1,1 +1,0 @@
-*.sol linguist-language=Solidity

--- a/contracts/.gitattributes
+++ b/contracts/.gitattributes
@@ -1,0 +1,1 @@
+*.sol linguist-language=Solidity


### PR DESCRIPTION
Looks like you named your `.gitattributes` file incorrectly. This causes some of the .sol files to not have proper syntax highlighting in github, which is rough on the eyes. I went ahead and changed that for y'all.