### PR TITLE
Resolves CD 6.38 - Removed unused boolean return values from *Token methods in vault

### DIFF
--- a/contracts/contract/RocketVault.sol
+++ b/contracts/contract/RocketVault.sol
@@ -80,7 +80,7 @@ contract RocketVault is RocketBase, RocketVaultInterface {
 
 
     // Accept an token deposit and assign it's balance to a network contract (saves a large amount of gas this way through not needing a double token transfer via a network contract first)
-    function depositToken(string memory _networkContractName, IERC20 _tokenContract, uint256 _amount) override external returns (bool) {
+    function depositToken(string memory _networkContractName, IERC20 _tokenContract, uint256 _amount) override external {
          // Valid amount?
         require(_amount > 0, "No valid amount of tokens given to deposit");
         // Make sure the network contract is valid (will throw if not)
@@ -93,13 +93,11 @@ contract RocketVault is RocketBase, RocketVaultInterface {
         tokenBalances[contractKey] = tokenBalances[contractKey].add(_amount);
         // Emit token transfer
         emit TokenDeposited(contractKey, address(_tokenContract), _amount, block.timestamp);
-        // Done
-        return true;
     }
 
     // Withdraw an amount of a ERC20 token to an address
     // Only accepts calls from Rocket Pool network contracts
-    function withdrawToken(address _withdrawalAddress, IERC20 _tokenAddress, uint256 _amount) override external onlyLatestNetworkContract returns (bool) {
+    function withdrawToken(address _withdrawalAddress, IERC20 _tokenAddress, uint256 _amount) override external onlyLatestNetworkContract {
         // Valid amount?
         require(_amount > 0, "No valid amount of tokens given to withdraw");
         // Get contract key
@@ -112,14 +110,12 @@ contract RocketVault is RocketBase, RocketVaultInterface {
         require(tokenContract.transfer(_withdrawalAddress, _amount), "Rocket Vault token withdrawal unsuccessful");
         // Emit token withdrawn event
         emit TokenWithdrawn(contractKey, address(_tokenAddress), _amount, block.timestamp);
-        // Done
-        return true;
     }
 
 
     // Transfer token from one contract to another
     // Only accepts calls from Rocket Pool network contracts
-    function transferToken(string memory _networkContractName, IERC20 _tokenAddress, uint256 _amount) override external onlyLatestNetworkContract returns (bool) {
+    function transferToken(string memory _networkContractName, IERC20 _tokenAddress, uint256 _amount) override external onlyLatestNetworkContract {
         // Valid amount?
         require(_amount > 0, "No valid amount of tokens given to transfer");
         // Make sure the network contract is valid (will throw if not)
@@ -136,14 +132,12 @@ contract RocketVault is RocketBase, RocketVaultInterface {
         require(tokenContract.balanceOf(address(this)) >= _amount, "Insufficient contract token balance");
         // Emit token withdrawn event
         emit TokenTransfer(contractKeyFrom, contractKeyTo, address(_tokenAddress), _amount, block.timestamp);
-        // Done
-        return true;
     }
 
 
     // Burns an amount of a token that implements a burn(uint256) method
     // Only accepts calls from Rocket Pool network contracts
-    function burnToken(ERC20Burnable _tokenAddress, uint256 _amount) override external onlyLatestNetworkContract returns (bool) {
+    function burnToken(ERC20Burnable _tokenAddress, uint256 _amount) override external onlyLatestNetworkContract {
         // Get contract key
         bytes32 contractKey = keccak256(abi.encodePacked(getContractName(msg.sender), _tokenAddress));
         // Update balances
@@ -154,7 +148,5 @@ contract RocketVault is RocketBase, RocketVaultInterface {
         tokenContract.burn(_amount);
         // Emit token burn event
         emit TokenBurned(contractKey, address(_tokenAddress), _amount, block.timestamp);
-        // Done
-        return true;
     }
 }

--- a/contracts/contract/dao/node/RocketDAONodeTrustedActions.sol
+++ b/contracts/contract/dao/node/RocketDAONodeTrustedActions.sol
@@ -106,7 +106,7 @@ contract RocketDAONodeTrustedActions is RocketBase, RocketDAONodeTrustedActionsI
         // Allow RocketVault to transfer these tokens to itself now
         require(rplInflationContract.approve(rocketVaultAddress, rplBondAmount), "Approval for RocketVault to spend RocketDAONodeTrusted RPL bond tokens was not successful");
         // Let vault know it can move these tokens to itself now and credit the balance to this contract
-        require(rocketVault.depositToken(getContractName(address(this)), IERC20(rocketTokenRPLAddress), rplBondAmount), "Rocket Vault RPL bond deposit deposit was not successful");
+        rocketVault.depositToken(getContractName(address(this)), IERC20(rocketTokenRPLAddress), rplBondAmount);
         // Add them as a member now that they have accepted the invitation and record the size of the bond they paid
         _memberAdd(_nodeAddress, rplBondAmount);
         // Log it
@@ -147,7 +147,7 @@ contract RocketDAONodeTrustedActions is RocketBase, RocketDAONodeTrustedActionsI
             // Valid withdrawal address
             require(_rplBondRefundAddress != address(0x0), "Member has not supplied a valid address for their RPL bond refund");
             // Send tokens now
-            require(rocketVault.withdrawToken(_rplBondRefundAddress, IERC20(getContractAddress('rocketTokenRPL')), rplBondRefundAmount), "Could not send RPL bond token balance from vault");
+            rocketVault.withdrawToken(_rplBondRefundAddress, IERC20(getContractAddress('rocketTokenRPL')), rplBondRefundAmount);
         }
         // Remove them now
         _memberRemove(msg.sender);
@@ -167,11 +167,11 @@ contract RocketDAONodeTrustedActions is RocketBase, RocketDAONodeTrustedActionsI
         // Refund
         if (rplBondRefundAmount > 0) {
             // Send tokens now
-            require(rocketVault.withdrawToken(_nodeAddress, IERC20(getContractAddress('rocketTokenRPL')), rplBondRefundAmount), "Could not send kicked members RPL bond token balance from vault");
+            rocketVault.withdrawToken(_nodeAddress, IERC20(getContractAddress('rocketTokenRPL')));
         }
         // Burn the fine
         if (_rplFine > 0) {
-            require(rocketVault.burnToken(ERC20Burnable(getContractAddress('rocketTokenRPL')), _rplFine), "Could not burn the RPL fine");
+            rocketVault.burnToken(ERC20Burnable(getContractAddress('rocketTokenRPL')), _rplFine);
         }
         // Remove the member now
         _memberRemove(_nodeAddress);

--- a/contracts/contract/rewards/claims/RocketClaimDAO.sol
+++ b/contracts/contract/rewards/claims/RocketClaimDAO.sol
@@ -37,7 +37,7 @@ contract RocketClaimDAO is RocketBase, RocketClaimDAOInterface {
         // Some initial checks
         require(_amount > 0 && _amount <= rocketVault.balanceOfToken('rocketClaimDAO', rplToken), "You cannot send 0 RPL or more than the DAO has in its account");
         // Send now
-        require(rocketVault.withdrawToken(_recipientAddress, rplToken, _amount), "Could not send token balance from vault for network DAO");
+        rocketVault.withdrawToken(_recipientAddress, rplToken, _amount);
         // Log it
         emit RPLTokensSentByDAOProtocol(_invoiceID, address(this), _recipientAddress, _amount, block.timestamp);
     }

--- a/contracts/contract/token/RocketTokenRPL.sol
+++ b/contracts/contract/token/RocketTokenRPL.sol
@@ -174,7 +174,7 @@ contract RocketTokenRPL is RocketBase, ERC20Burnable, RocketTokenRPLInterface {
         // Now allow Rocket Vault to move those tokens, we also need to account of any other allowances for this token from other contracts in the same block
         require(rplInflationContract.approve(rocketVaultAddress, vaultAllowance.add(newTokens)), "Allowance for Rocket Vault could not be approved");
         // Let vault know it can move these tokens to itself now and credit the balance to the RPL rewards pool contract
-        require(rocketVaultContract.depositToken('rocketRewardsPool', IERC20(address(this)), newTokens), "Rocket Vault deposit was not successful");
+        rocketVaultContract.depositToken('rocketRewardsPool', IERC20(address(this)), newTokens);
         // Log it
         emit RPLInflationLog(msg.sender, newTokens, inflationCalcBlock);
         // return number minted

--- a/contracts/interface/RocketVaultInterface.sol
+++ b/contracts/interface/RocketVaultInterface.sol
@@ -8,9 +8,9 @@ interface RocketVaultInterface {
     function balanceOf(string memory _networkContractName) external view returns (uint256);
     function depositEther() external payable;
     function withdrawEther(uint256 _amount) external;
-    function depositToken(string memory _networkContractName, IERC20 _tokenAddress, uint256 _amount) external returns (bool);
-    function withdrawToken(address _withdrawalAddress, IERC20 _tokenAddress, uint256 _amount) external returns (bool);
+    function depositToken(string memory _networkContractName, IERC20 _tokenAddress, uint256 _amount) external;
+    function withdrawToken(address _withdrawalAddress, IERC20 _tokenAddress, uint256 _amount) external;
     function balanceOfToken(string memory _networkContractName, IERC20 _tokenAddress) external view returns (uint256);
-    function transferToken(string memory _networkContractName, IERC20 _tokenAddress, uint256 _amount) external returns (bool);
-    function burnToken(ERC20Burnable _tokenAddress, uint256 _amount) external returns (bool);
+    function transferToken(string memory _networkContractName, IERC20 _tokenAddress, uint256 _amount) external;
+    function burnToken(ERC20Burnable _tokenAddress, uint256 _amount) external;
 }


### PR DESCRIPTION
The *Token methods in `RocketVault` return a boolean value but this value is always true. If the method fails it reverts instead.

This PR removes the unused return values and any call that expects a false result.