### PR TITLE
Fixes CD 6.11 preventing upgrade with existing contract

### DIFF
--- a/contracts/contract/dao/node/RocketDAONodeTrustedUpgrade.sol
+++ b/contracts/contract/dao/node/RocketDAONodeTrustedUpgrade.sol
@@ -52,6 +52,7 @@ contract RocketDAONodeTrustedUpgrade is RocketBase, RocketDAONodeTrustedUpgradeI
         // Check new contract address
         require(_contractAddress != address(0x0), "Invalid contract address");
         require(_contractAddress != oldContractAddress, "The contract address cannot be set to its current address");
+        require(!getBool(keccak256(abi.encodePacked("contract.exists", _contractAddress))), "Contract address is already in use");
         // Register new contract
         setBool(keccak256(abi.encodePacked("contract.exists", _contractAddress)), true);
         setString(keccak256(abi.encodePacked("contract.name", _contractAddress)), _name);

--- a/test/dao/dao-node-trusted-tests.js
+++ b/test/dao/dao-node-trusted-tests.js
@@ -767,7 +767,14 @@ export default function() {
         it(printTitle('guardian', 'cannot upgrade a contract with an invalid address'), async () => {
             await shouldRevert(setDaoNodeTrustedBootstrapUpgrade('upgradeContract', 'rocketNodeManager', rocketMinipoolManagerNew.abi, '0x0000000000000000000000000000000000000000', {
                 from: guardian,
-            }), 'Guardian adupgradedded a contract with an invalid address', 'Invalid contract address');
+            }), 'Guardian upgrade a contract with an invalid address', 'Invalid contract address');
+        });
+
+        it(printTitle('guardian', 'cannot upgrade a contract with an existing one'), async () => {
+            const rocketStorageAddress = (await RocketStorage.deployed()).address
+            await shouldRevert(setDaoNodeTrustedBootstrapUpgrade('upgradeContract', 'rocketNodeManager', [], rocketStorageAddress, {
+                from: guardian,
+            }), 'Guardian upgraded a contract with an existing contract', 'Contract address is already in use');
         });
 
         it(printTitle('guardian', 'cannot upgrade a protected contract'), async () => {

--- a/test/dao/dao-node-trusted-tests.js
+++ b/test/dao/dao-node-trusted-tests.js
@@ -767,7 +767,7 @@ export default function() {
         it(printTitle('guardian', 'cannot upgrade a contract with an invalid address'), async () => {
             await shouldRevert(setDaoNodeTrustedBootstrapUpgrade('upgradeContract', 'rocketNodeManager', rocketMinipoolManagerNew.abi, '0x0000000000000000000000000000000000000000', {
                 from: guardian,
-            }), 'Guardian upgrade a contract with an invalid address', 'Invalid contract address');
+            }), 'Guardian upgraded a contract with an invalid address', 'Invalid contract address');
         });
 
         it(printTitle('guardian', 'cannot upgrade a contract with an existing one'), async () => {


### PR DESCRIPTION
This PR prevents a contract upgrade with an existing network contract which corrupts the internal state.