### PR TITLE
Unprocessed minipool index

### DIFF
--- a/contracts/contract/network/RocketNetworkWithdrawal.sol
+++ b/contracts/contract/network/RocketNetworkWithdrawal.sol
@@ -87,7 +87,7 @@ contract RocketNetworkWithdrawal is RocketBase, RocketNetworkWithdrawalInterface
         // Check balance
         require(getBalance() >= totalAmount, "Insufficient withdrawal pool balance");
         // Set withdrawal processed status
-        rocketMinipoolManager.setMinipoolWithdrawalProcessed(minipool, true);
+        rocketMinipoolManager.setMinipoolWithdrawalProcessed(minipool);
         // Withdraw ETH from vault
         if (totalAmount > 0) {
             // Withdraw

--- a/contracts/interface/minipool/RocketMinipoolManagerInterface.sol
+++ b/contracts/interface/minipool/RocketMinipoolManagerInterface.sol
@@ -7,6 +7,8 @@ import "../../types/MinipoolDeposit.sol";
 interface RocketMinipoolManagerInterface {
     function getMinipoolCount() external view returns (uint256);
     function getMinipoolAt(uint256 _index) external view returns (address);
+    function getUnprocessedMinipoolCount() external view returns (uint256);
+    function getUnprocessedMinipoolAt(uint256 _index) external view returns (address);
     function getNodeMinipoolCount(address _nodeAddress) external view returns (uint256);
     function getNodeMinipoolAt(address _nodeAddress, uint256 _index) external view returns (address);
     function getNodeValidatingMinipoolCount(address _nodeAddress) external view returns (uint256);
@@ -22,5 +24,5 @@ interface RocketMinipoolManagerInterface {
     function destroyMinipool() external;
     function setMinipoolPubkey(bytes calldata _pubkey) external;
     function setMinipoolWithdrawalBalances(address _minipoolAddress, uint256 _total, uint256 _node) external;
-    function setMinipoolWithdrawalProcessed(address _minipoolAddress, bool _processed) external;
+    function setMinipoolWithdrawalProcessed(address _minipoolAddress) external;
 }

--- a/test/network/scenario-process-withdrawal.js
+++ b/test/network/scenario-process-withdrawal.js
@@ -59,18 +59,20 @@ export async function processWithdrawal(validatorPubkey, txOptions) {
     }
 
     // Get initial balances & withdrawal processed status
-    let [balances1, withdrawalProcessed1] = await Promise.all([
+    let [balances1, withdrawalProcessed1, unprocessedMinipoolCount1] = await Promise.all([
         getBalances(),
         rocketMinipoolManager.getMinipoolWithdrawalProcessed.call(minipoolAddress),
+        rocketMinipoolManager.getUnprocessedMinipoolCount.call(),
     ]);
 
     // Process withdrawal
     await rocketNetworkWithdrawal.processWithdrawal(validatorPubkey, txOptions);
 
     // Get updated balances & withdrawal processed status
-    let [balances2, withdrawalProcessed2] = await Promise.all([
+    let [balances2, withdrawalProcessed2, unprocessedMinipoolCount2] = await Promise.all([
         getBalances(),
         rocketMinipoolManager.getMinipoolWithdrawalProcessed.call(minipoolAddress),
+        rocketMinipoolManager.getUnprocessedMinipoolCount.call(),
     ]);
 
     // Get expected user amount destination
@@ -92,6 +94,9 @@ export async function processWithdrawal(validatorPubkey, txOptions) {
         assert(balances2.rethContractEth.eq(balances1.rethContractEth), 'Incorrect updated rETH contract balance');
         assert(balances2.depositPoolEth.eq(balances1.depositPoolEth.add(withdrawalUserAmount)), 'Incorrect updated deposit pool balance');
     }
+
+    // Check unprocessed minipool index
+    assert(unprocessedMinipoolCount2.eq(unprocessedMinipoolCount1.sub(web3.utils.toBN(1))), 'Incorrect updated unprocessed minipool count');
 
 }
 


### PR DESCRIPTION
Added an index for "unprocessed" minipools to `RocketMinipoolManager`. An unprocessed minipool is one which may have been withdrawn from and destroyed, but has not yet had its withdrawal processed by the network.

This index is required for watchtower nodes to correctly report network balances (https://github.com/rocket-pool/rocketpool/issues/189).