### PR TITLE
Fix grammar: 'lets' to 'let's' in contract comments

### DIFF
--- a/contracts/contract/dao/node/RocketDAONodeTrusted.sol
+++ b/contracts/contract/dao/node/RocketDAONodeTrusted.sol
@@ -147,7 +147,7 @@ contract RocketDAONodeTrusted is RocketBase, RocketDAONodeTrustedInterface {
     
     // Bootstrap mode - In bootstrap mode, guardian can add members at will
     function bootstrapMember(string memory _id, string memory _url, address _nodeAddress) override external onlyGuardian onlyBootstrapMode onlyRegisteredNode(_nodeAddress) onlyLatestContract("rocketDAONodeTrusted", address(this)) {
-        // Ok good to go, lets add them
+        // Ok good to go, let's add them
         RocketDAONodeTrustedProposalsInterface(getContractAddress("rocketDAONodeTrustedProposals")).proposalInvite(_id, _url, _nodeAddress);
     }
 

--- a/contracts/contract/dao/node/RocketDAONodeTrustedProposals.sol
+++ b/contracts/contract/dao/node/RocketDAONodeTrustedProposals.sol
@@ -91,7 +91,7 @@ contract RocketDAONodeTrustedProposals is RocketBase, RocketDAONodeTrustedPropos
     function proposalInvite(string memory _id, string memory _url, address _nodeAddress) override external onlyExecutingContracts onlyRegisteredNode(_nodeAddress) {
         // Their proposal executed, record the block
         setUint(keccak256(abi.encodePacked(daoNameSpace, "member.executed.time", "invited", _nodeAddress)), block.timestamp);
-        // Ok all good, lets get their invitation and member data setup
+        // Ok all good, let's get their invitation and member data setup
         // They are initially only invited to join, so their membership isn't set as true until they accept it in RocketDAONodeTrustedActions
         _memberInit(_id, _url, _nodeAddress);
     }

--- a/contracts/contract/dao/node/RocketDAONodeTrustedUpgrade.sol
+++ b/contracts/contract/dao/node/RocketDAONodeTrustedUpgrade.sol
@@ -26,7 +26,7 @@ contract RocketDAONodeTrustedUpgrade is RocketBase, RocketDAONodeTrustedUpgradeI
     function upgrade(string memory _type, string memory _name, string memory _contractAbi, address _contractAddress) override external onlyLatestContract("rocketDAONodeTrustedProposals", msg.sender) {
         // What action are we performing?
         bytes32 typeHash = keccak256(abi.encodePacked(_type));
-        // Lets do it!
+        // Let's do it!
         if(typeHash == keccak256(abi.encodePacked("upgradeContract"))) _upgradeContract(_name, _contractAddress, _contractAbi);
         if(typeHash == keccak256(abi.encodePacked("addContract"))) _addContract(_name, _contractAddress, _contractAbi);
         if(typeHash == keccak256(abi.encodePacked("upgradeABI"))) _upgradeABI(_name, _contractAbi);

--- a/contracts/contract/dao/security/RocketDAOSecurityProposals.sol
+++ b/contracts/contract/dao/security/RocketDAOSecurityProposals.sol
@@ -126,7 +126,7 @@ contract RocketDAOSecurityProposals is RocketBase, RocketDAOSecurityProposalsInt
     function proposalInvite(string calldata _id, address _memberAddress) override public onlyLatestContract("rocketDAOProtocolProposals", msg.sender) {
         // Their proposal executed, record the block
         setUint(keccak256(abi.encodePacked(daoNameSpace, "member.executed.time", "invited", _memberAddress)), block.timestamp);
-        // Ok all good, lets get their invitation and member data setup
+        // Ok all good, let's get their invitation and member data setup
         // They are initially only invited to join, so their membership isn't set as true until they accept it in RocketDAONodeTrustedActions
         _memberInit(_id, _memberAddress);
     }


### PR DESCRIPTION
## Summary
- Fixed missing apostrophe in contractions across multiple contract files
- Changed 'lets' to 'let's' where it is used as a contraction (let us)
- Files modified:
  - RocketDAONodeTrustedProposals.sol
  - RocketDAOSecurityProposals.sol
  - RocketDAONodeTrustedUpgrade.sol
  - RocketDAONodeTrusted.sol

## Test plan
- No functional changes, comment-only fixes

Generated with Claude Code