### PR TITLE
Resolved 6.40 - Prevent direct calls against minipool delegate contract

### DIFF
--- a/contracts/contract/minipool/RocketMinipool.sol
+++ b/contracts/contract/minipool/RocketMinipool.sol
@@ -33,6 +33,8 @@ contract RocketMinipool is RocketMinipoolStorageLayout {
         depositType = _depositType;
         nodeAddress = _nodeAddress;
         nodeFee = rocketNetworkFees.getNodeFee();
+        // Set safety check flag
+        initialised = true;
     }
 
     // Receive an ETH deposit

--- a/contracts/contract/minipool/RocketMinipoolStorageLayout.sol
+++ b/contracts/contract/minipool/RocketMinipoolStorageLayout.sol
@@ -43,4 +43,6 @@ abstract contract RocketMinipoolStorageLayout {
     uint256 internal stakingStartBalance;
     uint256 internal stakingEndBalance;
 
+    // Safety check
+    bool internal initialised;
 }


### PR DESCRIPTION
This boolean flag on the minipool storage is set by the minipool contract and not set on the delegate contract. This prevents direct calls to the delegate contract but still allows the minipool contract to calll.