### PR TITLE
Make RPL burnable, add vault burn mechanism, burn RPL fine on member kick

### DIFF
--- a/contracts/contract/dao/node/RocketDAONodeTrustedProposals.sol
+++ b/contracts/contract/dao/node/RocketDAONodeTrustedProposals.sol
@@ -131,7 +131,7 @@ contract RocketDAONodeTrustedProposals is RocketBase, RocketDAONodeTrustedPropos
         // Set their bond amount minus the fine
         setUint(keccak256(abi.encodePacked(daoNameSpace, "member.bond.rpl", _nodeAddress)), rplBondAmount.sub(_rplFine));
         // Kick them now
-        daoActionsContract.actionKick(_nodeAddress);
+        daoActionsContract.actionKick(_nodeAddress, _rplFine);
     }
 
 

--- a/contracts/contract/token/RocketTokenRPL.sol
+++ b/contracts/contract/token/RocketTokenRPL.sol
@@ -2,7 +2,7 @@ pragma solidity 0.7.6;
 
 // SPDX-License-Identifier: GPL-3.0-only
 
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20Burnable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import "../RocketBase.sol";
@@ -13,7 +13,7 @@ import "../../interface/RocketVaultInterface.sol";
 // RPL Governance and utility token
 // Inlfationary with rate determined by DAO
 
-contract RocketTokenRPL is RocketBase, ERC20, RocketTokenRPLInterface {
+contract RocketTokenRPL is RocketBase, ERC20Burnable, RocketTokenRPLInterface {
 
     // Libs
     using SafeMath for uint;
@@ -199,6 +199,4 @@ contract RocketTokenRPL is RocketBase, ERC20, RocketTokenRPLInterface {
         // Log it
         emit RPLFixedSupplyBurn(msg.sender, _amount, block.timestamp);
     }
-
-
 }

--- a/contracts/interface/RocketVaultInterface.sol
+++ b/contracts/interface/RocketVaultInterface.sol
@@ -2,6 +2,7 @@ pragma solidity 0.7.6;
 
 // SPDX-License-Identifier: GPL-3.0-only
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20Burnable.sol";
 
 interface RocketVaultInterface {
     function balanceOf(string memory _networkContractName) external view returns (uint256);
@@ -11,4 +12,5 @@ interface RocketVaultInterface {
     function withdrawToken(address _withdrawalAddress, IERC20 _tokenAddress, uint256 _amount) external returns (bool);
     function balanceOfToken(string memory _networkContractName, IERC20 _tokenAddress) external view returns (uint256);
     function transferToken(string memory _networkContractName, IERC20 _tokenAddress, uint256 _amount) external returns (bool);
+    function burnToken(ERC20Burnable _tokenAddress, uint256 _amount) external returns (bool);
 }

--- a/contracts/interface/dao/node/RocketDAONodeTrustedActionsInterface.sol
+++ b/contracts/interface/dao/node/RocketDAONodeTrustedActionsInterface.sol
@@ -6,7 +6,7 @@ interface RocketDAONodeTrustedActionsInterface {
     function actionJoin() external;
     function actionJoinRequired(address _nodeAddress) external;
     function actionLeave(address _rplBondRefundAddress) external;
-    function actionKick(address _nodeAddress) external;
+    function actionKick(address _nodeAddress, uint256 _rplFine) external;
     function actionChallengeMake(address _nodeAddress) external payable;
     function actionChallengeDecide(address _nodeAddress) external;
 }


### PR DESCRIPTION
Currently RPL fines from a member kick are just being lost to the void. The RPL is no longer accessible but according to `totalSupply()` those tokens are still included in the circulating supply.

This PR adds burn functionality to the RPL token contract and burns the fine that occurs during a member kick. This allows for a more accurate circulating supply when querying `totalSupply()`.