### PR TITLE
Total effective RPL stake via oracle

### DIFF
--- a/contracts/contract/minipool/RocketMinipoolManager.sol
+++ b/contracts/contract/minipool/RocketMinipoolManager.sol
@@ -132,7 +132,7 @@ contract RocketMinipoolManager is RocketBase, RocketMinipoolManagerInterface {
         // Update unbonded validator count if minipool is unbonded
         if (_depositType == MinipoolDeposit.Empty) { rocketDAONodeTrusted.incrementMemberUnbondedValidatorCount(_nodeAddress); }
         // Prevent creation of minipools between price update block and price consensus
-        require(rocketNetworkPrices.inConsensus(), "Can not stake while network is reaching consensus");
+        require(rocketNetworkPrices.inConsensus(), "Can not create a minipool while network is reaching consensus");
         // Update total effective RPL stake
         updateTotalEffectiveRPLStake(_nodeAddress, minipoolCount, minipoolCount.add(1));
         // Emit minipool created event
@@ -163,7 +163,7 @@ contract RocketMinipoolManager is RocketBase, RocketMinipoolManagerInterface {
         // Update unbonded validator count if minipool is unbonded
         if (minipool.getDepositType() == MinipoolDeposit.Empty) { rocketDAONodeTrusted.decrementMemberUnbondedValidatorCount(nodeAddress); }
         // Prevent destroying minipools between price update block and price consensus
-        require(rocketNetworkPrices.inConsensus(), "Can not stake while network is reaching consensus");
+        require(rocketNetworkPrices.inConsensus(), "Can not destroy a minipool while network is reaching consensus");
         // Update total effective RPL stake
         updateTotalEffectiveRPLStake(msg.sender, minipoolCount, minipoolCount.sub(1));
         // Emit minipool destroyed event

--- a/contracts/contract/network/RocketNetworkPrices.sol
+++ b/contracts/contract/network/RocketNetworkPrices.sol
@@ -20,7 +20,7 @@ contract RocketNetworkPrices is RocketBase, RocketNetworkPricesInterface {
     uint256 constant calcBase = 1 ether;
 
     // Events
-    event PricesSubmitted(address indexed from, uint256 block, uint256 rplPrice, uint256 time);
+    event PricesSubmitted(address indexed from, uint256 block, uint256 rplPrice, uint256 effectiveRplStake, uint256 time);
     event PricesUpdated(uint256 block, uint256 rplPrice, uint256 time);
 
     // Construct
@@ -47,9 +47,29 @@ contract RocketNetworkPrices is RocketBase, RocketNetworkPricesInterface {
         setUintS("network.prices.rpl", _value);
     }
 
+    // The current RP network effective RPL stake
+    function getEffectiveRPLStake() override public view returns (uint256) {
+        return getUintS("network.rpl.stake");
+    }
+    function getEffectiveRPLStakeUpdatedBlock() override public view returns (uint256) {
+        return getUintS("network.rpl.stake.updated.block");
+    }
+    function setEffectiveRPLStake(uint256 _value) private {
+        setUintS("network.rpl.stake", _value);
+        setUintS("network.rpl.stake.updated.block", block.number);
+    }
+    function increaseEffectiveRPLStake(uint256 _amount) override public onlyLatestNetworkContract {
+        uint256 current = getEffectiveRPLStake();
+        setEffectiveRPLStake(current.add(_amount));
+    }
+    function decreaseEffectiveRPLStake(uint256 _amount) override public onlyLatestNetworkContract {
+        uint256 current = getEffectiveRPLStake();
+        setEffectiveRPLStake(current.sub(_amount));
+    }
+
     // Submit network price data for a block
     // Only accepts calls from trusted (oracle) nodes
-    function submitPrices(uint256 _block, uint256 _rplPrice) override external onlyLatestContract("rocketNetworkPrices", address(this)) onlyTrustedNode(msg.sender) {
+    function submitPrices(uint256 _block, uint256 _rplPrice, uint256 _effectiveRplStake) override external onlyLatestContract("rocketNetworkPrices", address(this)) onlyTrustedNode(msg.sender) {
         // Check settings
         RocketDAOProtocolSettingsNetworkInterface rocketDAOProtocolSettingsNetwork = RocketDAOProtocolSettingsNetworkInterface(getContractAddress("rocketDAOProtocolSettingsNetwork"));
         require(rocketDAOProtocolSettingsNetwork.getSubmitPricesEnabled(), "Submitting prices is currently disabled");
@@ -57,8 +77,8 @@ contract RocketNetworkPrices is RocketBase, RocketNetworkPricesInterface {
         require(_block < block.number, "Prices can not be submitted for a future block");
         require(_block > getPricesBlock(), "Network prices for an equal or higher block are set");
         // Get submission keys
-        bytes32 nodeSubmissionKey = keccak256(abi.encodePacked("network.prices.submitted.node.key", msg.sender, _block, _rplPrice));
-        bytes32 submissionCountKey = keccak256(abi.encodePacked("network.prices.submitted.count", _block, _rplPrice));
+        bytes32 nodeSubmissionKey = keccak256(abi.encodePacked("network.prices.submitted.node.key", msg.sender, _block, _rplPrice, _effectiveRplStake));
+        bytes32 submissionCountKey = keccak256(abi.encodePacked("network.prices.submitted.count", _block, _rplPrice, _effectiveRplStake));
         // Check & update node submission status
         require(!getBool(nodeSubmissionKey), "Duplicate submission from node");
         setBool(nodeSubmissionKey, true);
@@ -67,16 +87,16 @@ contract RocketNetworkPrices is RocketBase, RocketNetworkPricesInterface {
         uint256 submissionCount = getUint(submissionCountKey).add(1);
         setUint(submissionCountKey, submissionCount);
         // Emit prices submitted event
-        emit PricesSubmitted(msg.sender, _block, _rplPrice, block.timestamp);
+        emit PricesSubmitted(msg.sender, _block, _rplPrice, _effectiveRplStake, block.timestamp);
         // Check submission count & update network prices
         RocketDAONodeTrustedInterface rocketDAONodeTrusted = RocketDAONodeTrustedInterface(getContractAddress("rocketDAONodeTrusted"));
         if (calcBase.mul(submissionCount).div(rocketDAONodeTrusted.getMemberCount()) >= rocketDAOProtocolSettingsNetwork.getNodeConsensusThreshold()) {
-            updatePrices(_block, _rplPrice);
+            updatePrices(_block, _rplPrice, _effectiveRplStake);
         }
     }
 
     // Executes updatePrices if consensus threshold is reached
-    function executeUpdatePrices(uint256 _block, uint256 _rplPrice) override public onlyLatestContract("rocketNetworkPrices", address(this)) {
+    function executeUpdatePrices(uint256 _block, uint256 _rplPrice, uint256 _effectiveRplStake) override public onlyLatestContract("rocketNetworkPrices", address(this)) {
         // Check settings
         RocketDAOProtocolSettingsNetworkInterface rocketDAOProtocolSettingsNetwork = RocketDAOProtocolSettingsNetworkInterface(getContractAddress("rocketDAOProtocolSettingsNetwork"));
         require(rocketDAOProtocolSettingsNetwork.getSubmitPricesEnabled(), "Submitting prices is currently disabled");
@@ -84,22 +104,34 @@ contract RocketNetworkPrices is RocketBase, RocketNetworkPricesInterface {
         require(_block < block.number, "Prices can not be submitted for a future block");
         require(_block > getPricesBlock(), "Network prices for an equal or higher block are set");
         // Get submission keys
-        bytes32 submissionCountKey = keccak256(abi.encodePacked("network.prices.submitted.count", _block, _rplPrice));
+        bytes32 submissionCountKey = keccak256(abi.encodePacked("network.prices.submitted.count", _block, _rplPrice, _effectiveRplStake));
         // Get submission count
         uint256 submissionCount = getUint(submissionCountKey);
         // Check submission count & update network prices
         RocketDAONodeTrustedInterface rocketDAONodeTrusted = RocketDAONodeTrustedInterface(getContractAddress("rocketDAONodeTrusted"));
         require(calcBase.mul(submissionCount).div(rocketDAONodeTrusted.getMemberCount()) >= rocketDAOProtocolSettingsNetwork.getNodeConsensusThreshold(), "Consensus has not been reached");
-        updatePrices(_block, _rplPrice);
+        // Cannot update effective RPL stake based on a block that is lower than the last block that it was updated on chain
+        require(_effectiveRplStake == getEffectiveRPLStake() || _block >= getEffectiveRPLStakeUpdatedBlock(), "Cannot update effective RPL stake based on block lower than when it was last updated on chain");
+        updatePrices(_block, _rplPrice, _effectiveRplStake);
     }
 
     // Update network price data
-    function updatePrices(uint256 _block, uint256 _rplPrice) private {
+    function updatePrices(uint256 _block, uint256 _rplPrice, uint256 _effectiveRplStake) private {
         // Update prices
         setPricesBlock(_block);
         setRPLPrice(_rplPrice);
+        setEffectiveRPLStake(_effectiveRplStake);
         // Emit prices updated event
         emit PricesUpdated(_block, _rplPrice, block.timestamp);
     }
 
+    // Returns true if consensus has been reached for this price update interval, if the interval has passed and members
+    // have not yet reached consensus, return false
+    function inConsensus() override public view returns (bool) {
+        // Load contracts
+        RocketDAOProtocolSettingsNetworkInterface rocketDAOProtocolSettingsNetwork = RocketDAOProtocolSettingsNetworkInterface(getContractAddress("rocketDAOProtocolSettingsNetwork"));
+        uint256 pricesBlock = getPricesBlock();
+        uint256 updateFrequency = rocketDAOProtocolSettingsNetwork.getSubmitPricesFrequency();
+        return block.number < pricesBlock + updateFrequency;
+    }
 }

--- a/contracts/interface/network/RocketNetworkPricesInterface.sol
+++ b/contracts/interface/network/RocketNetworkPricesInterface.sol
@@ -5,6 +5,11 @@ pragma solidity 0.7.6;
 interface RocketNetworkPricesInterface {
     function getPricesBlock() external view returns (uint256);
     function getRPLPrice() external view returns (uint256);
-    function submitPrices(uint256 _block, uint256 _rplPrice) external;
-    function executeUpdatePrices(uint256 _block, uint256 _rplPrice) external;
+    function getEffectiveRPLStake() external view returns (uint256);
+    function getEffectiveRPLStakeUpdatedBlock() external view returns (uint256);
+    function inConsensus() external view returns (bool);
+    function submitPrices(uint256 _block, uint256 _rplPrice, uint256 _effectiveRplStake) external;
+    function executeUpdatePrices(uint256 _block, uint256 _rplPrice, uint256 _effectiveRplStake) external;
+    function increaseEffectiveRPLStake(uint256 _amount) external;
+    function decreaseEffectiveRPLStake(uint256 _amount) external;
 }

--- a/contracts/interface/node/RocketNodeStakingInterface.sol
+++ b/contracts/interface/node/RocketNodeStakingInterface.sol
@@ -7,6 +7,7 @@ interface RocketNodeStakingInterface {
     function getNodeRPLStake(address _nodeAddress) external view returns (uint256);
     function getNodeRPLStakedTime(address _nodeAddress) external view returns (uint256);
     function getTotalEffectiveRPLStake() external view returns (uint256);
+    function calculateTotalEffectiveRPLStake(uint256 offset, uint256 limit, uint256 rplPrice) external view returns (uint256);
     function getNodeEffectiveRPLStake(address _nodeAddress) external view returns (uint256);
     function getNodeMinimumRPLStake(address _nodeAddress) external view returns (uint256);
     function getNodeMaximumRPLStake(address _nodeAddress) external view returns (uint256);

--- a/test/_helpers/minipool.js
+++ b/test/_helpers/minipool.js
@@ -28,6 +28,14 @@ export async function getMinipoolWithdrawalUserBalance(minipoolAddress) {
 }
 
 
+// Get the number of minipools a node has
+export async function getNodeMinipoolCount(nodeAddress) {
+    const rocketMinipoolManager = await RocketMinipoolManager.deployed();
+    let count = await rocketMinipoolManager.getNodeMinipoolCount.call(nodeAddress);
+    return count;
+}
+
+
 // Get the minimum required RPL stake for a minipool
 export async function getMinipoolMinimumRPLStake() {
 

--- a/test/_helpers/network.js
+++ b/test/_helpers/network.js
@@ -33,9 +33,17 @@ export async function submitBalances(block, totalEth, stakingEth, rethSupply, tx
 
 
 // Submit network token prices
-export async function submitPrices(block, rplPrice, txOptions) {
+export async function submitPrices(block, rplPrice, effectiveRplStake, txOptions) {
     const rocketNetworkPrices = await RocketNetworkPrices.deployed();
-    await rocketNetworkPrices.submitPrices(block, rplPrice, txOptions);
+    await rocketNetworkPrices.submitPrices(block, rplPrice, effectiveRplStake, txOptions);
+}
+
+
+// Get network RPL price
+export async function getRPLPrice() {
+    const rocketNetworkPrices = await RocketNetworkPrices.deployed();
+    let price = await rocketNetworkPrices.getRPLPrice.call();
+    return price;
 }
 
 

--- a/test/_helpers/node.js
+++ b/test/_helpers/node.js
@@ -30,6 +30,22 @@ export async function getNodeMinimumRPLStake(nodeAddress) {
 }
 
 
+// Get total effective RPL stake
+export async function getTotalEffectiveRPLStake() {
+    const rocketNodeStaking = await RocketNodeStaking.deployed();
+    let totalStake = await rocketNodeStaking.getTotalEffectiveRPLStake.call();
+    return totalStake;
+}
+
+
+// Get calculated effective RPL stake
+export async function getCalculatedTotalEffectiveRPLStake(price) {
+    const rocketNodeStaking = await RocketNodeStaking.deployed();
+    let totalStake = await rocketNodeStaking.calculateTotalEffectiveRPLStake.call(0, 0, price);
+    return totalStake;
+}
+
+
 // Register a node
 export async function registerNode(txOptions) {
     const rocketNodeManager = await RocketNodeManager.deployed();

--- a/test/auction/auction-tests.js
+++ b/test/auction/auction-tests.js
@@ -108,7 +108,7 @@ export default function() {
             await setDAOProtocolBootstrapSetting(RocketDAOProtocolSettingsAuction, 'auction.price.reserve', web3.utils.toWei('0', 'ether'), {from: owner});
 
             // Set RPL price
-            await submitPrices(1, web3.utils.toWei('1', 'ether'), {from: trustedNode});
+            await submitPrices(1, web3.utils.toWei('1', 'ether'), '0', {from: trustedNode});
 
             // Create lot
             await submitMinipoolWithdrawable(minipool.address, web3.utils.toWei('32', 'ether'), web3.utils.toWei('0', 'ether'), {from: trustedNode});

--- a/test/network/network-staking-tests.js
+++ b/test/network/network-staking-tests.js
@@ -1,0 +1,226 @@
+import { takeSnapshot, revertSnapshot, mineBlocks, getCurrentTime, increaseTime } from '../_utils/evm'
+import { printTitle } from '../_utils/formatting';
+import { shouldRevert } from '../_utils/testing';
+import { getRPLPrice, submitPrices } from '../_helpers/network'
+import {
+    registerNode,
+    setNodeTrusted,
+    setNodeWithdrawalAddress,
+    nodeStakeRPL,
+    nodeDeposit,
+    getNodeRPLStake,
+    getNodeEffectiveRPLStake,
+    getTotalEffectiveRPLStake, getCalculatedTotalEffectiveRPLStake
+} from '../_helpers/node'
+import { RocketDAOProtocolSettingsNode } from '../_utils/artifacts';
+import { setDAOProtocolBootstrapSetting, setRewardsClaimIntervalTime, setRPLInflationStartTime } from '../dao/scenario-dao-protocol-bootstrap'
+import { mintRPL } from '../_helpers/tokens';
+import { setDAONetworkBootstrapRewardsClaimer, setRPLInflationIntervalRate } from '../dao/scenario-dao-protocol-bootstrap';
+
+// Contracts
+import { createMinipool, getNodeMinipoolCount, submitMinipoolWithdrawable } from '../_helpers/minipool'
+import BN from 'bn.js'
+import { withdrawValidatorBalance } from '../minipool/scenario-withdraw-validator-balance'
+import { close } from '../minipool/scenario-close'
+import { dissolve } from '../minipool/scenario-dissolve'
+
+
+export default function() {
+    contract.only('RocketNodeStaking', async (accounts) => {
+
+        // One day in seconds
+        const ONE_DAY = 24 * 60 * 60;
+        const maxStakePerMinipool = '1.5'
+
+
+        // Accounts
+        const [
+            owner,
+            userOne,
+            registeredNode1,
+            registeredNode2,
+            registeredNode3,
+            registeredNodeTrusted1,
+            registeredNodeTrusted2,
+            registeredNodeTrusted3,
+            node1WithdrawalAddress,
+            trustedNode,
+            daoInvoiceRecipient
+        ] = accounts;
+
+
+        // The testing config
+        const claimIntervalTime = ONE_DAY * 28;
+
+        // Set some RPL inflation scenes
+        let rplInflationSetup = async function() {
+            // Current time
+            let currentTime = await getCurrentTime(web3);
+            // Starting block for when inflation will begin
+            let timeStart = currentTime + ONE_DAY;
+            // Yearly inflation target
+            let yearlyInflationTarget = 0.05;
+
+            // Set the daily inflation start time
+            await setRPLInflationStartTime(timeStart, { from: owner });
+            // Set the daily inflation rate
+            await setRPLInflationIntervalRate(yearlyInflationTarget, { from: owner });
+
+            // claimIntervalTime must be greater than rewardIntervalTime for tests to properly function
+            assert(claimIntervalTime > ONE_DAY, 'Tests will not function correctly unless claimIntervalTime is greater than inflation period (1 day)')
+
+            // Return the starting time for inflation when it will be available
+            return timeStart + ONE_DAY;
+        }
+
+        // Set a rewards claiming contract
+        let rewardsContractSetup = async function(_claimContract, _claimAmountPerc) {
+            // Set the amount this contract can claim
+            await setDAONetworkBootstrapRewardsClaimer(_claimContract, web3.utils.toWei(_claimAmountPerc.toString(), 'ether'), { from: owner });
+            // Set the claim interval blocks
+            await setRewardsClaimIntervalTime(claimIntervalTime, { from: owner });
+        }
+
+
+        // State snapshotting
+        let snapshotId;
+        beforeEach(async () => { snapshotId = await takeSnapshot(web3); });
+        afterEach(async () => { await revertSnapshot(web3, snapshotId); });
+
+
+        // Setup
+        before(async () => {
+            // Disable RocketClaimNode claims contract
+            await setDAONetworkBootstrapRewardsClaimer('rocketClaimNode', web3.utils.toWei('0', 'ether'), {from: owner});
+            
+            // Register nodes
+            await registerNode({from: registeredNode1});
+            await registerNode({from: registeredNode2});
+            await registerNode({from: registeredNode3});
+            await registerNode({from: registeredNodeTrusted1});
+            await registerNode({from: registeredNodeTrusted2});
+            await registerNode({from: registeredNodeTrusted3});
+
+            // Register trusted node
+            await registerNode({from: trustedNode});
+            await setNodeTrusted(trustedNode, 'saas_1', 'node@home.com', owner);
+
+            // Set node 1 withdrawal address
+            await setNodeWithdrawalAddress(registeredNode1, node1WithdrawalAddress, {from: registeredNode1});
+
+            // Set nodes as trusted
+            await setNodeTrusted(registeredNodeTrusted1, 'saas_1', 'node@home.com', owner);
+            await setNodeTrusted(registeredNodeTrusted2, 'saas_2', 'node@home.com', owner);
+
+            // Set max per-minipool stake to 100% and RPL price to 1 ether
+            await setDAOProtocolBootstrapSetting(RocketDAOProtocolSettingsNode, 'node.per.minipool.stake.maximum', web3.utils.toWei(maxStakePerMinipool, 'ether'), {from: owner});
+            await submitPrices(1, web3.utils.toWei('1', 'ether'), '0', {from: registeredNodeTrusted1});
+            await submitPrices(1, web3.utils.toWei('1', 'ether'), '0', {from: registeredNodeTrusted2});
+
+            // Mint a tonne of RPL for testing
+            await mintRPL(owner, registeredNode1, web3.utils.toWei('10000', 'ether'));
+            await mintRPL(owner, registeredNode2, web3.utils.toWei('10000', 'ether'));
+            await mintRPL(owner, registeredNode3, web3.utils.toWei('10000', 'ether'));
+        });
+
+
+        async function testEffectiveStakeValues() {
+          let nodes = [registeredNode1, registeredNode2, registeredNode3];
+
+          let totalStake = web3.utils.toBN('0');
+          let rplPrice = await getRPLPrice();
+
+          for(const node of nodes){
+              let nodeStakedRpl = await getNodeRPLStake(node);
+              let minipoolCount = await getNodeMinipoolCount(node);
+              let maxStake = web3.utils.toBN(minipoolCount).mul(web3.utils.toBN(web3.utils.toWei(maxStakePerMinipool, 'ether'))).mul(web3.utils.toBN(web3.utils.toWei('16', 'ether'))).div(rplPrice);
+              let expectedEffectiveStake = BN.min(maxStake, nodeStakedRpl);
+              let effectiveStake = await getNodeEffectiveRPLStake(node);
+
+              console.log("Expected / actual / stake / minipool count: ", web3.utils.fromWei(expectedEffectiveStake), web3.utils.fromWei(effectiveStake), web3.utils.fromWei(nodeStakedRpl), minipoolCount.toString());
+              assert(effectiveStake.eq(expectedEffectiveStake), "Incorrect effective stake");
+
+              totalStake = totalStake.add(expectedEffectiveStake);
+          }
+
+          let actualTotalStake = await getTotalEffectiveRPLStake();
+          let calculatedTotalStake = await getCalculatedTotalEffectiveRPLStake(rplPrice);
+          console.log("Expected / actual / calculated: ", web3.utils.fromWei(totalStake), web3.utils.fromWei(actualTotalStake), web3.utils.fromWei(calculatedTotalStake));
+          assert(totalStake.eq(actualTotalStake), "Incorrect total effective stake");
+          assert(totalStake.eq(calculatedTotalStake), "Incorrect calculated total effective stake");
+        }
+
+
+        async function setPrice(price) {
+            await mineBlocks(web3, 1);
+            let blockNumber = await web3.eth.getBlockNumber();
+            let calculatedTotalEffectiveStake = await getCalculatedTotalEffectiveRPLStake(price);
+            await submitPrices(blockNumber, price, calculatedTotalEffectiveStake, {from: registeredNodeTrusted1});
+            await submitPrices(blockNumber, price, calculatedTotalEffectiveStake, {from: registeredNodeTrusted2});
+        }
+
+
+        /*** Regular Nodes *************************/
+
+
+        it(printTitle('node1+2', 'effective stake is correct after prices change'), async () => {
+            // Stake RPL against nodes and create minipools to set effective stakes
+            await nodeStakeRPL(web3.utils.toWei('32', 'ether'), {from: registeredNode1});
+            await nodeStakeRPL(web3.utils.toWei('32', 'ether'), {from: registeredNode2});
+            await nodeDeposit({from: registeredNode1, value: web3.utils.toWei('16', 'ether')});
+            await nodeDeposit({from: registeredNode2, value: web3.utils.toWei('16', 'ether')});
+            await nodeDeposit({from: registeredNode2, value: web3.utils.toWei('16', 'ether')});
+            await testEffectiveStakeValues()
+
+            // Double the price of RPL and test
+            await setPrice(web3.utils.toWei('2', 'ether'))
+            await testEffectiveStakeValues()
+
+            // Quarter the price of RPL and test
+            await setPrice(web3.utils.toWei('0.5', 'ether'))
+            await testEffectiveStakeValues()
+        });
+
+
+        it(printTitle('node1+2', 'effective stake is correct after various events occur'), async () => {
+            // Stake RPL against nodes and create minipools to set effective stakes
+            await nodeStakeRPL(web3.utils.toWei('32', 'ether'), {from: registeredNode1});
+            await nodeStakeRPL(web3.utils.toWei('32', 'ether'), {from: registeredNode2});
+            await nodeDeposit({from: registeredNode1, value: web3.utils.toWei('16', 'ether')});
+            await nodeDeposit({from: registeredNode2, value: web3.utils.toWei('16', 'ether')});
+            let initializedMinipool = await createMinipool({from: registeredNode2, value: web3.utils.toWei('16', 'ether')});
+            await testEffectiveStakeValues()
+
+            // Increase the price of RPL and create some more minipools
+            await setPrice(web3.utils.toWei('2', 'ether'))
+            await nodeDeposit({from: registeredNode2, value: web3.utils.toWei('16', 'ether')});
+            await testEffectiveStakeValues()
+
+            // Stake some more RPL
+            await nodeStakeRPL(web3.utils.toWei('32', 'ether'), {from: registeredNode2});
+            await testEffectiveStakeValues()
+
+            // Decrease the price of RPL and destroy some minipools
+            await setPrice(web3.utils.toWei('0.75', 'ether'))
+            await dissolve(initializedMinipool, {
+                from: registeredNode2,
+            });
+            await close(initializedMinipool, {
+                from: registeredNode2,
+            });
+            await testEffectiveStakeValues()
+        });
+
+
+        it.only(printTitle('node1+2+3', 'effective stake is correct'), async () => {
+            // Stake RPL against nodes and create minipools to set effective stakes
+            await nodeStakeRPL(web3.utils.toWei('1.6', 'ether'), {from: registeredNode1});
+            await nodeStakeRPL(web3.utils.toWei('50', 'ether'), {from: registeredNode2});
+            await nodeStakeRPL(web3.utils.toWei('50', 'ether'), {from: registeredNode3});
+            await nodeDeposit({from: registeredNode1, value: web3.utils.toWei('16', 'ether')});
+            await nodeDeposit({from: registeredNode2, value: web3.utils.toWei('16', 'ether')});
+            await nodeDeposit({from: registeredNode3, value: web3.utils.toWei('16', 'ether')});
+            await testEffectiveStakeValues()
+        });
+    });
+}

--- a/test/rocket-pool-tests.js
+++ b/test/rocket-pool-tests.js
@@ -14,6 +14,7 @@ import daoNodeTrustedTests from './dao/dao-node-trusted-tests';
 import rethTests from './token/reth-tests';
 import rplTests from './token/rpl-tests';
 import rewardsPoolTests from './rewards/rewards-tests';
+import networkStakingTests from './network/network-staking-tests';
 
 // Header
 console.log('\n');
@@ -34,6 +35,7 @@ minipoolStatusTests();
 networkBalancesTests();
 networkFeesTests();
 networkPricesTests();
+networkStakingTests();
 nodeDepositTests();
 nodeManagerTests();
 nodeStakingTests();


### PR DESCRIPTION
This is a proposed solution to RP-15.

It is impossible to calculate an accurate value for total effective RPL staked on chain because at some quantity of nodes we will run out of gas trying to iterate over the set.

The max stake in RPL depends on the ETH price of RPL as it is calculated as a percentage of the half deposit amount which is denominated in ETH. Therefore, we cannot simply keep track of the total effective RPL staked value at the time of staking and unstaking. 

This PR adds total effective RPL stake to the oracles' price submission process. So the value can be computed off chain where gas is not an issue and submitted to chain alongside price updates. It makes sense to include this value alongside price updates because it is a price update that cause this value to change.

Total effective RPL staked at a given block is submitted with a price update at the same block. It is then updated as nodes stake, unstake, create, and destroy minipools. Such that the value is always current and correct.

There is a small trade off. If someone were to stake, unstake, create, or destroy a minipool between a price update block and the oracle consensus result, it would corrupt this value as the oracle-calculated value would be invalidated by the time it gets executed on chain. Therefore, we must block these actions for the 1 or 2 blocks after a price update checkpoint and before consensus is reached for any given update window. And inversely, an "out-of-step" price update from oracles must be blocked if one of these actions are performed between the update block and the consensus transaction. In practice, these would be rare events and the TX would just revert and have to be submitted again.

The change required to the smartnode to adopt this procedure is very minimal. There is a new view function on the staking contract which calculates the total effective RPL stake based on a given price. Because it is only called via an `eth_call`, it is not gas bound. The smart contract will simply need to call this function at the checkpoint block and submit the returned value alongside the price to the `submitPrice` function.
