### PR TITLE
docs: fix comment for exchange rate to describe ratio as `rETH / ETH`

### DIFF
--- a/contracts/contract/token/RocketTokenRETH.sol
+++ b/contracts/contract/token/RocketTokenRETH.sol
@@ -61,7 +61,7 @@ contract RocketTokenRETH is RocketBase, ERC20, RocketTokenRETHInterface {
         return _ethAmount.mul(rethSupply).div(totalEthBalance);
     }
 
-    // Get the current ETH : rETH exchange rate
+    // Get the current rETH / ETH exchange rate
     // Returns the amount of ETH backing 1 rETH
     function getExchangeRate() override external view returns (uint256) {
         return getEthValue(1 ether);


### PR DESCRIPTION
The comment above the function `getExchangeRate()` seems to have an error. It mentions as ratio `ETH : rETH` while the function uses `getETHValue(1 ether)` and therefore describes how many ETH are backing 1 rETH.

Adjusted the comment to reflect that.