### PR TITLE
Add in a setting for restricting oracle nodes from creating unbonded minipools below a percentage of the max fee

### DIFF
--- a/contracts/contract/dao/node/settings/RocketDAONodeTrustedSettingsMembers.sol
+++ b/contracts/contract/dao/node/settings/RocketDAONodeTrustedSettingsMembers.sol
@@ -19,6 +19,7 @@ contract RocketDAONodeTrustedSettingsMembers is RocketDAONodeTrustedSettings, Ro
             setSettingUint("members.quorum", 0.51 ether);                    // Member quorum threshold that must be met for proposals to pass (51%)
             setSettingUint("members.rplbond", 15000 ether);                  // Bond amount required for a new member to join
             setSettingUint("members.minipool.unbonded.max", 250);            // The amount of unbonded minipool validators members can make (these validators are only used if no regular bonded validators are available)
+            setSettingUint("members.minipool.unbonded.min.fee", 0.8 ether);  // Node fee must be over this percentage of the maximum fee before validator members are allowed to make unbonded pools (80%)
             setSettingUint("members.challenge.cooldown", 43204);             // How long a member must wait before performing another challenge, approx. 1 day worth of blocks
             setSettingUint("members.challenge.window", 43204);               // How long a member has to respond to a challenge. 7 days worth of blocks
             setSettingUint("members.challenge.cost", 1 ether);               // How much it costs a non-member to challenge a members node. It's free for current members to challenge other members.
@@ -55,6 +56,11 @@ contract RocketDAONodeTrustedSettingsMembers is RocketDAONodeTrustedSettings, Ro
         return getSettingUint("members.minipool.unbonded.max");
     }
 
+    // Node fee must be over this percentage of the maximum fee before validator members are allowed to make unbonded pools (80%)
+    function getMinipoolUnbondedMinFee() override public view returns (uint256) {
+        return getSettingUint('members.minipool.unbonded.min.fee');
+    }
+
     // How long a member must wait before making consecutive challenges
     function getChallengeCooldown() override public view returns (uint256) { 
         return getSettingUint("members.challenge.cooldown");
@@ -69,6 +75,4 @@ contract RocketDAONodeTrustedSettingsMembers is RocketDAONodeTrustedSettings, Ro
     function getChallengeCost() override public view returns (uint256) { 
         return getSettingUint("members.challenge.cost");
     }
-        
-
 }

--- a/contracts/contract/dao/protocol/settings/RocketDAOProtocolSettingsNetwork.sol
+++ b/contracts/contract/dao/protocol/settings/RocketDAOProtocolSettingsNetwork.sol
@@ -86,6 +86,4 @@ contract RocketDAOProtocolSettingsNetwork is RocketDAOProtocolSettings, RocketDA
     function getTargetRethCollateralRate() override public view returns (uint256) {
         return getSettingUint("network.reth.collateral.target");
     }
-
-
 }

--- a/contracts/contract/node/RocketNodeDeposit.sol
+++ b/contracts/contract/node/RocketNodeDeposit.sol
@@ -64,7 +64,7 @@ contract RocketNodeDeposit is RocketBase, RocketNodeDepositInterface {
             if (depositType == MinipoolDeposit.Empty) {
                 require(rocketDaoNodeTrusted.getMemberUnbondedValidatorCount(msg.sender) < rocketDaoNodeTrustedSettingsMembers.getMinipoolUnbondedMax(), "Trusted node member would exceed the amount of unbonded minipools allowed");
                 uint256 maxFee = rocketDAOProtocolSettingsNetwork.getMaximumNodeFee();
-                require(nodeFee > maxFee.mul(rocketDaoNodeTrustedSettingsMembers.getMinipoolUnbondedMinFee()).div(1 ether), "Trusted node member can only create an unbonded minipool if current fee > 80% of maximum fee");
+                require(nodeFee > maxFee.mul(rocketDaoNodeTrustedSettingsMembers.getMinipoolUnbondedMinFee()).div(1 ether), "Current commission rate is not high enough to create unbonded minipools");
             }
         }
         // Node is not trusted - it cannot create unbonded minipools

--- a/contracts/interface/dao/node/settings/RocketDAONodeTrustedSettingsMembersInterface.sol
+++ b/contracts/interface/dao/node/settings/RocketDAONodeTrustedSettingsMembersInterface.sol
@@ -6,6 +6,7 @@ interface RocketDAONodeTrustedSettingsMembersInterface {
     function getQuorum() external view returns (uint256);
     function getRPLBond() external view returns(uint256);
     function getMinipoolUnbondedMax() external view returns(uint256);
+    function getMinipoolUnbondedMinFee() external view returns(uint256);
     function getChallengeCooldown() external view returns(uint256);
     function getChallengeWindow() external view returns(uint256);
     function getChallengeCost() external view returns(uint256);


### PR DESCRIPTION
This PR adds in a restriction to stop oracle nodes from being able to create unbonded minipools unless the current commission rate is above 80% of the maximum commission rate.

This threshold is configurable with a new setting `members.minipool.unbonded.min.fee` which defaults to 80%.