### PR TITLE
Fix issue when multiple node operators attempt to use the same withdrawal address

### DIFF
--- a/contracts/contract/node/RocketNodeManager.sol
+++ b/contracts/contract/node/RocketNodeManager.sol
@@ -34,16 +34,6 @@ contract RocketNodeManager is RocketBase, RocketNodeManagerInterface {
         return addressSetStorage.getItem(keccak256(abi.encodePacked("nodes.index")), _index);
     }
 
-    // Get a node by its current withdrawal address
-    function getNodeByWithdrawalAddress(address _withdrawalAddress) override public view returns (address) {
-        return getAddress(keccak256(abi.encodePacked("withdrawal.address.node", _withdrawalAddress)));
-    }
-
-    // Get a node by its pending withdrawal address
-    function getNodeByPendingWithdrawalAddress(address _pendingWithdrawalAddress) override public view returns (address) {
-        return getAddress(keccak256(abi.encodePacked("withdrawal.address.pending.node", _pendingWithdrawalAddress)));
-    }
-
     // Check whether a node exists
     function getNodeExists(address _nodeAddress) override public view returns (bool) {
         return getBool(keccak256(abi.encodePacked("node.exists", _nodeAddress)));
@@ -77,7 +67,6 @@ contract RocketNodeManager is RocketBase, RocketNodeManagerInterface {
         // Initialise node data
         setBool(keccak256(abi.encodePacked("node.exists", msg.sender)), true);
         setAddress(keccak256(abi.encodePacked("node.withdrawal.address", msg.sender)), msg.sender);
-        setAddress(keccak256(abi.encodePacked("withdrawal.address.node", msg.sender)), msg.sender);
         setString(keccak256(abi.encodePacked("node.timezone.location", msg.sender)), _timezoneLocation);
         // Add node to index
         addressSetStorage.addItem(keccak256(abi.encodePacked("nodes.index")), msg.sender);
@@ -88,33 +77,31 @@ contract RocketNodeManager is RocketBase, RocketNodeManagerInterface {
     }
 
     // Set a node's withdrawal address
-    function setWithdrawalAddress(address _newWithdrawalAddress, bool _confirm) override external onlyLatestContract("rocketNodeManager", address(this)) {
+    function setWithdrawalAddress(address _nodeAddress, address _newWithdrawalAddress, bool _confirm) override external onlyLatestContract("rocketNodeManager", address(this)) {
         // Check new withdrawal address
         require(_newWithdrawalAddress != address(0x0), "Invalid withdrawal address");
-        // Get node by current withdrawal address
-        address nodeAddress = getNodeByWithdrawalAddress(msg.sender);
-        require(getNodeExists(nodeAddress), "No node exists for the specified withdrawal address");
+        // Confirm the transaction is from the node's current withdrawal address
+        address withdrawalAddress = getNodeWithdrawalAddress(_nodeAddress);
+        require(withdrawalAddress == msg.sender, "Only a tx from a node's withdrawal address can update it");
         // Update immediately if confirmed
         if (_confirm) {
-            updateWithdrawalAddress(nodeAddress, msg.sender, _newWithdrawalAddress);
+            updateWithdrawalAddress(_nodeAddress, _newWithdrawalAddress);
         }
         // Set pending withdrawal address if not confirmed
         else {
-            setAddress(keccak256(abi.encodePacked("node.withdrawal.address.pending", nodeAddress)), _newWithdrawalAddress);
-            setAddress(keccak256(abi.encodePacked("withdrawal.address.pending.node", _newWithdrawalAddress)), nodeAddress);
+            setAddress(keccak256(abi.encodePacked("node.withdrawal.address.pending", _nodeAddress)), _newWithdrawalAddress);
         }
     }
 
     // Confirm a node's new withdrawal address
-    function confirmWithdrawalAddress() override external onlyLatestContract("rocketNodeManager", address(this)) {
+    function confirmWithdrawalAddress(address _nodeAddress) override external onlyLatestContract("rocketNodeManager", address(this)) {
         // Get node by pending withdrawal address
-        address nodeAddress = getNodeByPendingWithdrawalAddress(msg.sender);
-        require(getNodeExists(nodeAddress), "No node exists for the specified pending withdrawal address");
+        address pendingWithdrawalAddress = getNodePendingWithdrawalAddress(_nodeAddress);
+        require(pendingWithdrawalAddress == msg.sender, "Confirmation must come from the pending withdrawal address");
         // Deregister pending withdrawal address
-        deleteAddress(keccak256(abi.encodePacked("node.withdrawal.address.pending", nodeAddress)));
-        deleteAddress(keccak256(abi.encodePacked("withdrawal.address.pending.node", msg.sender)));
+        deleteAddress(keccak256(abi.encodePacked("node.withdrawal.address.pending", _nodeAddress)));
         // Update withdrawal address
-        updateWithdrawalAddress(nodeAddress, getNodeWithdrawalAddress(nodeAddress), msg.sender);
+        updateWithdrawalAddress(_nodeAddress, msg.sender);
     }
 
     // Set a node's timezone location
@@ -129,12 +116,9 @@ contract RocketNodeManager is RocketBase, RocketNodeManagerInterface {
     }
 
     // Update a node's withdrawal address
-    function updateWithdrawalAddress(address _nodeAddress, address _currentWithdrawalAddress, address _newWithdrawalAddress) private {
-        // Deregister current withdrawal address
-        deleteAddress(keccak256(abi.encodePacked("withdrawal.address.node", _currentWithdrawalAddress)));
+    function updateWithdrawalAddress(address _nodeAddress, address _newWithdrawalAddress) private {
         // Set new withdrawal address
         setAddress(keccak256(abi.encodePacked("node.withdrawal.address", _nodeAddress)), _newWithdrawalAddress);
-        setAddress(keccak256(abi.encodePacked("withdrawal.address.node", _newWithdrawalAddress)), _nodeAddress);
         // Emit withdrawal address set event
         emit NodeWithdrawalAddressSet(_nodeAddress, _newWithdrawalAddress, block.timestamp);
     }

--- a/contracts/interface/node/RocketNodeManagerInterface.sol
+++ b/contracts/interface/node/RocketNodeManagerInterface.sol
@@ -5,14 +5,12 @@ pragma solidity 0.7.6;
 interface RocketNodeManagerInterface {
     function getNodeCount() external view returns (uint256);
     function getNodeAt(uint256 _index) external view returns (address);
-    function getNodeByWithdrawalAddress(address _withdrawalAddress) external view returns (address);
-    function getNodeByPendingWithdrawalAddress(address _pendingWithdrawalAddress) external view returns (address);
     function getNodeExists(address _nodeAddress) external view returns (bool);
     function getNodeWithdrawalAddress(address _nodeAddress) external view returns (address);
     function getNodePendingWithdrawalAddress(address _nodeAddress) external view returns (address);
     function getNodeTimezoneLocation(address _nodeAddress) external view returns (string memory);
     function registerNode(string calldata _timezoneLocation) external;
-    function setWithdrawalAddress(address _newWithdrawalAddress, bool _confirm) external;
-    function confirmWithdrawalAddress() external;
+    function setWithdrawalAddress(address _nodeAddress, address _newWithdrawalAddress, bool _confirm) external;
+    function confirmWithdrawalAddress(address _nodeAddress) external;
     function setTimezoneLocation(string calldata _timezoneLocation) external;
 }

--- a/test/_helpers/node.js
+++ b/test/_helpers/node.js
@@ -80,9 +80,9 @@ export async function setNodeTrusted(_account, _id, _email, owner) {
 
 
 // Set a withdrawal address for a node
-export async function setNodeWithdrawalAddress(withdrawalAddress, txOptions) {
+export async function setNodeWithdrawalAddress(nodeAddress, withdrawalAddress, txOptions) {
     const rocketNodeManager = await RocketNodeManager.deployed();
-    await rocketNodeManager.setWithdrawalAddress(withdrawalAddress, true, txOptions);
+    await rocketNodeManager.setWithdrawalAddress(nodeAddress, withdrawalAddress, true, txOptions);
 }
 
 

--- a/test/minipool/minipool-tests.js
+++ b/test/minipool/minipool-tests.js
@@ -49,7 +49,7 @@ export default function() {
 
             // Register node & set withdrawal address
             await registerNode({from: node});
-            await setNodeWithdrawalAddress(nodeWithdrawalAddress, {from: node});
+            await setNodeWithdrawalAddress(node, nodeWithdrawalAddress, {from: node});
 
             // Register trusted node
             await registerNode({from: trustedNode});

--- a/test/node/node-manager-tests.js
+++ b/test/node/node-manager-tests.js
@@ -17,9 +17,11 @@ export default function() {
         const [
             owner,
             node,
-            registeredNode,
+            registeredNode1,
+            registeredNode2,
             withdrawalAddress1,
             withdrawalAddress2,
+            withdrawalAddress3,
             random,
         ] = accounts;
 
@@ -33,8 +35,9 @@ export default function() {
         // Setup
         before(async () => {
 
-            // Register node
-            await registerNode({from: registeredNode});
+            // Register nodes
+            await registerNode({from: registeredNode1});
+            await registerNode({from: registeredNode2});
 
         });
 
@@ -98,12 +101,35 @@ export default function() {
         it(printTitle('node operator', 'can set their withdrawal address immediately'), async () => {
 
             // Set withdrawal address
-            await setWithdrawalAddress(withdrawalAddress1, true, {
-                from: registeredNode,
+            await setWithdrawalAddress(registeredNode1, withdrawalAddress1, true, {
+                from: registeredNode1,
             });
 
             // Set withdrawal address again
-            await setWithdrawalAddress(withdrawalAddress2, true, {
+            await setWithdrawalAddress(registeredNode1, withdrawalAddress2, true, {
+                from: withdrawalAddress1,
+            });
+
+        });
+
+
+        it(printTitle('node operator', 'can set their withdrawal address to the same value as another node operator'), async () => {
+
+            // Set withdrawal addresses
+            await setWithdrawalAddress(registeredNode1, withdrawalAddress1, true, {
+                from: registeredNode1,
+            });
+
+            await setWithdrawalAddress(registeredNode2, withdrawalAddress1, true, {
+                from: registeredNode2,
+            });
+
+            // Set withdrawal addresses again
+            await setWithdrawalAddress(registeredNode1, withdrawalAddress2, true, {
+                from: withdrawalAddress1,
+            });
+
+            await setWithdrawalAddress(registeredNode2, withdrawalAddress2, true, {
                 from: withdrawalAddress1,
             });
 
@@ -113,8 +139,8 @@ export default function() {
         it(printTitle('node operator', 'cannot set their withdrawal address to an invalid address'), async () => {
 
             // Attempt to set withdrawal address
-            await shouldRevert(setWithdrawalAddress('0x0000000000000000000000000000000000000000', true, {
-                from: registeredNode,
+            await shouldRevert(setWithdrawalAddress(registeredNode1, '0x0000000000000000000000000000000000000000', true, {
+                from: registeredNode1,
             }), 'Set a withdrawal address to an invalid address');
 
         });
@@ -123,7 +149,7 @@ export default function() {
         it(printTitle('random address', 'cannot set a withdrawal address'), async () => {
 
             // Attempt to set withdrawal address
-            await shouldRevert(setWithdrawalAddress(withdrawalAddress1, true, {
+            await shouldRevert(setWithdrawalAddress(registeredNode1, withdrawalAddress1, true, {
                 from: random,
             }), 'Random address set a withdrawal address');
 
@@ -133,18 +159,18 @@ export default function() {
         it(printTitle('node operator', 'can set and confirm their withdrawal address'), async () => {
 
             // Set & confirm withdrawal address
-            await setWithdrawalAddress(withdrawalAddress1, false, {
-                from: registeredNode,
+            await setWithdrawalAddress(registeredNode1, withdrawalAddress1, false, {
+                from: registeredNode1,
             });
-            await confirmWithdrawalAddress({
+            await confirmWithdrawalAddress(registeredNode1, {
                 from: withdrawalAddress1,
             });
 
             // Set & confirm withdrawal address again
-            await setWithdrawalAddress(withdrawalAddress2, false, {
+            await setWithdrawalAddress(registeredNode1, withdrawalAddress2, false, {
                 from: withdrawalAddress1,
             });
-            await confirmWithdrawalAddress({
+            await confirmWithdrawalAddress(registeredNode1, {
                 from: withdrawalAddress2,
             });
 
@@ -154,7 +180,7 @@ export default function() {
         it(printTitle('random address', 'cannot confirm itself as a withdrawal address'), async () => {
 
             // Attempt to confirm a withdrawal address
-            await shouldRevert(confirmWithdrawalAddress({
+            await shouldRevert(confirmWithdrawalAddress(registeredNode1, {
                 from: random,
             }), 'Random address confirmed itself as a withdrawal address');
 
@@ -170,7 +196,7 @@ export default function() {
 
             // Set timezone location
             await setTimezoneLocation('Australia/Sydney', {
-                from: registeredNode,
+                from: registeredNode1,
             });
 
         });
@@ -180,7 +206,7 @@ export default function() {
 
             // Attempt to set timezone location
             await shouldRevert(setTimezoneLocation('a', {
-                from: registeredNode,
+                from: registeredNode1,
             }), 'Set a timezone location to an invalid value');
 
         });

--- a/test/node/scenario-set-withdrawal-address.js
+++ b/test/node/scenario-set-withdrawal-address.js
@@ -2,20 +2,13 @@ import { RocketNodeManager } from '../_utils/artifacts';
 
 
 // Set a node's withdrawal address
-export async function setWithdrawalAddress(withdrawalAddress, confirm, txOptions) {
+export async function setWithdrawalAddress(nodeAddress, withdrawalAddress, confirm, txOptions) {
 
     // Load contracts
     const rocketNodeManager = await RocketNodeManager.deployed();
 
-    // Get node address
-    let nodeAddress = await rocketNodeManager.getNodeByWithdrawalAddress.call(txOptions.from);
-
     // Set withdrawal address
-    await rocketNodeManager.setWithdrawalAddress(withdrawalAddress, confirm, txOptions);
-
-    // Get node by current/pending withdrawal address
-    let nodeByWithdrawalAddress = await rocketNodeManager.getNodeByWithdrawalAddress.call(withdrawalAddress);
-    let nodeByPendingWithdrawalAddress = await rocketNodeManager.getNodeByPendingWithdrawalAddress.call(withdrawalAddress);
+    await rocketNodeManager.setWithdrawalAddress(nodeAddress, withdrawalAddress, confirm, txOptions);
 
     // Get current & pending withdrawal addresses
     let nodeWithdrawalAddress = await rocketNodeManager.getNodeWithdrawalAddress.call(nodeAddress);
@@ -23,13 +16,11 @@ export async function setWithdrawalAddress(withdrawalAddress, confirm, txOptions
 
     // Confirmed update check
     if (confirm) {
-        assert.equal(nodeByWithdrawalAddress, nodeAddress, 'Incorrect node by withdrawal address');
         assert.equal(nodeWithdrawalAddress, withdrawalAddress, 'Incorrect updated withdrawal address');
     }
 
     // Unconfirmed update check
     else {
-        assert.equal(nodeByPendingWithdrawalAddress, nodeAddress, 'Incorrect node by pending withdrawal address');
         assert.equal(nodePendingWithdrawalAddress, withdrawalAddress, 'Incorrect updated pending withdrawal address');
     }
 
@@ -37,24 +28,20 @@ export async function setWithdrawalAddress(withdrawalAddress, confirm, txOptions
 
 
 // Confirm a node's net withdrawal address
-export async function confirmWithdrawalAddress(txOptions) {
+export async function confirmWithdrawalAddress(nodeAddress, txOptions) {
 
     // Load contracts
     const rocketNodeManager = await RocketNodeManager.deployed();
 
-    // Get node address
-    let nodeAddress = await rocketNodeManager.getNodeByPendingWithdrawalAddress.call(txOptions.from);
-
     // Confirm withdrawal address
-    await rocketNodeManager.confirmWithdrawalAddress(txOptions);
+    await rocketNodeManager.confirmWithdrawalAddress(nodeAddress, txOptions);
 
-    // Get node by withdrawal address & node withdrawal address
-    let nodeByWithdrawalAddress = await rocketNodeManager.getNodeByWithdrawalAddress.call(txOptions.from);
+    // Get current & pending withdrawal addresses
     let nodeWithdrawalAddress = await rocketNodeManager.getNodeWithdrawalAddress.call(nodeAddress);
+    let nodePendingWithdrawalAddress = await rocketNodeManager.getNodePendingWithdrawalAddress.call(nodeAddress);
 
     // Check
-    assert.equal(nodeByWithdrawalAddress, nodeAddress, 'Incorrect node by withdrawal address');
     assert.equal(nodeWithdrawalAddress, txOptions.from, 'Incorrect updated withdrawal address');
-
+    assert.equal(nodePendingWithdrawalAddress, '0x0000000000000000000000000000000000000000', 'Incorrect pending withdrawal address');
 }
 

--- a/test/rewards/rewards-tests.js
+++ b/test/rewards/rewards-tests.js
@@ -89,7 +89,7 @@ export default function() {
             await registerNode({from: registeredNodeTrusted3});
 
             // Set node 1 withdrawal address
-            await setNodeWithdrawalAddress(node1WithdrawalAddress, {from: registeredNode1});
+            await setNodeWithdrawalAddress(registeredNode1, node1WithdrawalAddress, {from: registeredNode1});
 
             // Set nodes as trusted
             await setNodeTrusted(registeredNodeTrusted1, 'saas_1', 'node@home.com', owner);

--- a/test/token/reth-tests.js
+++ b/test/token/reth-tests.js
@@ -47,7 +47,7 @@ export default function() {
 
             // Register node & set withdrawal address
             await registerNode({from: node});
-            await setNodeWithdrawalAddress(nodeWithdrawalAddress, {from: node});
+            await setNodeWithdrawalAddress(node, nodeWithdrawalAddress, {from: node});
 
             // Register trusted node
             await registerNode({from: trustedNode});


### PR DESCRIPTION
If two node operators try use the same withdrawal address then the call to `getNodeByWithdrawalAddress` in `setWithdrawalAddress` will just return the most recent node that changed to this address and then the system is in a corrupted state.

This solution adds `nodeAddress` as the first parameter to both `setWithdrawalAddress` and `confirmWithdrawalAddress` and requires the sender to be the node operator's current withdrawal address.

This simple solution removes the ability to call `getNodeByWithdrawalAddress` which wasn't working anyway because it would need to return an array of node addresses if multiple nodes are using that address.

If we want to add the ability to include a `getNodesByWithdrawalAddress` method then we would need to implement another address set on chain. This is possible but costs a lot more gas and probably not required.