### PR TITLE
Resolves CD 6.31 - Claimer count can be corrupted

### DIFF
--- a/contracts/contract/rewards/RocketRewardsPool.sol
+++ b/contracts/contract/rewards/RocketRewardsPool.sol
@@ -307,6 +307,9 @@ contract RocketRewardsPool is RocketBase, RocketRewardsPoolInterface {
             // Update the total registered claimers for next interval
             setUint(keccak256(abi.encodePacked("rewards.pool.claim.interval.claimers.total.next", contractName)), claimersIntervalTotalUpdate.add(1));
         }else{
+            // Make sure they are already registered
+            require(getClaimingContractUserRegisteredBlock(contractName, _claimerAddress) != 0, "Claimer is not registered");
+            // Update the total registered claimers for next interval
             setUint(keccak256(abi.encodePacked("rewards.pool.claim.interval.claimers.total.next", contractName)), claimersIntervalTotalUpdate.sub(1));
         }
         // Save the registered block


### PR DESCRIPTION
Fixes minor issue where total claimers in next interval is decremented even if the supplied `_claimerAddress` isn't a currently registered claimer.