### PR TITLE
Update RocketNodeStaking.sol

### DIFF
--- a/contracts/contract/node/RocketNodeStaking.sol
+++ b/contracts/contract/node/RocketNodeStaking.sol
@@ -201,7 +201,6 @@ contract RocketNodeStaking is RocketBase, RocketNodeStakingInterface {
         // Update RPL stake amounts
         decreaseTotalRPLStake(_amount);
         decreaseNodeRPLStake(msg.sender, _amount);
-        updateTotalEffectiveRPLStake(msg.sender, rplStake, rplStake.sub(_amount));
         // Transfer RPL tokens to node address
         rocketVault.withdrawToken(rocketStorage.getNodeWithdrawalAddress(msg.sender), IERC20(getContractAddress("rocketTokenRPL")), _amount);
         // Emit RPL withdrawn event


### PR DESCRIPTION
updateTotalEffectiveRPLStake() is a no-op here, because https://github.com/knoshua/rocketpool/blob/3d6df4c87401f303f6acbdd249bdcb182e8827f3/contracts/contract/node/RocketNodeStaking.sol#L226
will always be true, since a nearly identical check was already performed here:
https://github.com/knoshua/rocketpool/blob/3d6df4c87401f303f6acbdd249bdcb182e8827f3/contracts/contract/node/RocketNodeStaking.sol#L200

The only real difference is that the latter uses rocketMinipoolManager.getNodeActiveMinipoolCount(_nodeAddress) while the former uses rocketMinipoolManager.getNodeStakingMinipoolCount(_nodeAddress), which doesn't matter since "active minipools" is a superset of "staking minipools".

Removing the line might lead to some gas when withdrawing RPL.