### PR TITLE
Modify inflation and reward system to use time intead of block count

### DIFF
--- a/contracts/contract/dao/protocol/settings/RocketDAOProtocolSettingsInflation.sol
+++ b/contracts/contract/dao/protocol/settings/RocketDAOProtocolSettingsInflation.sol
@@ -35,7 +35,7 @@ contract RocketDAOProtocolSettingsInflation is RocketDAOProtocolSettings, Rocket
         // Check the inflation time interval
         if(keccak256(bytes(_settingPath)) == keccak256(bytes('rpl.inflation.interval.time'))) {
                 // Must be >= 30 mins, set 'rpl.inflation.interval.rate' to 0 if inflation is no longer required
-                require(_value >= 1800, "Inflation interval must be greater than 1 hour");
+                require(_value >= 1800, "Inflation interval must be greater than 30 minutes");
         }
         // The start time for inflation must be in the future and cannot be set again once started
         if(keccak256(bytes(_settingPath)) == keccak256(bytes('rpl.inflation.interval.start'))) {

--- a/contracts/contract/dao/protocol/settings/RocketDAOProtocolSettingsInflation.sol
+++ b/contracts/contract/dao/protocol/settings/RocketDAOProtocolSettingsInflation.sol
@@ -18,7 +18,6 @@ contract RocketDAOProtocolSettingsInflation is RocketDAOProtocolSettings, Rocket
         if(!getBool(keccak256(abi.encodePacked(settingNameSpace, "deployed")))) {
             // RPL Inflation settings
             setSettingUint("rpl.inflation.interval.rate", 1000133680617113500);                                 // 5% annual calculated on a daily interval - Calculate in js example: let dailyInflation = web3.utils.toBN((1 + 0.05) ** (1 / (365)) * 1e18);
-            setSettingUint("rpl.inflation.interval.time", 1 days);                                              // How often the inflation is calculated, if this is changed significantly, then the above 'rpl.inflation.interval.rate' will need to be adjusted. If inflation is no longer required, set 'rpl.inflation.interval.rate' to 0, not this parameter
             setSettingUint("rpl.inflation.interval.start", block.timestamp + 14 days);                          // Set the default start date for inflation to begin as 2 weeks from contract deployment (this can be changed after deployment)
             // Deployment check
             setBool(keccak256(abi.encodePacked(settingNameSpace, "deployed")), true);                           // Flag that this contract has been deployed, so default settings don't get reapplied on a contract upgrade
@@ -32,11 +31,6 @@ contract RocketDAOProtocolSettingsInflation is RocketDAOProtocolSettings, Rocket
     // Update a setting, overrides inherited setting method with extra checks for this contract
     function setSettingUint(string memory _settingPath, uint256 _value) override public onlyDAOProtocolProposal {
         // Some safety guards for certain settings
-        // Check the inflation time interval
-        if(keccak256(bytes(_settingPath)) == keccak256(bytes('rpl.inflation.interval.time'))) {
-                // Must be >= 30 mins, set 'rpl.inflation.interval.rate' to 0 if inflation is no longer required
-                require(_value >= 1800, "Inflation interval must be greater than 30 minutes");
-        }
         // The start time for inflation must be in the future and cannot be set again once started
         if(keccak256(bytes(_settingPath)) == keccak256(bytes('rpl.inflation.interval.start'))) {
                 // Must be a future timestamp
@@ -58,11 +52,6 @@ contract RocketDAOProtocolSettingsInflation is RocketDAOProtocolSettings, Rocket
         return getSettingUint("rpl.inflation.interval.rate");
     }
     
-    // Inflation block interval (default is 1 day)
-    function getInflationIntervalTime() override public view returns (uint256) {
-        return getSettingUint("rpl.inflation.interval.time");
-    }
-
     // The block to start inflation at
     function getInflationIntervalStartTime() override public view returns (uint256) {
         return getSettingUint("rpl.inflation.interval.start"); 

--- a/contracts/contract/dao/protocol/settings/RocketDAOProtocolSettingsInflation.sol
+++ b/contracts/contract/dao/protocol/settings/RocketDAOProtocolSettingsInflation.sol
@@ -17,9 +17,9 @@ contract RocketDAOProtocolSettingsInflation is RocketDAOProtocolSettings, Rocket
          // Set some initial settings on first deployment
         if(!getBool(keccak256(abi.encodePacked(settingNameSpace, "deployed")))) {
             // RPL Inflation settings
-            setSettingUint("rpl.inflation.interval.rate", 1000133680617113500);                                 // 5% annual calculated on a daily interval of blocks (6170 = 1 day approx in 14sec blocks) - Calculate in js example: let dailyInflation = web3.utils.toBN((1 + 0.05) ** (1 / (365)) * 1e18);
-            setSettingUint("rpl.inflation.interval.blocks", 6170);                                              // How often the inflation is calculated, if this is changed significantly, then the above 'rpl.inflation.interval.rate' will need to be adjusted. If inflation is no longer required, set 'rpl.inflation.interval.rate' to 0, not this parameter                
-            setSettingUint("rpl.inflation.interval.start", block.number+(getInflationIntervalBlocks()*14));     // Set the default start date for inflation to begin as 2 weeks from contract deployment (this can be changed after deployment)
+            setSettingUint("rpl.inflation.interval.rate", 1000133680617113500);                                 // 5% annual calculated on a daily interval - Calculate in js example: let dailyInflation = web3.utils.toBN((1 + 0.05) ** (1 / (365)) * 1e18);
+            setSettingUint("rpl.inflation.interval.time", 1 days);                                              // How often the inflation is calculated, if this is changed significantly, then the above 'rpl.inflation.interval.rate' will need to be adjusted. If inflation is no longer required, set 'rpl.inflation.interval.rate' to 0, not this parameter
+            setSettingUint("rpl.inflation.interval.start", block.timestamp + 14 days);                          // Set the default start date for inflation to begin as 2 weeks from contract deployment (this can be changed after deployment)
             // Deployment check
             setBool(keccak256(abi.encodePacked(settingNameSpace, "deployed")), true);                           // Flag that this contract has been deployed, so default settings don't get reapplied on a contract upgrade
         }
@@ -32,18 +32,18 @@ contract RocketDAOProtocolSettingsInflation is RocketDAOProtocolSettings, Rocket
     // Update a setting, overrides inherited setting method with extra checks for this contract
     function setSettingUint(string memory _settingPath, uint256 _value) override public onlyDAOProtocolProposal {
         // Some safety guards for certain settings
-        // Check the inflation block interval
-        if(keccak256(bytes(_settingPath)) == keccak256(bytes('rpl.inflation.interval.blocks'))) {
-                // Cannot be 0, set 'rpl.inflation.interval.rate' to 0 if inflation is no longer required
-                require(_value > 0, "Inflation interval block amount cannot be 0 or less");
+        // Check the inflation time interval
+        if(keccak256(bytes(_settingPath)) == keccak256(bytes('rpl.inflation.interval.time'))) {
+                // Must be >= 30 mins, set 'rpl.inflation.interval.rate' to 0 if inflation is no longer required
+                require(_value >= 1800, "Inflation interval must be greater than 1 hour");
         }
-        // The start blocks for inflation must be a future block and cannot be set again once started
+        // The start time for inflation must be in the future and cannot be set again once started
         if(keccak256(bytes(_settingPath)) == keccak256(bytes('rpl.inflation.interval.start'))) {
-                // Must be a block in the future
-                require(_value > block.number, "Inflation interval start block must be a future block");
+                // Must be a future timestamp
+                require(_value > block.timestamp, "Inflation interval start time must be in the future");
                 // If it's already set and started, a new start block cannot be set
-                if(getInflationIntervalStartBlock() > 0) {
-                    require(getInflationIntervalStartBlock() > block.number, "Inflation has already started");
+                if(getInflationIntervalStartTime() > 0) {
+                    require(getInflationIntervalStartTime() > block.timestamp, "Inflation has already started");
                 }
         }
         // Update setting now
@@ -58,13 +58,13 @@ contract RocketDAOProtocolSettingsInflation is RocketDAOProtocolSettings, Rocket
         return getSettingUint("rpl.inflation.interval.rate");
     }
     
-    // Inflation block interval (default is 6170 = 1 day approx in 14sec blocks) 
-    function getInflationIntervalBlocks() override public view returns (uint256) {
-        return getSettingUint("rpl.inflation.interval.blocks"); 
+    // Inflation block interval (default is 1 day)
+    function getInflationIntervalTime() override public view returns (uint256) {
+        return getSettingUint("rpl.inflation.interval.time");
     }
 
     // The block to start inflation at
-    function getInflationIntervalStartBlock() override public view returns (uint256) {
+    function getInflationIntervalStartTime() override public view returns (uint256) {
         return getSettingUint("rpl.inflation.interval.start"); 
     }
 

--- a/contracts/contract/dao/protocol/settings/RocketDAOProtocolSettingsRewards.sol
+++ b/contracts/contract/dao/protocol/settings/RocketDAOProtocolSettingsRewards.sol
@@ -23,7 +23,7 @@ contract RocketDAOProtocolSettingsRewards is RocketDAOProtocolSettings, RocketDA
             setSettingRewardsClaimer('rocketClaimNode', 0.70 ether);                                            // Bonded Node Rewards claim % amount - Percentage given of 1 ether
             setSettingRewardsClaimer('rocketClaimTrustedNode', 0.2 ether);                                      // Trusted Node Rewards claim % amount - Percentage given of 1 ether
             // RPL Claims settings
-            setSettingUint("rpl.rewards.claim.period.blocks", 86380);                                           // The period at which a claim period will span in blocks - 14 days approx by default
+            setSettingUint("rpl.rewards.claim.period.time", 14 days);                                           // The time in which a claim period will span in seconds - 14 days by default
             // Deployment check
             setBool(keccak256(abi.encodePacked(settingNameSpace, "deployed")), true);                           // Flag that this contract has been deployed, so default settings don't get reapplied on a contract upgrade
         }
@@ -44,8 +44,8 @@ contract RocketDAOProtocolSettingsRewards is RocketDAOProtocolSettings, RocketDA
         setUint(keccak256(abi.encodePacked(settingNameSpace,"rewards.claims", "group.totalPerc")), percTotalUpdate);
         // Update/Add the claimer amount
         setUint(keccak256(abi.encodePacked(settingNameSpace, "rewards.claims", "group.amount", _contractName)), _perc);
-        // Set the block it was updated at
-        setUint(keccak256(abi.encodePacked(settingNameSpace, "rewards.claims", "group.amount.updated.block", _contractName)), block.number);
+        // Set the time it was updated at
+        setUint(keccak256(abi.encodePacked(settingNameSpace, "rewards.claims", "group.amount.updated.time", _contractName)), block.timestamp);
     }
 
 
@@ -61,8 +61,8 @@ contract RocketDAOProtocolSettingsRewards is RocketDAOProtocolSettings, RocketDA
     } 
 
     // Get the perc amount that this rewards contract get claim
-    function getRewardsClaimerPercBlockUpdated(string memory _contractName) override public view returns (uint256) {
-        return getUint(keccak256(abi.encodePacked(settingNameSpace, "rewards.claims", "group.amount.updated.block", _contractName)));
+    function getRewardsClaimerPercTimeUpdated(string memory _contractName) override public view returns (uint256) {
+        return getUint(keccak256(abi.encodePacked(settingNameSpace, "rewards.claims", "group.amount.updated.time", _contractName)));
     } 
 
     // Get the perc amount total for all claimers (remaining goes to DAO)
@@ -74,8 +74,8 @@ contract RocketDAOProtocolSettingsRewards is RocketDAOProtocolSettings, RocketDA
     // RPL Rewards General Settings
 
     // The period over which claims can be made
-    function getRewardsClaimIntervalBlocks() override external view returns (uint256) {
-        return getSettingUint("rpl.rewards.claim.period.blocks");
+    function getRewardsClaimIntervalTime() override external view returns (uint256) {
+        return getSettingUint("rpl.rewards.claim.period.time");
     }
 
 

--- a/contracts/contract/dao/protocol/settings/RocketDAOProtocolSettingsRewards.sol
+++ b/contracts/contract/dao/protocol/settings/RocketDAOProtocolSettingsRewards.sol
@@ -60,7 +60,7 @@ contract RocketDAOProtocolSettingsRewards is RocketDAOProtocolSettings, RocketDA
         return getUint(keccak256(abi.encodePacked(settingNameSpace, "rewards.claims", "group.amount", _contractName)));
     } 
 
-    // Get the perc amount that this rewards contract get claim
+    // Get the time of when the claim perc was last updated
     function getRewardsClaimerPercTimeUpdated(string memory _contractName) override public view returns (uint256) {
         return getUint(keccak256(abi.encodePacked(settingNameSpace, "rewards.claims", "group.amount.updated.time", _contractName)));
     } 

--- a/contracts/contract/node/RocketNodeStaking.sol
+++ b/contracts/contract/node/RocketNodeStaking.sol
@@ -62,12 +62,12 @@ contract RocketNodeStaking is RocketBase, RocketNodeStakingInterface {
         setNodeRPLStake(_nodeAddress, getNodeRPLStake(_nodeAddress).sub(_amount));
     }
 
-    // Get/set the block a node last staked RPL at
-    function getNodeRPLStakedBlock(address _nodeAddress) override public view returns (uint256) {
-        return getUint(keccak256(abi.encodePacked("rpl.staked.node.block", _nodeAddress)));
+    // Get/set the time a node last staked RPL at
+    function getNodeRPLStakedTime(address _nodeAddress) override public view returns (uint256) {
+        return getUint(keccak256(abi.encodePacked("rpl.staked.node.time", _nodeAddress)));
     }
-    function setNodeRPLStakedBlock(address _nodeAddress, uint256 _block) private {
-        setUint(keccak256(abi.encodePacked("rpl.staked.node.block", _nodeAddress)), _block);
+    function setNodeRPLStakedTime(address _nodeAddress, uint256 _time) private {
+        setUint(keccak256(abi.encodePacked("rpl.staked.node.time", _nodeAddress)), _time);
     }
 
     // Get the total effective RPL stake amount
@@ -167,7 +167,7 @@ contract RocketNodeStaking is RocketBase, RocketNodeStakingInterface {
         // Update RPL stake amounts & node RPL staked block
         increaseTotalRPLStake(_amount);
         increaseNodeRPLStake(msg.sender, _amount);
-        setNodeRPLStakedBlock(msg.sender, block.number);
+        setNodeRPLStakedTime(msg.sender, block.timestamp);
         // Emit RPL staked event
         emit RPLStaked(msg.sender, _amount, block.timestamp);
     }
@@ -179,7 +179,7 @@ contract RocketNodeStaking is RocketBase, RocketNodeStakingInterface {
         RocketDAOProtocolSettingsRewardsInterface rocketDAOProtocolSettingsRewards = RocketDAOProtocolSettingsRewardsInterface(getContractAddress("rocketDAOProtocolSettingsRewards"));
         RocketVaultInterface rocketVault = RocketVaultInterface(getContractAddress("rocketVault"));
         // Check cooldown period (one claim period) has passed since RPL last staked
-        require(block.number.sub(getNodeRPLStakedBlock(msg.sender)) >= rocketDAOProtocolSettingsRewards.getRewardsClaimIntervalBlocks(), "The withdrawal cooldown period has not passed");
+        require(block.timestamp.sub(getNodeRPLStakedTime(msg.sender)) >= rocketDAOProtocolSettingsRewards.getRewardsClaimIntervalTime(), "The withdrawal cooldown period has not passed");
         // Get & check node's current RPL stake
         uint256 rplStake = getNodeRPLStake(msg.sender);
         require(rplStake >= _amount, "Withdrawal amount exceeds node's staked RPL balance");

--- a/contracts/contract/token/RocketTokenRPL.sol
+++ b/contracts/contract/token/RocketTokenRPL.sol
@@ -68,7 +68,7 @@ contract RocketTokenRPL is RocketBase, ERC20Burnable, RocketTokenRPLInterface {
     * How many seconds to calculate inflation at
     * @return uint256 how many seconds to calculate inflation at
     */
-    function getInflationIntervalTime() override public view returns(uint256) {
+    function getInflationIntervalTime() override public pure returns(uint256) {
         return inflationInterval;
     }
 

--- a/contracts/contract/token/RocketTokenRPL.sol
+++ b/contracts/contract/token/RocketTokenRPL.sol
@@ -22,6 +22,8 @@ contract RocketTokenRPL is RocketBase, ERC20Burnable, RocketTokenRPLInterface {
 
     // How many RPL tokens minted to date (18m from fixed supply)
     uint256 constant totalInitialSupply = 18000000000000000000000000;
+    // The RPL inflation interval
+    uint256 constant inflationInterval = 1 days;
     // How many RPL tokens have been swapped for new ones
     uint256 public totalSwappedRPL = 0;
 
@@ -67,8 +69,7 @@ contract RocketTokenRPL is RocketBase, ERC20Burnable, RocketTokenRPLInterface {
     * @return uint256 how many seconds to calculate inflation at
     */
     function getInflationIntervalTime() override public view returns(uint256) {
-        RocketDAOProtocolSettingsInflationInterface daoSettingsInflation = RocketDAOProtocolSettingsInflationInterface(getContractAddress('rocketDAOProtocolSettingsInflation'));
-        return daoSettingsInflation.getInflationIntervalTime();
+        return inflationInterval;
     }
 
     /**
@@ -108,8 +109,6 @@ contract RocketTokenRPL is RocketBase, ERC20Burnable, RocketTokenRPLInterface {
     function getInflationIntervalsPassed() override public view returns(uint256) {
         // The time that inflation was last calculated at
         uint256 inflationLastCalculatedTime = getInflationCalcTime();
-        // Get the daily inflation in seconds
-        uint256 inflationInterval = getInflationIntervalTime();
         // Calculate now if inflation has begun
         if(inflationLastCalculatedTime > 0) {
             return (block.timestamp).sub(inflationLastCalculatedTime).div(inflationInterval);
@@ -162,7 +161,7 @@ contract RocketTokenRPL is RocketBase, ERC20Burnable, RocketTokenRPLInterface {
         // Lets check
         require(newTokens > 0 && rocketVaultAddress != address(0x0), "New tokens cannot be minted at the moment, either no intervals have passed, inflation has not begun or inflation rate is set to 0");
         // Update last inflation calculation timestamp
-        inflationCalcTime = getInflationCalcTime().add(getInflationIntervalTime().mul(getInflationIntervalsPassed()));
+        inflationCalcTime = getInflationCalcTime().add(inflationInterval.mul(getInflationIntervalsPassed()));
         // Mint to itself, then allocate tokens for transfer to rewards contract, this will update balance & supply
         _mint(address(this), newTokens);
         // Initialise itself and allow from it's own balance (cant just do an allow as it could be any user calling this so they are msg.sender)

--- a/contracts/contract/token/RocketTokenRPL.sol
+++ b/contracts/contract/token/RocketTokenRPL.sol
@@ -26,7 +26,7 @@ contract RocketTokenRPL is RocketBase, ERC20Burnable, RocketTokenRPLInterface {
     uint256 public totalSwappedRPL = 0;
 
     // Last block inflation was calculated at
-    uint256 private inflationCalcBlock = 0;
+    uint256 private inflationCalcTime = 0;
 
 
     /**** Contracts ************/
@@ -37,7 +37,7 @@ contract RocketTokenRPL is RocketBase, ERC20Burnable, RocketTokenRPLInterface {
 
     /**** Events ***********/
     
-    event RPLInflationLog(address sender, uint256 value, uint256 inflationCalcBlock);
+    event RPLInflationLog(address sender, uint256 value, uint256 inflationCalcTime);
     event RPLFixedSupplyBurn(address indexed from, uint256 amount, uint256 time);
 
 
@@ -52,23 +52,23 @@ contract RocketTokenRPL is RocketBase, ERC20Burnable, RocketTokenRPLInterface {
     }
 
     /**
-    * Get the last block that inflation was calculated at
-    * @return uint256 Last block since inflation was calculated
+    * Get the last time that inflation was calculated at
+    * @return uint256 Last timestamp since inflation was calculated
     */
-    function getInflationCalcBlock() override public view returns(uint256) {
+    function getInflationCalcTime() override public view returns(uint256) {
         // Get the last time inflation was calculated if it has even started
-        uint256 inflationStartBlock = getInflationIntervalStartBlock();
+        uint256 inflationStartTime = getInflationIntervalStartTime();
         // If inflation has just begun but not been calculated previously, use the start block as the last calculated point if it has passed
-        return inflationCalcBlock == 0 && inflationStartBlock < block.number ? inflationStartBlock : inflationCalcBlock;
+        return inflationCalcTime == 0 && inflationStartTime < block.timestamp ? inflationStartTime : inflationCalcTime;
     }
 
     /**
-    * How many blocks to calculate inflation at (5760 = 1 day in 15sec blocks)
-    * @return uint256 ow many blocks to calculate inflation at
+    * How many seconds to calculate inflation at
+    * @return uint256 how many seconds to calculate inflation at
     */
-    function getInflationIntervalBlocks() override public view returns(uint256) {
+    function getInflationIntervalTime() override public view returns(uint256) {
         RocketDAOProtocolSettingsInflationInterface daoSettingsInflation = RocketDAOProtocolSettingsInflationInterface(getContractAddress('rocketDAOProtocolSettingsInflation'));
-        return daoSettingsInflation.getInflationIntervalBlocks();
+        return daoSettingsInflation.getInflationIntervalTime();
     }
 
     /**
@@ -85,10 +85,10 @@ contract RocketTokenRPL is RocketBase, ERC20Burnable, RocketTokenRPLInterface {
     * The current block to begin inflation at
     * @return uint256 The current block to begin inflation at
     */
-    function getInflationIntervalStartBlock() override public view returns(uint256) {
-        // Inflation rate start block controlled by the DAO
+    function getInflationIntervalStartTime() override public view returns(uint256) {
+        // Inflation rate start time controlled by the DAO
         RocketDAOProtocolSettingsInflationInterface daoSettingsInflation = RocketDAOProtocolSettingsInflationInterface(getContractAddress('rocketDAOProtocolSettingsInflation'));
-        return daoSettingsInflation.getInflationIntervalStartBlock();
+        return daoSettingsInflation.getInflationIntervalStartTime();
     }
 
     /**
@@ -106,13 +106,13 @@ contract RocketTokenRPL is RocketBase, ERC20Burnable, RocketTokenRPLInterface {
     * @return uint256 Time intervals since last update
     */
     function getInflationIntervalsPassed() override public view returns(uint256) {
-        // The block that inflation was last calculated at
-        uint256 inflationLastCalculatedBlock = getInflationCalcBlock();
-        // Get the daily inflation in blocks
-        uint256 inflationInterval = getInflationIntervalBlocks();
+        // The time that inflation was last calculated at
+        uint256 inflationLastCalculatedTime = getInflationCalcTime();
+        // Get the daily inflation in seconds
+        uint256 inflationInterval = getInflationIntervalTime();
         // Calculate now if inflation has begun
-        if(inflationLastCalculatedBlock > 0) {
-            return (block.number).sub(inflationLastCalculatedBlock).div(inflationInterval);
+        if(inflationLastCalculatedTime > 0) {
+            return (block.timestamp).sub(inflationLastCalculatedTime).div(inflationInterval);
         }else{
             return 0;
         }
@@ -161,9 +161,9 @@ contract RocketTokenRPL is RocketBase, ERC20Burnable, RocketTokenRPLInterface {
         RocketVaultInterface rocketVaultContract = RocketVaultInterface(rocketVaultAddress);
         // Lets check
         require(newTokens > 0 && rocketVaultAddress != address(0x0), "New tokens cannot be minted at the moment, either no intervals have passed, inflation has not begun or inflation rate is set to 0");
-        // Update last inflation calculation block
-        inflationCalcBlock = getInflationCalcBlock().add(getInflationIntervalBlocks().mul(getInflationIntervalsPassed()));
-        // Miint to itself, then allocate tokens for transfer to rewards contract, this will Update balance & supply
+        // Update last inflation calculation timestamp
+        inflationCalcTime = getInflationCalcTime().add(getInflationIntervalTime().mul(getInflationIntervalsPassed()));
+        // Mint to itself, then allocate tokens for transfer to rewards contract, this will update balance & supply
         _mint(address(this), newTokens);
         // Initialise itself and allow from it's own balance (cant just do an allow as it could be any user calling this so they are msg.sender)
         IERC20 rplInflationContract = IERC20(address(this));
@@ -176,7 +176,7 @@ contract RocketTokenRPL is RocketBase, ERC20Burnable, RocketTokenRPLInterface {
         // Let vault know it can move these tokens to itself now and credit the balance to the RPL rewards pool contract
         require(rocketVaultContract.depositToken('rocketRewardsPool', IERC20(address(this)), newTokens), "Rocket Vault deposit was not successful");
         // Log it
-        emit RPLInflationLog(msg.sender, newTokens, inflationCalcBlock);
+        emit RPLInflationLog(msg.sender, newTokens, inflationCalcTime);
         // return number minted
         return newTokens;
     }   

--- a/contracts/interface/dao/protocol/settings/RocketDAOProtocolSettingsInflationInterface.sol
+++ b/contracts/interface/dao/protocol/settings/RocketDAOProtocolSettingsInflationInterface.sol
@@ -4,6 +4,5 @@ pragma solidity 0.7.6;
 
 interface RocketDAOProtocolSettingsInflationInterface {
     function getInflationIntervalRate() external view returns (uint256);
-    function getInflationIntervalTime() external view returns (uint256);
     function getInflationIntervalStartTime() external view returns (uint256);
 }

--- a/contracts/interface/dao/protocol/settings/RocketDAOProtocolSettingsInflationInterface.sol
+++ b/contracts/interface/dao/protocol/settings/RocketDAOProtocolSettingsInflationInterface.sol
@@ -4,6 +4,6 @@ pragma solidity 0.7.6;
 
 interface RocketDAOProtocolSettingsInflationInterface {
     function getInflationIntervalRate() external view returns (uint256);
-    function getInflationIntervalBlocks() external view returns (uint256);
-    function getInflationIntervalStartBlock() external view returns (uint256);
+    function getInflationIntervalTime() external view returns (uint256);
+    function getInflationIntervalStartTime() external view returns (uint256);
 }

--- a/contracts/interface/dao/protocol/settings/RocketDAOProtocolSettingsRewardsInterface.sol
+++ b/contracts/interface/dao/protocol/settings/RocketDAOProtocolSettingsRewardsInterface.sol
@@ -5,7 +5,7 @@ pragma solidity 0.7.6;
 interface RocketDAOProtocolSettingsRewardsInterface {
     function setSettingRewardsClaimer(string memory _contractName, uint256 _perc) external;
     function getRewardsClaimerPerc(string memory _contractName) external view returns (uint256);
-    function getRewardsClaimerPercBlockUpdated(string memory _contractName) external view returns (uint256);
+    function getRewardsClaimerPercTimeUpdated(string memory _contractName) external view returns (uint256);
     function getRewardsClaimersPercTotal() external view returns (uint256);
-    function getRewardsClaimIntervalBlocks() external view returns (uint256);
+    function getRewardsClaimIntervalTime() external view returns (uint256);
 }

--- a/contracts/interface/node/RocketNodeStakingInterface.sol
+++ b/contracts/interface/node/RocketNodeStakingInterface.sol
@@ -5,7 +5,7 @@ pragma solidity 0.7.6;
 interface RocketNodeStakingInterface {
     function getTotalRPLStake() external view returns (uint256);
     function getNodeRPLStake(address _nodeAddress) external view returns (uint256);
-    function getNodeRPLStakedBlock(address _nodeAddress) external view returns (uint256);
+    function getNodeRPLStakedTime(address _nodeAddress) external view returns (uint256);
     function getTotalEffectiveRPLStake() external view returns (uint256);
     function getNodeEffectiveRPLStake(address _nodeAddress) external view returns (uint256);
     function getNodeMinimumRPLStake(address _nodeAddress) external view returns (uint256);

--- a/contracts/interface/rewards/RocketRewardsPoolInterface.sol
+++ b/contracts/interface/rewards/RocketRewardsPoolInterface.sol
@@ -4,18 +4,18 @@ pragma solidity 0.7.6;
 
 interface RocketRewardsPoolInterface {
     function getRPLBalance() external view returns(uint256);
-    function getClaimIntervalBlockStart() external view returns(uint256);
-    function getClaimIntervalBlockStartComputed() external view returns(uint256);
+    function getClaimIntervalTimeStart() external view returns(uint256);
+    function getClaimIntervalTimeStartComputed() external view returns(uint256);
     function getClaimIntervalsPassed() external view returns(uint256);
-    function getClaimIntervalBlocks() external view returns(uint256);
-    function getClaimBlockLastMade() external view returns(uint256);
+    function getClaimIntervalTime() external view returns(uint256);
+    function getClaimTimeLastMade() external view returns(uint256);
     function getClaimIntervalRewardsTotal() external view returns(uint256);
     function getClaimingContractTotalClaimed(string memory _claimingContract) external view returns(uint256);
     function getClaimingContractUserTotalNext(string memory _claimingContract) external view returns(uint256);
     function getClaimingContractUserTotalCurrent(string memory _claimingContract) external view returns(uint256);  
-    function getClaimingContractUserHasClaimed(uint256 _claimIntervalStartBlock, string memory _claimingContract, address _claimerAddress) external view returns(bool);
+    function getClaimingContractUserHasClaimed(uint256 _claimIntervalStartTime, string memory _claimingContract, address _claimerAddress) external view returns(bool);
     function getClaimingContractUserCanClaim(string memory _claimingContract, address _claimerAddress) external view returns(bool);
-    function getClaimingContractUserRegisteredBlock(string memory _claimingContract, address _claimerAddress) external view returns(uint256);  
+    function getClaimingContractUserRegisteredTime(string memory _claimingContract, address _claimerAddress) external view returns(uint256);
     function getClaimingContractAllowance(string memory _claimingContract) external view returns(uint256);
     function getClaimingContractPerc(string memory _claimingContract) external view returns(uint256);
     function getClaimingContractPercLast(string memory _claimingContract) external view returns(uint256);

--- a/contracts/interface/token/RocketTokenRPLInterface.sol
+++ b/contracts/interface/token/RocketTokenRPLInterface.sol
@@ -5,11 +5,11 @@ pragma solidity 0.7.6;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 interface RocketTokenRPLInterface is IERC20 {
-    function getInflationCalcBlock() external view returns(uint256);
-    function getInflationIntervalBlocks() external view returns(uint256);
+    function getInflationCalcTime() external view returns(uint256);
+    function getInflationIntervalTime() external view returns(uint256);
     function getInflationIntervalRate() external view returns(uint256);
     function getInflationIntervalsPassed() external view returns(uint256);
-    function getInflationIntervalStartBlock() external view returns(uint256);
+    function getInflationIntervalStartTime() external view returns(uint256);
     function getInflationRewardsContractAddress() external view returns(address);
     function inflationCalculate() external view returns (uint256);
     function inflationMintTokens() external returns (uint256);

--- a/test/_utils/evm.js
+++ b/test/_utils/evm.js
@@ -46,3 +46,24 @@ export async function mineBlocks(web3, numBlocks) {
     }
 }
 
+// Fast-forward time
+export async function increaseTime(web3, seconds) {
+    await new Promise((resolve, reject) => {
+        web3.currentProvider.send({
+            jsonrpc: '2.0',
+            method: 'evm_increaseTime',
+            params: [seconds],
+            id: (new Date()).getTime(),
+        }, function(err, response) {
+            if (err) { reject(err); }
+            else { resolve(); }
+        });
+    });
+    // Mine a block using the new time
+    await mineBlocks(web3, 1);
+}
+
+// Retrieve current time on block chain
+export async function getCurrentTime(web3) {
+    return (await web3.eth.getBlock('latest')).timestamp
+}

--- a/test/dao/scenario-dao-protocol-bootstrap.js
+++ b/test/dao/scenario-dao-protocol-bootstrap.js
@@ -86,7 +86,7 @@ export async function setDAONetworkBootstrapRewardsClaimer(_contractName, _perc,
 
 /*** Rewards *******/
 
-// Set the current rewards claim period in blocks
+// Set the current rewards claim period in seconds
 export async function setRewardsClaimIntervalTime(intervalTime, txOptions) {
     // Set it now
     await setDAOProtocolBootstrapSetting(RocketDAOProtocolSettingsRewards, 'rpl.rewards.claim.period.time', intervalTime, txOptions);

--- a/test/dao/scenario-dao-protocol-bootstrap.js
+++ b/test/dao/scenario-dao-protocol-bootstrap.js
@@ -141,11 +141,6 @@ export async function setRPLInflationIntervalRate(yearlyInflationPerc, txOptions
     await setDAOProtocolBootstrapSetting(RocketDAOProtocolSettingsInflation, 'rpl.inflation.interval.rate', dailyInflation, txOptions);
 };
 
-// Set the current RPL inflation rate blocks, how often inflation is calculated
-export async function setRPLInflationIntervalTime(intervalTime, txOptions) {
-    // Set it now
-    await setDAOProtocolBootstrapSetting(RocketDAOProtocolSettingsInflation, 'rpl.inflation.interval.time', intervalTime, txOptions);
-};
 
 // Set the current RPL inflation block interval
 export async function setRPLInflationStartTime(startTime, txOptions) {

--- a/test/dao/scenario-dao-protocol-bootstrap.js
+++ b/test/dao/scenario-dao-protocol-bootstrap.js
@@ -87,9 +87,9 @@ export async function setDAONetworkBootstrapRewardsClaimer(_contractName, _perc,
 /*** Rewards *******/
 
 // Set the current rewards claim period in blocks
-export async function setRewardsClaimIntervalBlocks(intervalBlocks, txOptions) {
+export async function setRewardsClaimIntervalTime(intervalTime, txOptions) {
     // Set it now
-    await setDAOProtocolBootstrapSetting(RocketDAOProtocolSettingsRewards, 'rpl.rewards.claim.period.blocks', intervalBlocks, txOptions);
+    await setDAOProtocolBootstrapSetting(RocketDAOProtocolSettingsRewards, 'rpl.rewards.claim.period.time', intervalTime, txOptions);
 };
 
 
@@ -142,15 +142,15 @@ export async function setRPLInflationIntervalRate(yearlyInflationPerc, txOptions
 };
 
 // Set the current RPL inflation rate blocks, how often inflation is calculated
-export async function setRPLInflationIntervalBlocks(intervalBlocks, txOptions) {
+export async function setRPLInflationIntervalTime(intervalTime, txOptions) {
     // Set it now
-    await setDAOProtocolBootstrapSetting(RocketDAOProtocolSettingsInflation, 'rpl.inflation.interval.blocks', intervalBlocks, txOptions);
+    await setDAOProtocolBootstrapSetting(RocketDAOProtocolSettingsInflation, 'rpl.inflation.interval.time', intervalTime, txOptions);
 };
 
 // Set the current RPL inflation block interval
-export async function setRPLInflationStartBlock(startBlock, txOptions) {
+export async function setRPLInflationStartTime(startTime, txOptions) {
     // Set it now
-    await setDAOProtocolBootstrapSetting(RocketDAOProtocolSettingsInflation, 'rpl.inflation.interval.start', startBlock, txOptions);
+    await setDAOProtocolBootstrapSetting(RocketDAOProtocolSettingsInflation, 'rpl.inflation.interval.start', startTime, txOptions);
 };
 
 

--- a/test/node/node-staking-tests.js
+++ b/test/node/node-staking-tests.js
@@ -6,7 +6,7 @@ import { registerNode, nodeStakeRPL, nodeDeposit } from '../_helpers/node';
 import { mintRPL, approveRPL } from '../_helpers/tokens';
 import { stakeRpl } from './scenario-stake-rpl';
 import { withdrawRpl } from './scenario-withdraw-rpl';
-import { setRewardsClaimIntervalBlocks } from '../dao/scenario-dao-protocol-bootstrap';
+import { setRewardsClaimIntervalTime } from '../dao/scenario-dao-protocol-bootstrap'
 
 export default function() {
     contract('RocketNodeStaking', async (accounts) => {
@@ -87,7 +87,7 @@ export default function() {
             const rplAmount = web3.utils.toWei('10000', 'ether');
 
             // Remove withdrawal cooldown period
-            await setRewardsClaimIntervalBlocks(0, {from: owner});
+            await setRewardsClaimIntervalTime(0, {from: owner});
 
             // Stake RPL
             await nodeStakeRPL(rplAmount, {from: node});
@@ -123,7 +123,7 @@ export default function() {
             const withdrawAmount = web3.utils.toWei('20000', 'ether');
 
             // Remove withdrawal cooldown period
-            await setRewardsClaimIntervalBlocks(0, {from: owner});
+            await setRewardsClaimIntervalTime(0, {from: owner});
 
             // Stake RPL
             await nodeStakeRPL(stakeAmount, {from: node});
@@ -142,7 +142,7 @@ export default function() {
             const rplAmount = web3.utils.toWei('10000', 'ether');
 
             // Remove withdrawal cooldown period
-            await setRewardsClaimIntervalBlocks(0, {from: owner});
+            await setRewardsClaimIntervalTime(0, {from: owner});
 
             // Stake RPL
             await nodeStakeRPL(rplAmount, {from: node});
@@ -164,7 +164,7 @@ export default function() {
             const rplAmount = web3.utils.toWei('10000', 'ether');
 
             // Remove withdrawal cooldown period
-            await setRewardsClaimIntervalBlocks(0, {from: owner});
+            await setRewardsClaimIntervalTime(0, {from: owner});
 
             // Stake RPL
             await nodeStakeRPL(rplAmount, {from: node});

--- a/test/rewards/scenario-rewards-claim-node.js
+++ b/test/rewards/scenario-rewards-claim-node.js
@@ -37,11 +37,11 @@ export async function rewardsClaimNode(txOptions) {
     // Get balances
     function getBalances() {
         return Promise.all([
-            rocketRewardsPool.getClaimIntervalBlockStart(),
+            rocketRewardsPool.getClaimIntervalTimeStart(),
             rocketTokenRPL.balanceOf.call(nodeWithdrawalAddress),
         ]).then(
-            ([claimIntervalBlockStart, nodeRpl]) =>
-            ({claimIntervalBlockStart, nodeRpl})
+            ([claimIntervalTimeStart, nodeRpl]) =>
+            ({claimIntervalTimeStart, nodeRpl})
         );
     }
 
@@ -65,11 +65,9 @@ export async function rewardsClaimNode(txOptions) {
     let claimPerc = calcBase.mul(details2.nodeRplStake).div(details2.totalRplStake);
     let expectedClaimAmount = details2.nodesRplShare.mul(claimPerc).div(calcBase);
 
-    // console.log(Number(balances1.claimIntervalBlockStart), Number(balances2.claimIntervalBlockStart));
+    // console.log(Number(balances1.claimIntervalTimeStart), Number(balances2.claimIntervalTimeStart));
     // console.log(web3.utils.fromWei(balances2.nodeRpl.sub(balances1.nodeRpl)), web3.utils.fromWei(expectedClaimAmount));
 
     // Check balances
     assert(balances2.nodeRpl.sub(balances1.nodeRpl).eq(expectedClaimAmount), 'Incorrect updated node RPL balance');
-
 }
-

--- a/test/rewards/scenario-rewards-claim-trusted-node.js
+++ b/test/rewards/scenario-rewards-claim-trusted-node.js
@@ -1,5 +1,5 @@
 import { RocketRewardsPool, RocketClaimTrustedNode } from '../_utils/artifacts';
-
+import { getCurrentTime } from '../_utils/evm'
 
 // Can this trusted node make a claim yet? They need to wait 1 claim interval after being made a trusted node
 export async function rewardsClaimTrustedNodePossibleGet(trustedNodeAddress, txOptions) {
@@ -8,13 +8,13 @@ export async function rewardsClaimTrustedNodePossibleGet(trustedNodeAddress, txO
     return await rocketClaimTrustedNode.getClaimPossible.call(trustedNodeAddress);
 };
 
-// Get the current rewards claim period in blocks
-export async function rewardsClaimTrustedNodeRegisteredBlockGet(trustedNodeAddress, txOptions) {
+// Get the current rewards claim period in seconds
+export async function rewardsClaimTrustedNodeRegisteredTimeGet(trustedNodeAddress, txOptions) {
     // Load contracts
     const rocketRewardsPool = await RocketRewardsPool.deployed();
     const rocketClaimTrustedNode = await RocketClaimTrustedNode.deployed();
     // Do it
-    return await rocketRewardsPool.getClaimContractRegisteredBlock.call(rocketClaimTrustedNode.address, trustedNodeAddress);
+    return await rocketRewardsPool.getClaimContractRegisteredTime.call(rocketClaimTrustedNode.address, trustedNodeAddress);
 };
 
 // Perform rewards claims for Trusted Nodes + Minipools
@@ -28,23 +28,23 @@ export async function rewardsClaimTrustedNode(trusedNodeAccount, txOptions) {
     // Get data about the tx
     function getTxData() {
         return Promise.all([
-            web3.eth.getBlockNumber(),
-            rocketRewardsPool.getClaimIntervalBlockStart(),
+            getCurrentTime(web3),
+            rocketRewardsPool.getClaimIntervalTimeStart(),
             rocketRewardsPool.getClaimingContractAllowance('rocketClaimTrustedNode'),
             rocketRewardsPool.getClaimingContractTotalClaimed('rocketClaimTrustedNode'),
             rocketRewardsPool.getClaimingContractPerc('rocketClaimTrustedNode'),
             rocketClaimTrustedNode.getClaimRewardsAmount.call(txOptions.from),
             rocketRewardsPool.getClaimingContractUserTotalCurrent('rocketClaimTrustedNode')
         ]).then(
-            ([currentBlock, claimIntervalBlockStart, contractClaimAllowance, contractClaimTotal, contractClaimPerc, trustedNodeClaimAmount, trustedNodeClaimIntervalTotal]) =>
-            ({currentBlock, claimIntervalBlockStart, contractClaimAllowance, contractClaimTotal, contractClaimPerc, trustedNodeClaimAmount, trustedNodeClaimIntervalTotal})
+            ([currentTime, claimIntervalTimeStart, contractClaimAllowance, contractClaimTotal, contractClaimPerc, trustedNodeClaimAmount, trustedNodeClaimIntervalTotal]) =>
+            ({currentTime, claimIntervalTimeStart, contractClaimAllowance, contractClaimTotal, contractClaimPerc, trustedNodeClaimAmount, trustedNodeClaimIntervalTotal})
         );
     }
 
     // Capture data
     let ds1 = await getTxData();
 
-    //console.log('Node DAO Contract Amount', Number(web3.utils.fromWei(ds1.currentBlock)), Number(web3.utils.fromWei(ds1.claimIntervalBlockStart)));
+    //console.log('Node DAO Contract Amount', Number(web3.utils.fromWei(ds1.currentTime)), Number(web3.utils.fromWei(ds1.claimIntervalTimeStart)));
 
     // Perform tx
     let tx = await rocketClaimTrustedNode.claim(txOptions);
@@ -54,14 +54,14 @@ export async function rewardsClaimTrustedNode(trusedNodeAccount, txOptions) {
     // Capture data
     let ds2 = await getTxData();
 
-    //console.log('Node DAO Contract Amount', Number(web3.utils.fromWei(ds2.currentBlock)), Number(web3.utils.fromWei(ds2.claimIntervalBlockStart)));
+    //console.log('Node DAO Contract Amount', Number(web3.utils.fromWei(ds2.currentTime)), Number(web3.utils.fromWei(ds2.claimIntervalTimeStart)));
 
     // Verify 
-    if(Number(ds1.claimIntervalBlockStart) == Number(ds2.claimIntervalBlockStart)) {
+    if(Number(ds1.claimIntervalTimeStart) === Number(ds2.claimIntervalTimeStart)) {
         // Claim occured in the same interval
         assert(ds2.contractClaimTotal.eq(ds1.contractClaimTotal.add(ds1.trustedNodeClaimAmount)), 'Contract claim amount total incorrect');
         // How many trusted nodes where in this interval? Their % claimed should be equal to that
-        assert(Number(web3.utils.fromWei(ds1.trustedNodeClaimAmount)).toFixed(4) == Number(web3.utils.fromWei(ds2.contractClaimAllowance.div(ds2.trustedNodeClaimIntervalTotal))).toFixed(4), 'Contract claim amount should be equal to their desired equal allocation');
+        assert(Number(web3.utils.fromWei(ds1.trustedNodeClaimAmount)).toFixed(4) === Number(web3.utils.fromWei(ds2.contractClaimAllowance.div(ds2.trustedNodeClaimIntervalTotal))).toFixed(4), 'Contract claim amount should be equal to their desired equal allocation');
         // The contracts claim perc should never change after a claim in the same interval
         assert(ds1.contractClaimPerc.eq(ds2.contractClaimPerc), "Contracts claiming percentage changed in an interval");
     }else{
@@ -69,15 +69,9 @@ export async function rewardsClaimTrustedNode(trusedNodeAccount, txOptions) {
         // The contracts claim total should be greater than 0 due to the claim that just occured
         assert(ds2.contractClaimTotal.gt(0), 'Contract claim amount should be > 0 for new interval');
         // How many trusted nodes where in this interval? Their % claimed should be equal to that
-        assert(Number(web3.utils.fromWei(ds2.contractClaimTotal)).toFixed(4) == Number(web3.utils.fromWei(ds2.contractClaimAllowance.div(ds2.trustedNodeClaimIntervalTotal))).toFixed(4), 'Contract claim amount should be equal to their desired equal allocation');
+        assert(Number(web3.utils.fromWei(ds2.contractClaimTotal)).toFixed(4) === Number(web3.utils.fromWei(ds2.contractClaimAllowance.div(ds2.trustedNodeClaimIntervalTotal))).toFixed(4), 'Contract claim amount should be equal to their desired equal allocation');
     }
     // Always verify
     // Can't claim more than contracts allowance
     assert(ds2.contractClaimTotal.lte(ds2.contractClaimAllowance), 'Trusted node claimed more than contracts allowance');
-    
-    
-
-  
 };
-
-

--- a/test/rewards/scenario-rewards-claim.js
+++ b/test/rewards/scenario-rewards-claim.js
@@ -1,12 +1,11 @@
-import { mineBlocks } from '../_utils/evm';
-import { RocketTokenRPL, RocketDAOProtocol, RocketDAOProtocolSettingsRewards, RocketRewardsPool } from '../_utils/artifacts';
+import { RocketDAOProtocolSettingsRewards, RocketRewardsPool } from '../_utils/artifacts';
 
 
 // Get the current rewards claim period in blocks
-export async function rewardsClaimIntervalBlocksGet(txOptions) {
+export async function rewardsClaimIntervalTimeGet(txOptions) {
     // Load contracts
     const rocketDAOProtocolSettingsRewards = await RocketDAOProtocolSettingsRewards.deployed();
-    return await rocketDAOProtocolSettingsRewards.getClaimIntervalBlocks.call();
+    return await rocketDAOProtocolSettingsRewards.getClaimIntervalTime.call();
 };
 
 
@@ -18,7 +17,7 @@ export async function rewardsClaimersPercTotalGet(txOptions) {
 };
 
 
-// Get how many blocks needed until the next claim interval
+// Get how many seconds needed until the next claim interval
 export async function rewardsClaimIntervalsPassedGet(txOptions) {
     // Load contracts
     const rocketRewardsPool = await RocketRewardsPool.deployed();

--- a/test/token/rpl-tests.js
+++ b/test/token/rpl-tests.js
@@ -21,6 +21,8 @@ export default function() {
             userOne,
         ] = accounts;
 
+        // One day in seconds
+        const ONE_DAY = 24 * 60 * 60;
 
         // State snapshotting
         let snapshotId;
@@ -173,7 +175,6 @@ export default function() {
             let currentTime = await getCurrentTime(web3);
 
             let config = {
-                timeInterval: 3600,
                 timeStart: currentTime + 3600,
                 timeClaim: currentTime + 1800,
                 yearlyInflationTarget: 0.05
@@ -192,7 +193,6 @@ export default function() {
             let currentTime = await getCurrentTime(web3);
 
             let config = {
-                timeInterval: 3600,
                 timeStart: currentTime + 1800,
                 timeClaim: currentTime + 3600,      // Mid way through first interval
                 yearlyInflationTarget: 0.05
@@ -211,9 +211,9 @@ export default function() {
             let currentTime = await getCurrentTime(web3);
 
             let config = {
-                timeInterval: 3600,
-                timeStart: currentTime + 1800,
-                timeClaim: currentTime + 5400,      // Claim in 1.5 hours (mid way through second interval)
+                timeInterval: ONE_DAY,
+                timeStart: currentTime + ONE_DAY,
+                timeClaim: currentTime + (ONE_DAY*2.5),      // Claimm mid way through second interval
                 yearlyInflationTarget: 0.05
             }
 
@@ -228,12 +228,12 @@ export default function() {
             await rplClaimInflation(config, { from: userOne });
         });
         
-        
+
         it(printTitle('userOne', 'mint inflation at multiple random intervals'), async () => {
             // Current time
             let currentTime = await getCurrentTime(web3);
 
-            const INTERVAL = 3600
+            const INTERVAL = ONE_DAY
             const HALF_INTERVAL = INTERVAL/2
 
             let config = {
@@ -266,7 +266,7 @@ export default function() {
             await rplClaimInflation(config, { from: userOne });
         });
         
-
+        
         it(printTitle('userOne', 'mint one years inflation after 365 days at 5% which would equal 18,900,000 tokens'), async () => {
             // Current time
             let currentTime = await getCurrentTime(web3);
@@ -370,5 +370,6 @@ export default function() {
             config.timeClaim += (ONE_DAY * 365)
             await shouldRevert(rplClaimInflation(config, { from: userOne }), "Minted inflation after rate set to 0", "New tokens cannot be minted at the moment, either no intervals have passed, inflation has not begun or inflation rate is set to 0");
         });
+        
     });
 }

--- a/test/token/scenario-rpl-inflation.js
+++ b/test/token/scenario-rpl-inflation.js
@@ -1,7 +1,16 @@
-import { mineBlocks } from '../_utils/evm';
+import { getCurrentTime, increaseTime, mineBlocks } from '../_utils/evm'
 import { RocketTokenRPL, RocketVault, RocketRewardsPool } from '../_utils/artifacts';
+import { setRPLInflationIntervalRate, setRPLInflationIntervalTime, setRPLInflationStartTime } from '../dao/scenario-dao-protocol-bootstrap'
 
-
+// Set inflation config
+export async function rplSetInflationConfig(config, txOptions) {
+    // Set the daily inflation start block
+    await setRPLInflationStartTime(config.timeStart, txOptions);
+    // Set the daily inflation block count
+    await setRPLInflationIntervalTime(config.timeInterval, txOptions);
+    // Set the daily inflation rate
+    await setRPLInflationIntervalRate(config.yearlyInflationTarget, txOptions);
+}
 
 // Get the current inflation period in blocks
 export async function rplInflationIntervalBlocksGet(txOptions) {
@@ -13,38 +22,37 @@ export async function rplInflationIntervalBlocksGet(txOptions) {
 
 // Claim the inflation after a set amount of blocks have passed
 export async function rplClaimInflation(config, txOptions, tokenAmountToMatch = null) {
-
     // Load contracts
     const rocketTokenRPL = await RocketTokenRPL.deployed();
     const rocketVault = await RocketVault.deployed();
 
     // Get the previously last inflation calculated block
-    const blockIntervalLastCalc = web3.utils.toBN(await rocketTokenRPL.getInflationCalcBlock.call());
+    const timeIntervalLastCalc = web3.utils.toBN(await rocketTokenRPL.getInflationCalcTime.call());
 
     // Get data about the current inflation
     function getInflationData() {
         return Promise.all([
-            web3.eth.getBlockNumber(),
+            getCurrentTime(web3),
             rocketTokenRPL.totalSupply.call(),
-            rocketTokenRPL.getInflationIntervalStartBlock.call(),
+            rocketTokenRPL.getInflationIntervalStartTime.call(),
             rocketTokenRPL.getInflationIntervalsPassed.call(),
-            rocketTokenRPL.getInflationCalcBlock.call(),
-            rocketTokenRPL.getInflationIntervalBlocks.call(),
+            rocketTokenRPL.getInflationCalcTime.call(),
+            rocketTokenRPL.getInflationIntervalTime.call(),
             rocketTokenRPL.balanceOf(rocketVault.address),
             rocketVault.balanceOfToken('rocketRewardsPool', rocketTokenRPL.address),
         ]).then(
-            ([currentBlock, tokenTotalSupply, inflationStartBlock, inflationIntervalsPassed, inflationCalcBlock, intervalBlocks, rocketVaultBalanceRPL, rocketVaultInternalBalanceRPL]) =>
-            ({currentBlock, tokenTotalSupply, inflationStartBlock, inflationIntervalsPassed, inflationCalcBlock, intervalBlocks, rocketVaultBalanceRPL, rocketVaultInternalBalanceRPL})
+            ([currentTime, tokenTotalSupply, inflationStartTime, inflationIntervalsPassed, inflationCalcTime, intervalTime, rocketVaultBalanceRPL, rocketVaultInternalBalanceRPL]) =>
+            ({currentTime, tokenTotalSupply, inflationStartTime, inflationIntervalsPassed, inflationCalcTime, intervalTime, rocketVaultBalanceRPL, rocketVaultInternalBalanceRPL})
         );
     }
 
-    // Get the current block so we can calculate how many blocks to mine to make it to the claim block
-    let blockCurrent = await web3.eth.getBlockNumber();
+    // Get the current time so we can calculate how much time to pass to make it to the claim time
+    let currentTime = await getCurrentTime(web3);
 
     // Blocks to process as passing
-    let blocksToSimulatePassing = config.blockClaim - blockCurrent;
-    // Process the blocks now to simulate blocks passing (need minus 1 block as the 'inflationMintTokens' tx triggers a new block with ganache which is equal to the claim block)
-    await mineBlocks(web3, blocksToSimulatePassing);  
+    let timeToSimulatePassing = config.timeClaim - currentTime;
+    // Simulate time passing
+    await increaseTime(web3, timeToSimulatePassing);
 
     // Get initial data
     let inflationData1 = await getInflationData();
@@ -57,42 +65,43 @@ export async function rplClaimInflation(config, txOptions, tokenAmountToMatch = 
 
     // Some expected data results based on the passed parameters
     let expectedInflationDaily = (1 + config.yearlyInflationTarget) ** (1 / (365));
-    let expectedInflationLastCalcBlock = Number(blockIntervalLastCalc) == 0 && config.blockStart < config.blockClaim ? config.blockStart : Number(blockIntervalLastCalc);
+    let expectedInflationLastCalcTime = Number(timeIntervalLastCalc) === 0 && config.timeStart < config.timeClaim ? config.timeStart : Number(timeIntervalLastCalc);
     let expectedInflationIntervalsPassed = Number(inflationData1.inflationIntervalsPassed);
-    // Get updated block number after processing blocks
-    blockCurrent = await web3.eth.getBlockNumber();
-     // How many tokens to be epected minted
+
+    // Get updated time after fast forward
+    currentTime = await getCurrentTime(web3);
+
+     // How many tokens to be expected minted
      let expectedTokensMinted = 0;
+
     // Are we expecting inflation? have any intervals passed?
     if(inflationData1.inflationIntervalsPassed > 0) {
         // How much inflation to use based on intervals passed
         let expectedInflationAmount = expectedInflationDaily;
-        // Check the next expected claim block, since ganache triggers a block when it does the mint function, we need to anticipate that
-        let nextExpectedClaimBlock = (Number(expectedInflationLastCalcBlock)+(Number(inflationData1.intervalBlocks)*Number(inflationData1.inflationIntervalsPassed))) + Number(inflationData1.intervalBlocks);
-        // Is it going to trigger another claim on the txt that occurs?
-        expectedInflationIntervalsPassed = nextExpectedClaimBlock == (blockCurrent+1) ? expectedInflationIntervalsPassed+1 : expectedInflationIntervalsPassed;
+
        // console.log("nextExpectedClaimBlock", nextExpectedClaimBlock);
         //console.log("expectedInflationIntervalsPassed", expectedInflationIntervalsPassed);
         //console.log((nextExpectedClaimBlock), (blockCurrent+1));
+
         // Add an extra interval to the calculations match up
         for(let i=1; i < expectedInflationIntervalsPassed; i++) {
             expectedInflationAmount = (expectedInflationAmount * expectedInflationDaily);
         }
+
+        // Calculate expected inflation amount
         expectedTokensMinted = (expectedInflationAmount * totalSupplyStart) - totalSupplyStart;
     }
    
-    /*
-    console.log('');
-    console.log('Current block', await web3.eth.getBlockNumber());
-    console.log('Inflation start block', Number(inflationData1.inflationStartBlock));
-    console.log('Inflation calc block', Number(inflationData1.inflationCalcBlock));
-    console.log('Inflation interval blocks', Number(inflationData1.intervalBlocks));
-    console.log('Inflation intervals passed', Number(inflationData1.inflationIntervalsPassed));
-    console.log('Inflation calc block expected', Number(expectedInflationLastCalcBlock));
-    console.log('Inflation intervals expected', Number(expectedInflationIntervalsPassed));
-    console.log('Inflation next calc block', Number(inflationData1.inflationCalcBlock)+Number(inflationData1.intervalBlocks));
-    */
-    
+    // console.log('');
+    // console.log('Current time', currentTime);
+    // console.log('Inflation start time', Number(inflationData1.inflationStartTime));
+    // console.log('Inflation calc time', Number(inflationData1.inflationCalcTime));
+    // console.log('Inflation interval time', Number(inflationData1.intervalTime));
+    // console.log('Inflation intervals passed', Number(inflationData1.inflationIntervalsPassed));
+    // console.log('Inflation calc time expected', Number(expectedInflationLastCalcTime));
+    // console.log('Inflation intervals expected', Number(expectedInflationIntervalsPassed));
+    // console.log('Inflation next calc time', Number(inflationData1.inflationCalcTime)+Number(inflationData1.intervalTime));
+
     
     // Claim tokens now
     await rocketTokenRPL.inflationMintTokens(txOptions);
@@ -100,11 +109,10 @@ export async function rplClaimInflation(config, txOptions, tokenAmountToMatch = 
     // Get inflation data
     let inflationData2 = await getInflationData();
 
-    //console.log('');
-    //console.log('Current block', await web3.eth.getBlockNumber());
-    //console.log('Inflation calc block', Number(inflationData2.inflationCalcBlock));
+    // console.log('');
+    // console.log('Current time', await getCurrentTime(web3));
+    // console.log('Inflation calc time', Number(inflationData2.inflationCalcTime));
 
-    
     //console.log(inflationData2.currentBlock, web3.utils.fromWei(inflationData2.tokenTotalSupply), inflationData2.inflationStartBlock.toString(), web3.utils.fromWei(inflationData2.rocketVaultBalanceRPL), web3.utils.fromWei(inflationData2.rocketVaultInternalBalanceRPL));
 
     // Ending amount of total supply
@@ -114,10 +122,9 @@ export async function rplClaimInflation(config, txOptions, tokenAmountToMatch = 
     //console.log(Number(tokenAmountToMatch).toFixed(4), Number(totalSupplyEnd).toFixed(4), Number(totalSupplyStart).toFixed(4));
 
     // Verify the minted amount is correct based on inflation rate etc
-    assert(expectedTokensMinted.toFixed(4) == (totalSupplyEnd - totalSupplyStart).toFixed(4), 'Incorrect amount of minted tokens expected');
+    assert(expectedTokensMinted.toFixed(4) === (totalSupplyEnd - totalSupplyStart).toFixed(4), 'Incorrect amount of minted tokens expected');
     // Verify the minted tokens are now stored in Rocket Vault on behalf of Rocket Rewards Pool
     assert(inflationData2.rocketVaultInternalBalanceRPL.eq(inflationData2.rocketVaultBalanceRPL), 'Incorrect amount of tokens stored in Rocket Vault for Rocket Rewards Pool');
     // Are we verifying an exact amount of tokens given as a required parameter on this pass?
-    if(tokenAmountToMatch) assert(Number(tokenAmountToMatch).toFixed(4) == Number(totalSupplyEnd).toFixed(4), 'Given token amount does not match total supply made');
-
+    if(tokenAmountToMatch) assert(Number(tokenAmountToMatch).toFixed(4) === Number(totalSupplyEnd).toFixed(4), 'Given token amount does not match total supply made');
 }

--- a/test/token/scenario-rpl-inflation.js
+++ b/test/token/scenario-rpl-inflation.js
@@ -1,13 +1,11 @@
 import { getCurrentTime, increaseTime, mineBlocks } from '../_utils/evm'
 import { RocketTokenRPL, RocketVault, RocketRewardsPool } from '../_utils/artifacts';
-import { setRPLInflationIntervalRate, setRPLInflationIntervalTime, setRPLInflationStartTime } from '../dao/scenario-dao-protocol-bootstrap'
+import { setRPLInflationIntervalRate, setRPLInflationStartTime } from '../dao/scenario-dao-protocol-bootstrap'
 
 // Set inflation config
 export async function rplSetInflationConfig(config, txOptions) {
     // Set the daily inflation start block
     await setRPLInflationStartTime(config.timeStart, txOptions);
-    // Set the daily inflation block count
-    await setRPLInflationIntervalTime(config.timeInterval, txOptions);
     // Set the daily inflation rate
     await setRPLInflationIntervalRate(config.yearlyInflationTarget, txOptions);
 }


### PR DESCRIPTION
This PR changes the inflation system to use `block.timestamp` instead of `block.number * 15 seconds` to make inflation more predictable. Previously, inflation was based on an estimate of 15s blocks. Meanwhile, the current average block time is closer to 13s and this might vary over time as network hashrate fluctuates and difficulty doesn't keep up.

This PR also changes the reward period (default of approx. 14 days) to use time instead of an estimate of blocks.

There are some other less critical sections such as proposal voting periods, etc. that could also be converted over to seconds instead of blocks. But they have not been changed in this PR.