### PR TITLE
Implement wait period between depositing ETH for rETH and then burning or transferring

### DIFF
--- a/contracts/contract/deposit/RocketDepositPool.sol
+++ b/contracts/contract/deposit/RocketDepositPool.sol
@@ -63,6 +63,8 @@ contract RocketDepositPool is RocketBase, RocketDepositPoolInterface, RocketVaul
         require(rocketDAOProtocolSettingsDeposit.getDepositEnabled(), "Deposits into Rocket Pool are currently disabled");
         require(msg.value >= rocketDAOProtocolSettingsDeposit.getMinimumDeposit(), "The deposited amount is less than the minimum deposit size");
         require(getBalance().add(msg.value) <= rocketDAOProtocolSettingsDeposit.getMaximumDepositPoolSize(), "The deposit pool size after depositing exceeds the maximum size");
+        // Record last deposit to time delay ability to withdraw
+        setUint(keccak256(abi.encodePacked("user.deposit.block", msg.sender)), block.number);
         // Mint rETH to user account
         rocketTokenRETH.mint(msg.value, msg.sender);
         // Emit deposit received event

--- a/contracts/contract/token/RocketTokenRETH.sol
+++ b/contracts/contract/token/RocketTokenRETH.sol
@@ -147,7 +147,7 @@ contract RocketTokenRETH is RocketBase, ERC20, RocketTokenRETHInterface {
                 // Ensure enough blocks have passed
                 RocketDAOProtocolSettingsNetworkInterface rocketDAOProtocolSettingsNetwork = RocketDAOProtocolSettingsNetworkInterface(getContractAddress("rocketDAOProtocolSettingsNetwork"));
                 uint256 blocksPassed = block.number.sub(lastDepositBlock);
-                require(blocksPassed > rocketDAOProtocolSettingsNetwork.getSubmitPricesFrequency(), "Not enough time has passed since deposit");
+                require(blocksPassed > rocketDAOProtocolSettingsNetwork.getRethDepositDelay(), "Not enough time has passed since deposit");
                 // Clear the state as it's no longer necessary to check this until another deposit is made
                 deleteUint(key);
             }

--- a/contracts/contract/token/RocketTokenRETH.sol
+++ b/contracts/contract/token/RocketTokenRETH.sol
@@ -8,6 +8,7 @@ import "../RocketBase.sol";
 import "../../interface/deposit/RocketDepositPoolInterface.sol";
 import "../../interface/network/RocketNetworkBalancesInterface.sol";
 import "../../interface/token/RocketTokenRETHInterface.sol";
+import "../../interface/dao/protocol/settings/RocketDAOProtocolSettingsNetworkInterface.sol";
 
 // rETH is a tokenized stake in the Rocket Pool network
 // rETH is backed by ETH (subject to liquidity) at a variable exchange rate
@@ -135,4 +136,21 @@ contract RocketTokenRETH is RocketBase, ERC20, RocketTokenRETHInterface {
         rocketDepositPool.withdrawExcessBalance(_ethRequired.sub(ethBalance));
     }
 
+    // This is called by the base ERC20 contract before all transfer, mint, and burns
+    function _beforeTokenTransfer(address from, address, uint256) internal override {
+        // Don't run check if this is a mint transaction
+        if (from != address(0)) {
+            // Check which block the user's last deposit was
+            bytes32 key = keccak256(abi.encodePacked("user.deposit.block", from));
+            uint256 lastDepositBlock = getUint(key);
+            if (lastDepositBlock > 0) {
+                // Ensure enough blocks have passed
+                RocketDAOProtocolSettingsNetworkInterface rocketDAOProtocolSettingsNetwork = RocketDAOProtocolSettingsNetworkInterface(getContractAddress("rocketDAOProtocolSettingsNetwork"));
+                uint256 blocksPassed = block.number.sub(lastDepositBlock);
+                require(blocksPassed > rocketDAOProtocolSettingsNetwork.getSubmitPricesFrequency(), "Not enough time has passed since deposit");
+                // Clear the state as it's no longer necessary to check this until another deposit is made
+                deleteUint(key);
+            }
+        }
+    }
 }

--- a/contracts/interface/dao/protocol/settings/RocketDAOProtocolSettingsNetworkInterface.sol
+++ b/contracts/interface/dao/protocol/settings/RocketDAOProtocolSettingsNetworkInterface.sol
@@ -14,4 +14,5 @@ interface RocketDAOProtocolSettingsNetworkInterface {
     function getMaximumNodeFee() external view returns (uint256);
     function getNodeFeeDemandRange() external view returns (uint256);
     function getTargetRethCollateralRate() external view returns (uint256);
+    function getRethDepositDelay() external view returns (uint256);
 }

--- a/test/dao/dao-protocol-tests.js
+++ b/test/dao/dao-protocol-tests.js
@@ -63,6 +63,9 @@ export default function() {
             await setDAOProtocolBootstrapSetting(RocketDAOProtocolSettingsRewards, 'rpl.rewards.claim.period.blocks', 100, {
                 from: guardian
             });
+            await setDAOProtocolBootstrapSetting(RocketDAOProtocolSettingsInflation, 'network.reth.deposit.delay', 500, {
+                from: guardian
+            });
         });
 
         // Update a setting, then try again

--- a/test/token/reth-tests.js
+++ b/test/token/reth-tests.js
@@ -40,6 +40,7 @@ export default function() {
         let withdrawalBalance = web3.utils.toWei('36', 'ether');
         let rethBalance;
         let submitPricesFrequency = 50;
+        let depositDeplay = 100;
         before(async () => {
 
             // Get current rETH exchange rate
@@ -59,6 +60,7 @@ export default function() {
             // Set settings
             await setDAOProtocolBootstrapSetting(RocketDAOProtocolSettingsNetwork, 'network.reth.collateral.target', web3.utils.toWei('1', 'ether'), {from: owner});
             await setDAOProtocolBootstrapSetting(RocketDAOProtocolSettingsNetwork, 'network.submit.prices.frequency', submitPricesFrequency, {from: owner});
+            await setDAOProtocolBootstrapSetting(RocketDAOProtocolSettingsNetwork, 'network.reth.deposit.delay', depositDeplay, {from: owner});
 
 
             // Stake RPL to cover minipools
@@ -125,8 +127,8 @@ export default function() {
             const depositAmount = web3.utils.toBN(web3.utils.toWei('20', 'ether'));
             await userDeposit({from: staker2, value: depositAmount});
 
-            // Wait "network.submit.prices.frequency" blocks
-            await mineBlocks(web3, submitPricesFrequency);
+            // Wait "network.reth.deposit.delay" blocks
+            await mineBlocks(web3, depositDeplay);
 
             // Transfer rETH
             await transferReth(random, rethBalance, {
@@ -142,8 +144,8 @@ export default function() {
             const depositAmount = web3.utils.toBN(web3.utils.toWei('20', 'ether'));
             await userDeposit({from: staker2, value: depositAmount});
 
-            // Wait "network.submit.prices.frequency" blocks
-            await mineBlocks(web3, submitPricesFrequency);
+            // Wait "network.reth.deposit.delay" blocks
+            await mineBlocks(web3, depositDeplay);
 
             // Transfer rETH
             await transferReth(random, rethBalance, {
@@ -160,8 +162,8 @@ export default function() {
 
         it(printTitle('rETH holder', 'can burn rETH for ETH collateral'), async () => {
 
-            // Wait "network.submit.prices.frequency" blocks
-            await mineBlocks(web3, submitPricesFrequency);
+            // Wait "network.reth.deposit.delay" blocks
+            await mineBlocks(web3, depositDeplay);
 
             // Send ETH to the minipool to simulate receving from SWC
             await web3.eth.sendTransaction({
@@ -193,8 +195,8 @@ export default function() {
             let excessBalance = await getDepositExcessBalance();
             assert(web3.utils.toBN(excessBalance).eq(depositAmount), 'Incorrect deposit pool excess balance');
 
-            // Wait "network.submit.prices.frequency" blocks
-            await mineBlocks(web3, submitPricesFrequency);
+            // Wait "network.reth.deposit.delay" blocks
+            await mineBlocks(web3, depositDeplay);
 
             // Burn rETH
             await burnReth(rethBalance, {
@@ -206,8 +208,8 @@ export default function() {
 
         it(printTitle('rETH holder', 'cannot burn an invalid amount of rETH'), async () => {
 
-            // Wait "network.submit.prices.frequency" blocks
-            await mineBlocks(web3, submitPricesFrequency);
+            // Wait "network.reth.deposit.delay" blocks
+            await mineBlocks(web3, depositDeplay);
 
             // Send ETH to the minipool to simulate receving from SWC
             await web3.eth.sendTransaction({
@@ -241,8 +243,8 @@ export default function() {
 
         it(printTitle('rETH holder', 'cannot burn rETH with insufficient collateral'), async () => {
 
-            // Wait "network.submit.prices.frequency" blocks
-            await mineBlocks(web3, submitPricesFrequency);
+            // Wait "network.reth.deposit.delay" blocks
+            await mineBlocks(web3, depositDeplay);
 
             // Attempt to burn rETH for contract collateral
             await shouldRevert(burnReth(rethBalance, {

--- a/test/token/scenario-reth-transfer.js
+++ b/test/token/scenario-reth-transfer.js
@@ -1,0 +1,35 @@
+import { RocketTokenRETH } from '../_utils/artifacts';
+
+
+// Burn rETH for ETH
+export async function transferReth(to, amount, txOptions) {
+
+    // Load contracts
+    const rocketTokenRETH = await RocketTokenRETH.deployed();
+
+    // Get balances
+    function getBalances() {
+        return Promise.all([
+            rocketTokenRETH.balanceOf.call(txOptions.from),
+            rocketTokenRETH.balanceOf.call(to)
+        ]).then(
+            ([userFromTokenBalance, userToTokenBalance]) =>
+            ({userFromTokenBalance, userToTokenBalance})
+        );
+    }
+
+    // Get initial balances
+    let balances1 = await getBalances();
+
+    // Transfer tokens
+    await rocketTokenRETH.transfer(to, amount, txOptions);
+
+    // Get updated balances
+    let balances2 = await getBalances();
+
+    // Check balances
+    assert(balances2.userFromTokenBalance.eq(balances1.userFromTokenBalance.sub(amount)), 'Incorrect updated user token balance');
+    assert(balances2.userToTokenBalance.eq(balances1.userToTokenBalance.add(amount)), 'Incorrect updated user token balance');
+
+}
+

--- a/test/token/scenario-reth-transfer.js
+++ b/test/token/scenario-reth-transfer.js
@@ -1,7 +1,7 @@
 import { RocketTokenRETH } from '../_utils/artifacts';
 
 
-// Burn rETH for ETH
+// Transfer rETH between accounts
 export async function transferReth(to, amount, txOptions) {
 
     // Load contracts


### PR DESCRIPTION
This PR implements a waiting period after depositing ETH for rETH. Users must wait some number of blocks before burning or transferring rETH after a deposit.

The intention behind this change is to prevent sandwich attacking price submission transactions from oracles by buying and selling immediately before and after this submission.

Things to consider:

- I have used the existing `network.submit.prices.frequency` parameter for the delay period. Should this be a separate parameter in case we want to adjust it independently of the price submission frequency? 24 hours is a good time for this delay as it gives enough time for node operators to use a would-be attacker's deposit in a pool rendering his attack toothless. If we adjust price submission frequency to be a lower number in future, it may affect the efficacy of this protection.

- This logic is hardcoded into the rETH token contract which is not upgradable. So once this logic is decided on, there is no means of changing it at a future date. Using a separate parameter could allow us to disable this logic by setting it to 0 or some low inconsequential value. Alternatively, we could have the logic exist in an upgradable contract and have the token contract make a call to this contract to check if a transfer should revert. This would allow the logic to be upgradable by DAO consensus.