### PR TITLE
Fix typo: 'Intialise' to 'Initialise' in RocketMinipoolDelegate.sol

### DIFF
--- a/contracts/contract/minipool/RocketMinipoolDelegate.sol
+++ b/contracts/contract/minipool/RocketMinipoolDelegate.sol
@@ -138,7 +138,7 @@ contract RocketMinipoolDelegate is RocketMinipoolStorageLayout, RocketMinipoolIn
         rocketTokenRETH = getContractAddress("rocketTokenRETH");
         // Set local copy of penalty contract
         rocketMinipoolPenalty = getContractAddress("rocketMinipoolPenalty");
-        // Intialise storage state
+        // Initialise storage state
         storageState = StorageState.Initialised;
     }
 


### PR DESCRIPTION
## Summary
- Fixed typo in comment in RocketMinipoolDelegate.sol
- Changed 'Intialise' to 'Initialise'

## Test plan
- No functional changes, comment-only fix

Generated with Claude Code