### PR TITLE
Update RocketDAOProtocolSettingsInflation.sol for 12 second block/slot time.

### DIFF
--- a/contracts/contract/dao/protocol/settings/RocketDAOProtocolSettingsInflation.sol
+++ b/contracts/contract/dao/protocol/settings/RocketDAOProtocolSettingsInflation.sol
@@ -19,7 +19,7 @@ contract RocketDAOProtocolSettingsInflation is RocketDAOProtocolSettings, Rocket
             // RPL Inflation settings
             setSettingUint("rpl.inflation.interval.rate", 1000133680617113440);                                 // 5% annual calculated on a daily interval of blocks (7200 = 1 day approx in 12sec blocks) - Calculate in js example: let dailyInflation = web3.utils.toBN((1 + 0.05) ** (1 / (365)) * 1e18);
             setSettingUint("rpl.inflation.interval.blocks", 7200);                                              // How often the inflation is calculated, if this is changed significantly, then the above 'rpl.inflation.interval.rate' will need to be adjusted. If inflation is no longer required, set 'rpl.inflation.interval.rate' to 0, not this parameter                
-            setSettingUint("rpl.inflation.interval.start", block.number+(getInflationIntervalBlocks()*14));     // Set the default start date for inflation to begin as 2 weeks from contract deployment (this can be changed after deployment)
+            setSettingUint("rpl.inflation.interval.start", block.number+(getInflationIntervalBlocks()*28));     // Set the default start date for inflation to begin as 4 weeks from contract deployment (this can be changed after deployment)
             // Deployment check
             setBool(keccak256(abi.encodePacked(settingNameSpace, "deployed")), true);                           // Flag that this contract has been deployed, so default settings don't get reapplied on a contract upgrade
         }
@@ -58,7 +58,7 @@ contract RocketDAOProtocolSettingsInflation is RocketDAOProtocolSettings, Rocket
         return getSettingUint("rpl.inflation.interval.rate");
     }
     
-    // Inflation block interval (default is 6170 = 1 day approx in 14sec blocks) 
+    // Inflation block interval (default is 7200 = 1 day approx in 12sec blocks) 
     function getInflationIntervalBlocks() override public view returns (uint256) {
         return getSettingUint("rpl.inflation.interval.blocks"); 
     }

--- a/contracts/contract/dao/protocol/settings/RocketDAOProtocolSettingsInflation.sol
+++ b/contracts/contract/dao/protocol/settings/RocketDAOProtocolSettingsInflation.sol
@@ -17,8 +17,8 @@ contract RocketDAOProtocolSettingsInflation is RocketDAOProtocolSettings, Rocket
          // Set some initial settings on first deployment
         if(!getBool(keccak256(abi.encodePacked(settingNameSpace, "deployed")))) {
             // RPL Inflation settings
-            setSettingUint("rpl.inflation.interval.rate", 1000133680617113500);                                 // 5% annual calculated on a daily interval of blocks (6170 = 1 day approx in 14sec blocks) - Calculate in js example: let dailyInflation = web3.utils.toBN((1 + 0.05) ** (1 / (365)) * 1e18);
-            setSettingUint("rpl.inflation.interval.blocks", 6170);                                              // How often the inflation is calculated, if this is changed significantly, then the above 'rpl.inflation.interval.rate' will need to be adjusted. If inflation is no longer required, set 'rpl.inflation.interval.rate' to 0, not this parameter                
+            setSettingUint("rpl.inflation.interval.rate", 1000133680617113440);                                 // 5% annual calculated on a daily interval of blocks (7200 = 1 day approx in 12sec blocks) - Calculate in js example: let dailyInflation = web3.utils.toBN((1 + 0.05) ** (1 / (365)) * 1e18);
+            setSettingUint("rpl.inflation.interval.blocks", 7200);                                              // How often the inflation is calculated, if this is changed significantly, then the above 'rpl.inflation.interval.rate' will need to be adjusted. If inflation is no longer required, set 'rpl.inflation.interval.rate' to 0, not this parameter                
             setSettingUint("rpl.inflation.interval.start", block.number+(getInflationIntervalBlocks()*14));     // Set the default start date for inflation to begin as 2 weeks from contract deployment (this can be changed after deployment)
             // Deployment check
             setBool(keccak256(abi.encodePacked(settingNameSpace, "deployed")), true);                           // Flag that this contract has been deployed, so default settings don't get reapplied on a contract upgrade


### PR DESCRIPTION
Line 20 & 21 of the RocketDAOProtocolSettingsInflation.sol uses 6,170 blocks as being equal to 1 day. This assumes an average of 14 seconds per block. I did notice that over the last couple of years the average block time was shorter (13.1 sec) . See  https://etherscan.io/chart/blocktime.

With the likelihood of the quick merge coming this year it might be good just to use the eth2 fixed slot time (12 sec) as a good approximation of the current eth1 block time (~13.2 sec).  It will save time adjusting it after the merge. Assuming you went with 12 sec/block the number of block in a day = 7,200. 

Might mean a little few RPL rewards for me as a node operator as the daily inflation would take 26.4 hrs (@7,200) vs 22.5 hrs (@ 6,140) but figured I'd mention this as a suggestion. 

Also, a year in the code is arbitrarily set to 365 days, not 365.25