### PR TITLE
address CD minor 6.29 and 6.30 - show correct status after defeated a…

### DIFF
--- a/contracts/contract/dao/RocketDAOProposal.sol
+++ b/contracts/contract/dao/RocketDAOProposal.sol
@@ -140,13 +140,13 @@ contract RocketDAOProposal is RocketBase, RocketDAOProposalInterface {
         } else if (getExecuted(_proposalID)) {
             return ProposalState.Executed;
             // Is the proposal pending? Eg. waiting to be voted on
-        } else if (block.number <= getStart(_proposalID)) {
+        } else if (block.number < getStart(_proposalID)) {
             return ProposalState.Pending;
             // Vote was successful, is now awaiting execution
         } else if (votesFor >= getVotesRequired(_proposalID) && block.number < getExpires(_proposalID)) {
             return ProposalState.Succeeded;
             // The proposal is active and can be voted on
-        } else if (block.number <= getEnd(_proposalID)) {
+        } else if (block.number < getEnd(_proposalID)) {
             return ProposalState.Active;
             // Check the votes, was it defeated?
         } else if (votesFor <= votesAgainst || votesFor < getVotesRequired(_proposalID)) {

--- a/contracts/contract/dao/RocketDAOProposal.sol
+++ b/contracts/contract/dao/RocketDAOProposal.sol
@@ -28,7 +28,6 @@ contract RocketDAOProposal is RocketBase, RocketDAOProposalInterface {
     
     // Only allow the DAO contract to access
     modifier onlyDAOContract(string memory _daoName) {
-        // TODO: Potentially lock this down to final DAO contract names
         // Load contracts
         require(keccak256(abi.encodePacked(getContractName(msg.sender))) == keccak256(abi.encodePacked(_daoName)), "Sender is not the required DAO contract");
         _;
@@ -132,7 +131,7 @@ contract RocketDAOProposal is RocketBase, RocketDAOProposalInterface {
         require(getTotal() >= _proposalID && _proposalID > 0, "Invalid proposal ID");
         // Get the amount of votes for and against
         uint256 votesFor = getVotesFor(_proposalID);
-        // uint256 votesAgainst = getVotesAgainst(_proposalID);
+        uint256 votesAgainst = getVotesAgainst(_proposalID);
         // Now return the state of the current proposal
         if (getCancelled(_proposalID)) {
             // Cancelled by the proposer?
@@ -140,22 +139,21 @@ contract RocketDAOProposal is RocketBase, RocketDAOProposalInterface {
             // Has it been executed?
         } else if (getExecuted(_proposalID)) {
             return ProposalState.Executed;
-            // Has it expired?
-        } else if (block.number >= getExpires(_proposalID)) {
-            return ProposalState.Expired;
-            // Vote was successful, is now awaiting execution
-        } else if (votesFor >= getVotesRequired(_proposalID)) {
-            return ProposalState.Succeeded;
             // Is the proposal pending? Eg. waiting to be voted on
         } else if (block.number <= getStart(_proposalID)) {
             return ProposalState.Pending;
+            // Vote was successful, is now awaiting execution
+        } else if (votesFor >= getVotesRequired(_proposalID) && block.number < getExpires(_proposalID)) {
+            return ProposalState.Succeeded;
             // The proposal is active and can be voted on
         } else if (block.number <= getEnd(_proposalID)) {
             return ProposalState.Active;
-        } else {
             // Check the votes, was it defeated?
-            // if (votesFor <= votesAgainst || votesFor < getVotesRequired(_proposalID))
+        } else if (votesFor <= votesAgainst || votesFor < getVotesRequired(_proposalID)) {
             return ProposalState.Defeated;
+        } else {
+            // Was it successful, but has now expired? and cannot be executed anymore?
+            return ProposalState.Expired;
         }
     }
 
@@ -237,10 +235,8 @@ contract RocketDAOProposal is RocketBase, RocketDAOProposalInterface {
 
     // Cancel a proposal, can be cancelled by the original proposer only if it hasn't been executed yet
     function cancel(address _member, uint256 _proposalID) override public onlyDAOContract(getDAO(_proposalID)) {
-        // Firstly make sure this proposal that hasn't already been executed
-        require(getState(_proposalID) != ProposalState.Executed, "Proposal has already been executed");
-        // Make sure this proposal hasn't already been successful
-        require(getState(_proposalID) != ProposalState.Succeeded, "Proposal has already succeeded");
+        // Firstly make sure this proposal can be cancelled
+        require(getState(_proposalID) == ProposalState.Pending || getState(_proposalID) == ProposalState.Active, "Proposal can only be cancelled if pending or active");
         // Only allow the proposer to cancel
         require(getProposer(_proposalID) == _member, "Proposal can only be cancelled by the proposer");
         // Set as cancelled now

--- a/contracts/contract/dao/node/settings/RocketDAONodeTrustedSettingsProposals.sol
+++ b/contracts/contract/dao/node/settings/RocketDAONodeTrustedSettingsProposals.sol
@@ -18,7 +18,7 @@ contract RocketDAONodeTrustedSettingsProposals is RocketDAONodeTrustedSettings, 
             // Init settings
             setSettingUint('proposal.cooldown', 13220);                      // How long before a member can make sequential proposals. Approx. 2 days of blocks
             setSettingUint('proposal.vote.blocks', 92550);                   // How long a proposal can be voted on. Approx. 2 weeks worth of blocks
-            setSettingUint('proposal.vote.delay.blocks', 1);                 // How long before a proposal can be voted on after it is created. Approx. Next Block
+            setSettingUint('proposal.vote.delay.blocks', 46276);             // How long before a proposal can be voted on after it is created. Approx. 1 week
             setSettingUint('proposal.execute.blocks', 185100);               // How long a proposal can be executed after its voting period is finished. Approx. 4 weeks worth of blocks
             setSettingUint('proposal.action.blocks', 185100);                // Certain proposals require a secondary action to be run after the proposal is successful (joining, leaving etc). This is how long until that action expires Approx. 2 weeks worth of blocks     
             // Settings initialized

--- a/test/dao/dao-node-trusted-tests.js
+++ b/test/dao/dao-node-trusted-tests.js
@@ -91,6 +91,8 @@ export default function() {
             rocketDAONodeTrustedUpgradeNew = await RocketDAONodeTrustedUpgrade.new(rocketStorage.address, {from: guardian});
             // Set a small proposal cooldown
             await setDAONodeTrustedBootstrapSetting(RocketDAONodeTrustedSettingsProposals, 'proposal.cooldown', 10, { from: guardian });
+            // Set a small vote delay
+            await setDAONodeTrustedBootstrapSetting(RocketDAONodeTrustedSettingsProposals, 'proposal.vote.delay.blocks', 4, { from: guardian });
 
         });
 
@@ -169,7 +171,6 @@ export default function() {
             }), 'Guardian changed quorum setting to invalid value', 'Quorum setting must be > 0 & <= 90%');
         });
         
-
 
         it(printTitle('registeredNode1', 'verify trusted node quorum votes required is correct'), async () => {
             // Load contracts
@@ -250,6 +251,7 @@ export default function() {
             // Join now
             await daoNodeTrustedMemberJoin({from: registeredNode1});
             await daoNodeTrustedMemberJoin({from: registeredNode2});
+            
             // Now registeredNodeTrusted2 wants to leave
             // Encode the calldata for the proposal
             let proposalCalldata3 = web3.eth.abi.encodeFunctionCall(
@@ -269,20 +271,20 @@ export default function() {
             await daoNodeTrustedVote(proposalID_3, true, { from: registeredNodeTrusted2 });
             await daoNodeTrustedVote(proposalID_3, false, { from: registeredNode1 });
             await daoNodeTrustedVote(proposalID_3, true, { from: registeredNode2 });
+            // Current block
+            blockCurrent = await web3.eth.getBlockNumber();
             // Fast forward to this voting period finishing
             await mineBlocks(web3, (await getDAOProposalEndBlock(proposalID_3)-blockCurrent)+1);
             // Proposal should be successful, lets execute it
             await daoNodeTrustedExecute(proposalID_3, { from: registeredNodeTrusted2 });
             // Member can now leave and collect any RPL bond
             await daoNodeTrustedMemberLeave(registeredNodeTrusted2, {from: registeredNodeTrusted2});
+            
         });
         
-
+        
         // Test various proposal states
         it(printTitle('registeredNodeTrusted1', 'creates a proposal and verifies the proposal states as it passes and is executed'), async () => {
-            // Get the DAO settings
-            const daoNode = await RocketDAONodeTrusted.deployed();
-            const rocketTokenRPL = await RocketTokenRPL.deployed();
             // Setup our proposal settings
             let proposalVoteBlocks = 10;
             let proposalVoteExecuteBlocks = 10; 
@@ -324,9 +326,6 @@ export default function() {
 
         // Test various proposal states
         it(printTitle('registeredNodeTrusted1', 'creates a proposal and verifies the proposal states as it fails after it expires'), async () => {
-            // Get the DAO settings
-            const daoNode = await RocketDAONodeTrusted.deployed();
-            const rocketTokenRPL = await RocketTokenRPL.deployed();
             // Setup our proposal settings
             let proposalVoteBlocks = 10;
             let proposalVoteExecuteBlocks = 10; 
@@ -352,7 +351,7 @@ export default function() {
             // Current block
             let blockCurrent = await web3.eth.getBlockNumber();
             // Now mine blocks until the proposal is 'active' and can be voted on
-            await mineBlocks(web3, (await getDAOProposalStartBlock(proposalID)-blockCurrent)+1);
+            await mineBlocks(web3, await getDAOProposalStartBlock(proposalID)-blockCurrent);
             // Now lets vote
             await daoNodeTrustedVote(proposalID, true, { from: registeredNode1 });
             await daoNodeTrustedVote(proposalID, false, { from: registeredNodeTrusted2 });   
@@ -626,6 +625,8 @@ export default function() {
             await mineBlocks(web3, (await getDAOProposalEndBlock(proposalID)-blockCurrent)+1+proposalVoteExecuteBlocks);
             // Execution should fail
             await shouldRevert(daoNodeTrustedExecute(proposalID, { from: registeredNode2 }), 'Member execute proposal after it had expired', 'Proposal has not succeeded, has expired or has already been executed');
+            // Cancel should fail
+            await shouldRevert(daoNodeTrustedCancel(proposalID, { from: registeredNodeTrusted1 }), 'Member cancelled proposal after it had expired', 'Proposal can only be cancelled if pending or active');
         });  
 
         
@@ -929,6 +930,7 @@ export default function() {
                 from: userOne,
             }), 'Random address added a new contract ABI', 'Account is not a temporary guardian');
         });
+        
         
     });
 }

--- a/test/minipool/minipool-status-tests.js
+++ b/test/minipool/minipool-status-tests.js
@@ -89,6 +89,8 @@ export default function() {
             // Set a small proposal cooldown
             await setDAONodeTrustedBootstrapSetting(RocketDAONodeTrustedSettingsProposals, 'proposal.cooldown', proposalCooldown, { from: owner });
             await setDAONodeTrustedBootstrapSetting(RocketDAONodeTrustedSettingsProposals, 'proposal.vote.blocks', proposalVoteBlocks, { from: owner });
+            // Set a small vote delay
+            await setDAONodeTrustedBootstrapSetting(RocketDAONodeTrustedSettingsProposals, 'proposal.vote.delay.blocks', 4, { from: owner });
 
         });
 

--- a/test/network/network-balances-tests.js
+++ b/test/network/network-balances-tests.js
@@ -53,6 +53,8 @@ export default function() {
             // Set a small proposal cooldown
             await setDAONodeTrustedBootstrapSetting(RocketDAONodeTrustedSettingsProposals, 'proposal.cooldown', proposalCooldown, { from: owner });
             await setDAONodeTrustedBootstrapSetting(RocketDAONodeTrustedSettingsProposals, 'proposal.vote.blocks', proposalVoteBlocks, { from: owner });
+            // Set a small vote delay
+            await setDAONodeTrustedBootstrapSetting(RocketDAONodeTrustedSettingsProposals, 'proposal.vote.delay.blocks', 4, { from: owner });
 
         });
 

--- a/test/network/network-prices-tests.js
+++ b/test/network/network-prices-tests.js
@@ -53,6 +53,8 @@ export default function() {
             // Set a small proposal cooldown
             await setDAONodeTrustedBootstrapSetting(RocketDAONodeTrustedSettingsProposals, 'proposal.cooldown', proposalCooldown, { from: owner });
             await setDAONodeTrustedBootstrapSetting(RocketDAONodeTrustedSettingsProposals, 'proposal.vote.blocks', proposalVoteBlocks, { from: owner });
+            // Set a small vote delay
+            await setDAONodeTrustedBootstrapSetting(RocketDAONodeTrustedSettingsProposals, 'proposal.vote.delay.blocks', 4, { from: owner });
 
         });
 


### PR DESCRIPTION
Addresses minor issues 6.29 and 6.30 from CD report. 

- Can only cancel a proposal if it is now pending or active.
- Changed `getState` logic to show correct final status of proposals that had been defeated or had been successful, but not executed in the given time frame, they now show as expired.