### PR TITLE
Fix typo: 'persistant' to 'persistent' in RocketBase.sol

### DIFF
--- a/contracts/contract/RocketBase.sol
+++ b/contracts/contract/RocketBase.sol
@@ -15,7 +15,7 @@ abstract contract RocketBase {
     // Version of the contract
     uint8 public version;
 
-    // The main storage contract where primary persistant storage is maintained
+    // The main storage contract where primary persistent storage is maintained
     RocketStorageInterface rocketStorage = RocketStorageInterface(address(0));
 
 


### PR DESCRIPTION
## Summary
- Fixed typo in comment in RocketBase.sol
- Changed 'persistant' to 'persistent'

## Test plan
- No functional changes, comment-only fix

Generated with Claude Code