### PR TITLE
Fixes CD 6.18

### DIFF
--- a/contracts/interface/minipool/RocketMinipoolStatusInterface.sol
+++ b/contracts/interface/minipool/RocketMinipoolStatusInterface.sol
@@ -5,4 +5,5 @@ pragma solidity 0.7.6;
 interface RocketMinipoolStatusInterface {
     function submitMinipoolWithdrawable(address _minipoolAddress, uint256 _stakingStartBalance, uint256 _stakingEndBalance) external;
     function getMinipoolNodeRewardAmount(uint256 _nodeFee, uint256 _userDeposit, uint256 _startBalance, uint256 _endBalance) external pure returns (uint256);
+    function executeMinipoolWithdrawable(address _minipoolAddress, uint256 _stakingStartBalance, uint256 _stakingEndBalance) external;
 }

--- a/contracts/interface/network/RocketNetworkBalancesInterface.sol
+++ b/contracts/interface/network/RocketNetworkBalancesInterface.sol
@@ -9,4 +9,5 @@ interface RocketNetworkBalancesInterface {
     function getTotalRETHSupply() external view returns (uint256);
     function getETHUtilizationRate() external view returns (uint256);
     function submitBalances(uint256 _block, uint256 _total, uint256 _staking, uint256 _rethSupply) external;
+    function executeUpdateBalances(uint256 _block, uint256 _totalEth, uint256 _stakingEth, uint256 _rethSupply) external;
 }

--- a/contracts/interface/network/RocketNetworkPricesInterface.sol
+++ b/contracts/interface/network/RocketNetworkPricesInterface.sol
@@ -6,4 +6,5 @@ interface RocketNetworkPricesInterface {
     function getPricesBlock() external view returns (uint256);
     function getRPLPrice() external view returns (uint256);
     function submitPrices(uint256 _block, uint256 _rplPrice) external;
+    function executeUpdatePrices(uint256 _block, uint256 _rplPrice) external;
 }

--- a/test/network/network-balances-tests.js
+++ b/test/network/network-balances-tests.js
@@ -1,10 +1,13 @@
-import { takeSnapshot, revertSnapshot } from '../_utils/evm';
+import { takeSnapshot, revertSnapshot, mineBlocks } from '../_utils/evm'
 import { printTitle } from '../_utils/formatting';
 import { shouldRevert } from '../_utils/testing';
 import { registerNode, setNodeTrusted } from '../_helpers/node';
-import { submitBalances } from './scenario-submit-balances';
-import { RocketDAOProtocolSettingsNetwork } from '../_utils/artifacts';
+import { executeUpdateBalances, submitBalances } from './scenario-submit-balances'
+import { RocketDAONodeTrustedSettingsProposals, RocketDAOProtocolSettingsNetwork } from '../_utils/artifacts'
 import { setDAOProtocolBootstrapSetting } from '../dao/scenario-dao-protocol-bootstrap';
+import { daoNodeTrustedExecute, daoNodeTrustedMemberLeave, daoNodeTrustedPropose, daoNodeTrustedVote } from '../dao/scenario-dao-node-trusted'
+import { getDAOProposalEndBlock, getDAOProposalStartBlock } from '../dao/scenario-dao-proposal'
+import { setDAONodeTrustedBootstrapSetting } from '../dao/scenario-dao-node-trusted-bootstrap'
 
 export default function() {
     contract('RocketNetworkBalances', async (accounts) => {
@@ -17,7 +20,14 @@ export default function() {
             trustedNode1,
             trustedNode2,
             trustedNode3,
+            trustedNode4,
+            random
         ] = accounts;
+
+
+        // Constants
+        let proposalCooldown = 10
+        let proposalVoteBlocks = 10
 
 
         // State snapshotting
@@ -40,7 +50,46 @@ export default function() {
             await setNodeTrusted(trustedNode2, 'saas_2', 'node@home.com', owner);
             await setNodeTrusted(trustedNode3, 'saas_3', 'node@home.com', owner);
 
+            // Set a small proposal cooldown
+            await setDAONodeTrustedBootstrapSetting(RocketDAONodeTrustedSettingsProposals, 'proposal.cooldown', proposalCooldown, { from: owner });
+            await setDAONodeTrustedBootstrapSetting(RocketDAONodeTrustedSettingsProposals, 'proposal.vote.blocks', proposalVoteBlocks, { from: owner });
+
         });
+
+
+        async function trustedNode4JoinDao() {
+            await registerNode({from: trustedNode4});
+            await setNodeTrusted(trustedNode4, 'saas_4', 'node@home.com', owner);
+        }
+
+
+        async function trustedNode4LeaveDao() {
+            // Wait enough time to do a new proposal
+            await mineBlocks(web3, proposalCooldown);
+            // Encode the calldata for the proposal
+            let proposalCallData = web3.eth.abi.encodeFunctionCall(
+              {name: 'proposalLeave', type: 'function', inputs: [{type: 'address', name: '_nodeAddress'}]},
+              [trustedNode4]
+            );
+            // Add the proposal
+            let proposalId = await daoNodeTrustedPropose('hey guys, can I please leave the DAO?', proposalCallData, {
+                from: trustedNode4
+            });
+            // Current block
+            let blockCurrent = await web3.eth.getBlockNumber();
+            // Now mine blocks until the proposal is 'active' and can be voted on
+            await mineBlocks(web3, (await getDAOProposalStartBlock(proposalId)-blockCurrent)+2);
+            // Now lets vote
+            await daoNodeTrustedVote(proposalId, true, { from: trustedNode1 });
+            await daoNodeTrustedVote(proposalId, true, { from: trustedNode2 });
+            await daoNodeTrustedVote(proposalId, true, { from: trustedNode3 });
+            // Fast forward to this voting period finishing
+            await mineBlocks(web3, (await getDAOProposalEndBlock(proposalId)-blockCurrent)+1);
+            // Proposal should be successful, lets execute it
+            await daoNodeTrustedExecute(proposalId, { from: trustedNode1 });
+            // Member can now leave and collect any RPL bond
+            await daoNodeTrustedMemberLeave(trustedNode4, { from: trustedNode4 });
+        }
 
 
         it(printTitle('trusted nodes', 'can submit network balances'), async () => {
@@ -196,5 +245,49 @@ export default function() {
         });
 
 
+        it(printTitle('random', 'can execute balances update when consensus is reached after member count changes'), async () => {
+            // Setup
+            await trustedNode4JoinDao();
+            // Set parameters
+            let block = 1;
+            let totalBalance = web3.utils.toWei('10', 'ether');
+            let stakingBalance = web3.utils.toWei('9', 'ether');
+            let rethSupply = web3.utils.toWei('8', 'ether');
+            // Submit same parameters from 2 nodes (not enough for 4 member consensus but enough for 3)
+            await submitBalances(block, totalBalance, stakingBalance, rethSupply, {
+                from: trustedNode1,
+            });
+            await submitBalances(block, totalBalance, stakingBalance, rethSupply, {
+                from: trustedNode2,
+            });
+            // trustedNode4 leaves the DAO
+            await trustedNode4LeaveDao();
+            // There is now consensus with the remaining 3 trusted nodes about the balances, try to execute the update
+            await executeUpdateBalances(block, totalBalance, stakingBalance, rethSupply, {
+                from: random
+            })
+        });
+
+
+        it(printTitle('random', 'cannot execute balances update without consensus'), async () => {
+            // Setup
+            await trustedNode4JoinDao();
+            // Set parameters
+            let block = 1;
+            let totalBalance = web3.utils.toWei('10', 'ether');
+            let stakingBalance = web3.utils.toWei('9', 'ether');
+            let rethSupply = web3.utils.toWei('8', 'ether');
+            // Submit same price from 2 nodes (not enough for 4 member consensus)
+            await submitBalances(block, totalBalance, stakingBalance, rethSupply, {
+                from: trustedNode1,
+            });
+            await submitBalances(block, totalBalance, stakingBalance, rethSupply, {
+                from: trustedNode2,
+            });
+            // There is no consensus so execute should fail
+            await shouldRevert(executeUpdateBalances(block, totalBalance, stakingBalance, rethSupply, {
+                from: random
+            }), 'Random account could execute update balances without consensus')
+        });
     });
 }

--- a/test/network/network-prices-tests.js
+++ b/test/network/network-prices-tests.js
@@ -1,10 +1,13 @@
-import { takeSnapshot, revertSnapshot } from '../_utils/evm';
+import { takeSnapshot, revertSnapshot, mineBlocks } from '../_utils/evm'
 import { printTitle } from '../_utils/formatting';
 import { shouldRevert } from '../_utils/testing';
 import { registerNode, setNodeTrusted } from '../_helpers/node';
-import { submitPrices } from './scenario-submit-prices';
-import { RocketDAOProtocolSettingsNetwork } from '../_utils/artifacts';
+import { executeUpdatePrices, submitPrices } from './scenario-submit-prices'
+import { RocketDAONodeTrustedSettingsProposals, RocketDAOProtocolSettingsNetwork } from '../_utils/artifacts'
 import { setDAOProtocolBootstrapSetting } from '../dao/scenario-dao-protocol-bootstrap';
+import { setDAONodeTrustedBootstrapSetting } from '../dao/scenario-dao-node-trusted-bootstrap'
+import { daoNodeTrustedExecute, daoNodeTrustedMemberLeave, daoNodeTrustedPropose, daoNodeTrustedVote } from '../dao/scenario-dao-node-trusted'
+import { getDAOProposalEndBlock, getDAOProposalStartBlock } from '../dao/scenario-dao-proposal'
 
 export default function() {
     contract('RocketNetworkPrices', async (accounts) => {
@@ -17,6 +20,8 @@ export default function() {
             trustedNode1,
             trustedNode2,
             trustedNode3,
+            trustedNode4,   // Joins and leaves DAO in certain tests
+            random
         ] = accounts;
 
 
@@ -24,6 +29,11 @@ export default function() {
         let snapshotId;
         beforeEach(async () => { snapshotId = await takeSnapshot(web3); });
         afterEach(async () => { await revertSnapshot(web3, snapshotId); });
+
+
+        // Constants
+        let proposalCooldown = 10
+        let proposalVoteBlocks = 10
 
 
         // Setup
@@ -40,7 +50,46 @@ export default function() {
             await setNodeTrusted(trustedNode2, 'saas_2', 'node@home.com', owner);
             await setNodeTrusted(trustedNode3, 'saas_3', 'node@home.com', owner);
 
+            // Set a small proposal cooldown
+            await setDAONodeTrustedBootstrapSetting(RocketDAONodeTrustedSettingsProposals, 'proposal.cooldown', proposalCooldown, { from: owner });
+            await setDAONodeTrustedBootstrapSetting(RocketDAONodeTrustedSettingsProposals, 'proposal.vote.blocks', proposalVoteBlocks, { from: owner });
+
         });
+
+
+        async function trustedNode4JoinDao() {
+            await registerNode({from: trustedNode4});
+            await setNodeTrusted(trustedNode4, 'saas_4', 'node@home.com', owner);
+        }
+
+
+        async function trustedNode4LeaveDao() {
+            // Wait enough time to do a new proposal
+            await mineBlocks(web3, proposalCooldown);
+            // Encode the calldata for the proposal
+            let proposalCallData = web3.eth.abi.encodeFunctionCall(
+              {name: 'proposalLeave', type: 'function', inputs: [{type: 'address', name: '_nodeAddress'}]},
+              [trustedNode4]
+            );
+            // Add the proposal
+            let proposalId = await daoNodeTrustedPropose('hey guys, can I please leave the DAO?', proposalCallData, {
+                from: trustedNode4
+            });
+            // Current block
+            let blockCurrent = await web3.eth.getBlockNumber();
+            // Now mine blocks until the proposal is 'active' and can be voted on
+            await mineBlocks(web3, (await getDAOProposalStartBlock(proposalId)-blockCurrent)+2);
+            // Now lets vote
+            await daoNodeTrustedVote(proposalId, true, { from: trustedNode1 });
+            await daoNodeTrustedVote(proposalId, true, { from: trustedNode2 });
+            await daoNodeTrustedVote(proposalId, true, { from: trustedNode3 });
+            // Fast forward to this voting period finishing
+            await mineBlocks(web3, (await getDAOProposalEndBlock(proposalId)-blockCurrent)+1);
+            // Proposal should be successful, lets execute it
+            await daoNodeTrustedExecute(proposalId, { from: trustedNode1 });
+            // Member can now leave and collect any RPL bond
+            await daoNodeTrustedMemberLeave(trustedNode4, { from: trustedNode4 });
+        }
 
 
         it(printTitle('trusted nodes', 'can submit network prices'), async () => {
@@ -167,6 +216,47 @@ export default function() {
 
         });
 
+
+        it(printTitle('random', 'can execute price update when consensus is reached after member count changes'), async () => {
+            // Setup
+            await trustedNode4JoinDao();
+            // Set parameters
+            let block = 1;
+            let rplPrice = web3.utils.toWei('0.02', 'ether');
+            // Submit same price from 2 nodes (not enough for 4 member consensus but enough for 3)
+            await submitPrices(block, rplPrice, {
+                from: trustedNode1,
+            });
+            await submitPrices(block, rplPrice, {
+                from: trustedNode2,
+            });
+            // trustedNode4 leaves the DAO
+            await trustedNode4LeaveDao();
+            // There is now consensus with the remaining 3 trusted nodes about the price, try to execute the update
+            await executeUpdatePrices(block, rplPrice, {
+                from: random
+            })
+        });
+
+
+        it(printTitle('random', 'cannot execute price update without consensus'), async () => {
+            // Setup
+            await trustedNode4JoinDao();
+            // Set parameters
+            let block = 1;
+            let rplPrice = web3.utils.toWei('0.02', 'ether');
+            // Submit same price from 2 nodes (not enough for 4 member consensus)
+            await submitPrices(block, rplPrice, {
+                from: trustedNode1,
+            });
+            await submitPrices(block, rplPrice, {
+                from: trustedNode2,
+            });
+            // There is no consensus so execute should fail
+            await shouldRevert(executeUpdatePrices(block, rplPrice, {
+                from: random
+            }), 'Random account could execute update prices without consensus')
+        });
 
     });
 }

--- a/test/network/scenario-submit-prices.js
+++ b/test/network/scenario-submit-prices.js
@@ -57,7 +57,7 @@ export async function submitPrices(block, rplPrice, txOptions) {
     ]);
 
     // Check if prices should be updated
-    let expectUpdatedPrices = submission2.count.mul(web3.utils.toBN(2)).gte(trustedNodeCount);
+    let expectUpdatedPrices = submission2.count.mul(web3.utils.toBN(2)).gt(trustedNodeCount);
 
     // Check submission details
     assert.isFalse(submission1.nodeSubmitted, 'Incorrect initial node submitted status');
@@ -72,6 +72,36 @@ export async function submitPrices(block, rplPrice, txOptions) {
         assert(!prices.block.eq(web3.utils.toBN(block)), 'Incorrectly updated network prices block');
         assert(!prices.rplPrice.eq(web3.utils.toBN(rplPrice)), 'Incorrectly updated network RPL price');
     }
+
+}
+
+
+// Execute price update
+export async function executeUpdatePrices(block, rplPrice, txOptions) {
+
+    // Load contracts
+    const rocketNetworkPrices = await RocketNetworkPrices.deployed();
+
+    // Get prices
+    function getPrices() {
+        return Promise.all([
+            rocketNetworkPrices.getPricesBlock.call(),
+            rocketNetworkPrices.getRPLPrice.call(),
+        ]).then(
+          ([block, rplPrice]) =>
+            ({block, rplPrice})
+        );
+    }
+
+    // Submit prices
+    await rocketNetworkPrices.executeUpdatePrices(block, rplPrice, txOptions);
+
+    // Get updated submission details & prices
+    let prices = await getPrices();
+
+    // Check the prices
+    assert(prices.block.eq(web3.utils.toBN(block)), 'Incorrect updated network prices block');
+    assert(prices.rplPrice.eq(web3.utils.toBN(rplPrice)), 'Incorrect updated network RPL price');
 
 }
 


### PR DESCRIPTION
This PR fixes an issue that occurs if enough members leave or are kicked from the DAO and a price, balances, or minipool withdrawal consensus can no longer be acted on.

Example:

1. The DAO consists of five members
2. Two members vote to make a Minipool withdrawable
3. The other three members are inactive, the community votes, and they get kicked from the DAO
4. The two remaining members have no way to change the Minipool state now. All method calls to trigger the state update fails because the members have already voted before.

It fixes this issue by exposing a public method which can be called by anyone and will perform the relevant action if there is currently a consensus.