### PR TITLE
Voting past consensus

### DIFF
--- a/contracts/contract/network/RocketNetworkBalances.sol
+++ b/contracts/contract/network/RocketNetworkBalances.sol
@@ -56,7 +56,7 @@ contract RocketNetworkBalances is RocketBase, RocketNetworkBalancesInterface {
     }
 
     /// @notice Get the current RP network ETH utilization rate as a fraction of 1 ETH
-    /// @notice Represents what % of the network's balance is actively earning rewards
+    /// Represents what % of the network's balance is actively earning rewards
     function getETHUtilizationRate() override external view returns (uint256) {
         uint256 totalEthBalance = getTotalETHBalance();
         uint256 stakingEthBalance = getStakingETHBalance();
@@ -65,7 +65,7 @@ contract RocketNetworkBalances is RocketBase, RocketNetworkBalancesInterface {
     }
 
     /// @notice Submit network balances for a block
-    /// @notice Only accepts calls from trusted (oracle) nodes
+    /// Only accepts calls from trusted (oracle) nodes
     function submitBalances(uint256 _block, uint256 _totalEth, uint256 _stakingEth, uint256 _rethSupply) override external onlyLatestContract("rocketNetworkBalances", address(this)) onlyTrustedNode(msg.sender) {
         // Check settings
         RocketDAOProtocolSettingsNetworkInterface rocketDAOProtocolSettingsNetwork = RocketDAOProtocolSettingsNetworkInterface(getContractAddress("rocketDAOProtocolSettingsNetwork"));
@@ -97,7 +97,7 @@ contract RocketNetworkBalances is RocketBase, RocketNetworkBalancesInterface {
         }
     }
 
-    // Executes updateBalances if consensus threshold is reached
+    /// @notice Executes updateBalances if consensus threshold is reached
     function executeUpdateBalances(uint256 _block, uint256 _totalEth, uint256 _stakingEth, uint256 _rethSupply) override external onlyLatestContract("rocketNetworkBalances", address(this)) {
         // Check settings
         RocketDAOProtocolSettingsNetworkInterface rocketDAOProtocolSettingsNetwork = RocketDAOProtocolSettingsNetworkInterface(getContractAddress("rocketDAOProtocolSettingsNetwork"));
@@ -117,7 +117,7 @@ contract RocketNetworkBalances is RocketBase, RocketNetworkBalancesInterface {
         updateBalances(_block, _totalEth, _stakingEth, _rethSupply);
     }
 
-    // Update network balances
+    /// @notice Update network balances
     function updateBalances(uint256 _block, uint256 _totalEth, uint256 _stakingEth, uint256 _rethSupply) private {
         // Update balances
         setBalancesBlock(_block);
@@ -128,7 +128,7 @@ contract RocketNetworkBalances is RocketBase, RocketNetworkBalancesInterface {
         emit BalancesUpdated(_block, _totalEth, _stakingEth, _rethSupply, block.timestamp);
     }
 
-    // Returns the latest block number that oracles should be reporting balances for
+    /// @notice Returns the latest block number that oracles should be reporting balances for
     function getLatestReportableBlock() override external view returns (uint256) {
         // Load contracts
         RocketDAOProtocolSettingsNetworkInterface rocketDAOProtocolSettingsNetwork = RocketDAOProtocolSettingsNetworkInterface(getContractAddress("rocketDAOProtocolSettingsNetwork"));

--- a/contracts/contract/network/RocketNetworkBalances.sol
+++ b/contracts/contract/network/RocketNetworkBalances.sol
@@ -1,20 +1,14 @@
-pragma solidity 0.7.6;
+pragma solidity 0.8.18;
 
 // SPDX-License-Identifier: GPL-3.0-only
-
-import "@openzeppelin/contracts/math/SafeMath.sol";
 
 import "../RocketBase.sol";
 import "../../interface/dao/node/RocketDAONodeTrustedInterface.sol";
 import "../../interface/network/RocketNetworkBalancesInterface.sol";
 import "../../interface/dao/protocol/settings/RocketDAOProtocolSettingsNetworkInterface.sol";
 
-// Network balances
-
+/// @notice Network balances
 contract RocketNetworkBalances is RocketBase, RocketNetworkBalancesInterface {
-
-    // Libs
-    using SafeMath for uint;
 
     // Events
     event BalancesSubmitted(address indexed from, uint256 block, uint256 totalEth, uint256 stakingEth, uint256 rethSupply, uint256 time);
@@ -22,59 +16,64 @@ contract RocketNetworkBalances is RocketBase, RocketNetworkBalancesInterface {
 
     // Construct
     constructor(RocketStorageInterface _rocketStorageAddress) RocketBase(_rocketStorageAddress) {
-        version = 2;
+        version = 3;
     }
 
-    // The block number which balances are current for
+    /// @notice The block number which balances are current for
     function getBalancesBlock() override public view returns (uint256) {
         return getUint(keccak256("network.balances.updated.block"));
     }
+    /// @notice Sets the block number which balances are current for
     function setBalancesBlock(uint256 _value) private {
         setUint(keccak256("network.balances.updated.block"), _value);
     }
 
-    // The current RP network total ETH balance
+    /// @notice The current RP network total ETH balance
     function getTotalETHBalance() override public view returns (uint256) {
         return getUint(keccak256("network.balance.total"));
     }
+    /// @notice Sets the current RP network total ETH balance
     function setTotalETHBalance(uint256 _value) private {
         setUint(keccak256("network.balance.total"), _value);
     }
 
-    // The current RP network staking ETH balance
+    /// @notice The current RP network staking ETH balance
     function getStakingETHBalance() override public view returns (uint256) {
         return getUint(keccak256("network.balance.staking"));
     }
+    /// @notice Sets the current RP network staking ETH balance
     function setStakingETHBalance(uint256 _value) private {
         setUint(keccak256("network.balance.staking"), _value);
     }
 
-    // The current RP network total rETH supply
+    /// @notice The current RP network total rETH supply
     function getTotalRETHSupply() override external view returns (uint256) {
         return getUint(keccak256("network.balance.reth.supply"));
     }
+    /// @notice Sets the current RP network total rETH supply
     function setTotalRETHSupply(uint256 _value) private {
         setUint(keccak256("network.balance.reth.supply"), _value);
     }
 
-    // Get the current RP network ETH utilization rate as a fraction of 1 ETH
-    // Represents what % of the network's balance is actively earning rewards
+    /// @notice Get the current RP network ETH utilization rate as a fraction of 1 ETH
+    /// @notice Represents what % of the network's balance is actively earning rewards
     function getETHUtilizationRate() override external view returns (uint256) {
         uint256 totalEthBalance = getTotalETHBalance();
         uint256 stakingEthBalance = getStakingETHBalance();
         if (totalEthBalance == 0) { return calcBase; }
-        return calcBase.mul(stakingEthBalance).div(totalEthBalance);
+        return calcBase * stakingEthBalance / totalEthBalance;
     }
 
-    // Submit network balances for a block
-    // Only accepts calls from trusted (oracle) nodes
+    /// @notice Submit network balances for a block
+    /// @notice Only accepts calls from trusted (oracle) nodes
     function submitBalances(uint256 _block, uint256 _totalEth, uint256 _stakingEth, uint256 _rethSupply) override external onlyLatestContract("rocketNetworkBalances", address(this)) onlyTrustedNode(msg.sender) {
         // Check settings
         RocketDAOProtocolSettingsNetworkInterface rocketDAOProtocolSettingsNetwork = RocketDAOProtocolSettingsNetworkInterface(getContractAddress("rocketDAOProtocolSettingsNetwork"));
         require(rocketDAOProtocolSettingsNetwork.getSubmitBalancesEnabled(), "Submitting balances is currently disabled");
         // Check block
         require(_block < block.number, "Balances can not be submitted for a future block");
-        require(_block > getBalancesBlock(), "Network balances for an equal or higher block are set");
+        uint256 lastBalancesBlock = getBalancesBlock();
+        require(_block >= lastBalancesBlock, "Network balances for a higher block are set");
         // Get submission keys
         bytes32 nodeSubmissionKey = keccak256(abi.encodePacked("network.balances.submitted.node", msg.sender, _block, _totalEth, _stakingEth, _rethSupply));
         bytes32 submissionCountKey = keccak256(abi.encodePacked("network.balances.submitted.count", _block, _totalEth, _stakingEth, _rethSupply));
@@ -83,13 +82,17 @@ contract RocketNetworkBalances is RocketBase, RocketNetworkBalancesInterface {
         setBool(nodeSubmissionKey, true);
         setBool(keccak256(abi.encodePacked("network.balances.submitted.node", msg.sender, _block)), true);
         // Increment submission count
-        uint256 submissionCount = getUint(submissionCountKey).add(1);
+        uint256 submissionCount = getUint(submissionCountKey) + 1;
         setUint(submissionCountKey, submissionCount);
         // Emit balances submitted event
         emit BalancesSubmitted(msg.sender, _block, _totalEth, _stakingEth, _rethSupply, block.timestamp);
+        // If voting past consensus, return
+        if (_block == lastBalancesBlock) {
+            return;
+        }
         // Check submission count & update network balances
         RocketDAONodeTrustedInterface rocketDAONodeTrusted = RocketDAONodeTrustedInterface(getContractAddress("rocketDAONodeTrusted"));
-        if (calcBase.mul(submissionCount).div(rocketDAONodeTrusted.getMemberCount()) >= rocketDAOProtocolSettingsNetwork.getNodeConsensusThreshold()) {
+        if (calcBase * submissionCount / rocketDAONodeTrusted.getMemberCount() >= rocketDAOProtocolSettingsNetwork.getNodeConsensusThreshold()) {
             updateBalances(_block, _totalEth, _stakingEth, _rethSupply);
         }
     }
@@ -110,7 +113,7 @@ contract RocketNetworkBalances is RocketBase, RocketNetworkBalancesInterface {
         uint256 submissionCount = getUint(submissionCountKey);
         // Check submission count & update network balances
         RocketDAONodeTrustedInterface rocketDAONodeTrusted = RocketDAONodeTrustedInterface(getContractAddress("rocketDAONodeTrusted"));
-        require(calcBase.mul(submissionCount).div(rocketDAONodeTrusted.getMemberCount()) >= rocketDAOProtocolSettingsNetwork.getNodeConsensusThreshold(), "Consensus has not been reached");
+        require(calcBase * submissionCount / rocketDAONodeTrusted.getMemberCount() >= rocketDAOProtocolSettingsNetwork.getNodeConsensusThreshold(), "Consensus has not been reached");
         updateBalances(_block, _totalEth, _stakingEth, _rethSupply);
     }
 
@@ -132,6 +135,6 @@ contract RocketNetworkBalances is RocketBase, RocketNetworkBalancesInterface {
         // Get the block balances were lasted updated and the update frequency
         uint256 updateFrequency = rocketDAOProtocolSettingsNetwork.getSubmitBalancesFrequency();
         // Calculate the last reportable block based on update frequency
-        return block.number.div(updateFrequency).mul(updateFrequency);
+        return block.number / updateFrequency * updateFrequency;
     }
 }

--- a/contracts/contract/rewards/RocketRewardsPool.sol
+++ b/contracts/contract/rewards/RocketRewardsPool.sol
@@ -142,7 +142,8 @@ contract RocketRewardsPool is RocketBase, RocketRewardsPoolInterface {
         // Check submission is currently enabled
         require(rocketDAOProtocolSettingsNetwork.getSubmitRewardsEnabled(), "Submitting rewards is currently disabled");
         // Validate inputs
-        require(_submission.rewardIndex <= getRewardIndex(), "Can only submit snapshot for periods up to next");
+        uint256 rewardIndex = getRewardIndex();
+        require(_submission.rewardIndex <= rewardIndex, "Can only submit snapshot for periods up to next");
         require(_submission.intervalsPassed > 0, "Invalid number of intervals passed");
         require(_submission.nodeRPL.length == _submission.trustedNodeRPL.length && _submission.trustedNodeRPL.length == _submission.nodeETH.length, "Invalid array length");
         // Calculate RPL reward total and validate
@@ -182,12 +183,12 @@ contract RocketRewardsPool is RocketBase, RocketRewardsPoolInterface {
         // Emit snapshot submitted event
         emit RewardSnapshotSubmitted(msg.sender, _submission.rewardIndex, _submission, block.timestamp);
         // Return if already executed
-        if (_submission.rewardIndex != getRewardIndex()) {
+        if (_submission.rewardIndex != rewardIndex) {
             return;
         }
         // If consensus is reached, execute the snapshot
         RocketDAONodeTrustedInterface rocketDAONodeTrusted = RocketDAONodeTrustedInterface(getContractAddress("rocketDAONodeTrusted"));
-        if (calcBase * submissionCount / rocketDAONodeTrusted.getMemberCount() == rocketDAOProtocolSettingsNetwork.getNodeConsensusThreshold()) {
+        if (calcBase * submissionCount / rocketDAONodeTrusted.getMemberCount() >= rocketDAOProtocolSettingsNetwork.getNodeConsensusThreshold()) {
             _executeRewardSnapshot(_submission);
         }
     }

--- a/test/network/network-balances-tests.js
+++ b/test/network/network-balances-tests.js
@@ -159,7 +159,30 @@ export default function() {
         });
 
 
-        it(printTitle('trusted nodes', 'cannot submit network balances for the current recorded block or lower'), async () => {
+        it(printTitle('trusted nodes', 'cannot submit network balances for a lower block than recorded'), async () => {
+
+            // Set parameters
+            let block = 2;
+            let totalBalance = '10'.ether;
+            let stakingBalance = '9'.ether;
+            let rethSupply = '8'.ether;
+
+            // Submit balances for block to trigger update
+            await submitBalances(block, totalBalance, stakingBalance, rethSupply, {
+                from: trustedNode1,
+            });
+            await submitBalances(block, totalBalance, stakingBalance, rethSupply, {
+                from: trustedNode2,
+            });
+
+            // Attempt to submit balances for lower block
+            await shouldRevert(submitBalances(block - 1, totalBalance, stakingBalance, rethSupply, {
+                from: trustedNode3,
+            }), 'Submitted balances for a lower block');
+
+        });
+
+        it(printTitle('trusted nodes', 'can submit network balances for the same block as recorded (vote past consensus)'), async () => {
 
             // Set parameters
             let block = 2;
@@ -176,17 +199,11 @@ export default function() {
             });
 
             // Attempt to submit balances for current block
-            await shouldRevert(submitBalances(block, totalBalance, stakingBalance, rethSupply, {
+            await submitBalances(block, totalBalance, stakingBalance, rethSupply, {
                 from: trustedNode3,
-            }), 'Submitted balances for the current block');
-
-            // Attempt to submit balances for lower block
-            await shouldRevert(submitBalances(block - 1, totalBalance, stakingBalance, rethSupply, {
-                from: trustedNode3,
-            }), 'Submitted balances for a lower block');
+            });
 
         });
-
 
         it(printTitle('trusted nodes', 'cannot submit the same network balances twice'), async () => {
 

--- a/test/network/network-prices-tests.js
+++ b/test/network/network-prices-tests.js
@@ -151,7 +151,26 @@ export default function() {
         });
 
 
-        it(printTitle('trusted nodes', 'cannot submit network prices for the current recorded block or lower'), async () => {
+        it(printTitle('trusted nodes', 'cannot submit network prices for a lower block than recorded'), async () => {
+            // Set parameters
+            let block = await web3.eth.getBlockNumber();
+            let rplPrice = '0.02'.ether;
+
+            // Submit prices for block to trigger update
+            await submitPrices(block, rplPrice, {
+                from: trustedNode1,
+            });
+            await submitPrices(block, rplPrice, {
+                from: trustedNode2,
+            });
+
+            // Attempt to submit prices for lower block
+            await shouldRevert(submitPrices(block - 1, rplPrice, {
+                from: trustedNode3,
+            }), 'Submitted prices for a lower block');
+        });
+
+        it(printTitle('trusted nodes', 'can submit network prices for the current recorded block (vote past consensus)'), async () => {
             // Set parameters
             let block = await web3.eth.getBlockNumber();
             let rplPrice = '0.02'.ether;
@@ -165,14 +184,10 @@ export default function() {
             });
 
             // Attempt to submit prices for current block
-            await shouldRevert(submitPrices(block, rplPrice, {
+            await submitPrices(block, rplPrice, {
                 from: trustedNode3,
-            }), 'Submitted prices for the current block');
+            });
 
-            // Attempt to submit prices for lower block
-            await shouldRevert(submitPrices(block - 1, rplPrice, {
-                from: trustedNode3,
-            }), 'Submitted prices for a lower block');
         });
 
 

--- a/test/rewards/scenario-submit-rewards.js
+++ b/test/rewards/scenario-submit-rewards.js
@@ -93,7 +93,7 @@ export async function submitRewards(index, rewards, treasuryRPL, userETH, txOpti
         web3.eth.getBalance(rocketTokenRETH.address)
     ]);
 
-
+    let alreadyExecuted = submission.rewardIndex != rewardIndex1;
     // Submit prices
     await rocketRewardsPool.submitRewardSnapshot(submission, txOptions);
     assert.isTrue( await rocketRewardsPool.getSubmissionFromNodeExists(txOptions.from, submission));
@@ -106,9 +106,8 @@ export async function submitRewards(index, rewards, treasuryRPL, userETH, txOpti
         web3.eth.getBalance(rocketTokenRETH.address)
     ]);
 
-    // Check if prices should be updated
-    let expectedExecute = submission2.count.mul('2'.BN).gt(trustedNodeCount);
-
+    // Check if prices should be updated and were not updated yet
+    let expectedExecute = submission2.count.mul('2'.BN).gt(trustedNodeCount) && !alreadyExecuted;
     // Check submission details
     assert.isFalse(submission1.nodeSubmitted, 'Incorrect initial node submitted status');
     assert.isTrue(submission2.nodeSubmitted, 'Incorrect updated node submitted status');


### PR DESCRIPTION
Allow oDAO nodes to submit prices/balances/rewards even after consensus is reached, according to [RPIP-19](https://github.com/rocket-pool/RPIPs/blob/main/RPIPs/RPIP-19.md#voting-past-consensus).