### PR TITLE
fix: add overflow check for unchecked exponentiation in getNodeFeeByDemand

### DIFF
--- a/contracts/contract/network/RocketNetworkFees.sol
+++ b/contracts/contract/network/RocketNetworkFees.sol
@@ -69,7 +69,9 @@ contract RocketNetworkFees is RocketBase, RocketNetworkFeesInterface {
             return minFee;
         }
         // Get fee interpolation factor
-        uint256 t = nNodeDemand.div(demandDivisor) ** 3;
+        uint256 base = nNodeDemand.div(demandDivisor);
+        uint256 t = base * base * base;
+        require(t / base / base == base, "Fee calculation overflow");
         // Interpolate between min / target / max fee
         if (nNodeDemandSign) { return targetFee.add(maxFee.sub(targetFee).mul(t).div(calcBase)); }
         return minFee.add(targetFee.sub(minFee).mul(calcBase.sub(t)).div(calcBase));


### PR DESCRIPTION
The `** 3` operator in Solidity 0.7.6 doesn't have built-in overflow protection, and SafeMath doesn't cover exponentiation either. Split the cube into three multiplications with a check that reverts on overflow.

Closes #343