### PR TITLE
Enables rETH refund flow

### DIFF
--- a/contracts/contract/minipool/RocketMinipoolQueue.sol
+++ b/contracts/contract/minipool/RocketMinipoolQueue.sol
@@ -102,6 +102,16 @@ contract RocketMinipoolQueue is RocketBase, RocketMinipoolQueueInterface {
     }
 
     // Add a minipool to the end of the appropriate queue
+    // Only accepts calls from registered minipools
+    function enqueueMinipool(MinipoolDeposit _depositType) override external onlyLatestContract("rocketMinipoolQueue", address(this)) onlyRegisteredMinipool(msg.sender) {
+        // Remove minipool from queue
+        if (_depositType == MinipoolDeposit.Half) { return enqueueMinipool(queueKeyHalf, msg.sender); }
+        if (_depositType == MinipoolDeposit.Full) { return enqueueMinipool(queueKeyFull, msg.sender); }
+        if (_depositType == MinipoolDeposit.Empty) { return enqueueMinipool(queueKeyEmpty, msg.sender); }
+        require(false, "Invalid minipool deposit type");
+    }
+
+    // Add a minipool to the end of the appropriate queue
     // Only accepts calls from the RocketMinipoolManager contract
     function enqueueMinipool(MinipoolDeposit _depositType, address _minipool) override external onlyLatestContract("rocketMinipoolQueue", address(this)) onlyLatestContract("rocketMinipoolManager", msg.sender) {
         if (_depositType == MinipoolDeposit.Half) { return enqueueMinipool(queueKeyHalf, _minipool); }

--- a/contracts/interface/minipool/RocketMinipoolQueueInterface.sol
+++ b/contracts/interface/minipool/RocketMinipoolQueueInterface.sol
@@ -12,6 +12,7 @@ interface RocketMinipoolQueueInterface {
     function getNextCapacity() external view returns (uint256);
     function getNextDeposit() external view returns (MinipoolDeposit, uint256);
     function enqueueMinipool(MinipoolDeposit _depositType, address _minipool) external;
+    function enqueueMinipool(MinipoolDeposit _depositType) external;
     function dequeueMinipool() external returns (address minipoolAddress);
     function dequeueMinipoolByDeposit(MinipoolDeposit _depositType) external returns (address minipoolAddress);
     function removeMinipool(MinipoolDeposit _depositType) external;


### PR DESCRIPTION
- Minipools can upgrade from half to full deposits
- Full deposit minipools can mint rETH immediately instead of waiting for an ETH refund

This was made to support https://dao.rocketpool.net/t/improvements-to-skipping-the-minipool-queue/732/7.

I should note that there are some valid concerns about what is best:
1 - Allow full and half deposits, but use a single queue for them
2 - Allow just half deposits
3 - Allow rETH refunds (this PR)